### PR TITLE
feat: default project selection + fix project dropdown z-index

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { ReactNode, useState } from 'react'
 import { AuthProvider, useAuth } from './lib/auth'
 import { ProjectProvider, useProjects } from './lib/projects'
+import Shell from './components/Shell'
 import Landing from './pages/Landing'
 import Login from './pages/Login'
 import Dashboard from './pages/Dashboard'
@@ -75,6 +76,25 @@ function RootRedirect() {
   return <Landing />
 }
 
+function DefaultProjectRoute({ base }: { base: string }) {
+  const { projects, isLoading, defaultProjectId } = useProjects()
+
+  if (isLoading || projects.length === 0) {
+    return (
+      <Shell>
+        <div />
+      </Shell>
+    )
+  }
+
+  const target =
+    defaultProjectId && projects.some((p) => p.id === defaultProjectId)
+      ? defaultProjectId
+      : projects[0].id
+
+  return <Navigate to={`${base}/${target}`} replace />
+}
+
 function AppRoutes() {
   const { user } = useAuth()
   const { refetch } = useProjects()
@@ -93,7 +113,7 @@ function AppRoutes() {
         <Route path="/login" element={<Login />} />
         <Route
           path="/dashboard"
-          element={<ProtectedRoute><Dashboard /></ProtectedRoute>}
+          element={<ProtectedRoute><DefaultProjectRoute base="/dashboard" /></ProtectedRoute>}
         />
         <Route
           path="/dashboard/:projectId"
@@ -101,7 +121,7 @@ function AppRoutes() {
         />
         <Route
           path="/funnels"
-          element={<ProtectedRoute><Funnels /></ProtectedRoute>}
+          element={<ProtectedRoute><DefaultProjectRoute base="/funnels" /></ProtectedRoute>}
         />
         <Route
           path="/funnels/:projectId"
@@ -109,7 +129,7 @@ function AppRoutes() {
         />
         <Route
           path="/abtests"
-          element={<ProtectedRoute><ABTests /></ProtectedRoute>}
+          element={<ProtectedRoute><DefaultProjectRoute base="/abtests" /></ProtectedRoute>}
         />
         <Route
           path="/abtests/:projectId"
@@ -117,7 +137,7 @@ function AppRoutes() {
         />
         <Route
           path="/live"
-          element={<ProtectedRoute><Live /></ProtectedRoute>}
+          element={<ProtectedRoute><DefaultProjectRoute base="/live" /></ProtectedRoute>}
         />
         <Route
           path="/live/:projectId"

--- a/web/src/components/Shell.tsx
+++ b/web/src/components/Shell.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useState } from 'react'
 import { Link, useNavigate, useLocation } from 'react-router-dom'
-import { BarChart2, Layers, Radio, Settings, ChevronDown, LogOut, User, FlaskConical, MoreHorizontal } from 'lucide-react'
+import { BarChart2, Layers, Radio, Settings, ChevronDown, LogOut, User, FlaskConical, MoreHorizontal, Star } from 'lucide-react'
 import { useAuth } from '../lib/auth'
 import { useProjects } from '../lib/projects'
 
@@ -21,13 +21,14 @@ interface ShellProps {
 
 export default function Shell({ children, projectId, onProjectChange }: ShellProps) {
   const { user, logout } = useAuth()
-  const { projects } = useProjects()
+  const { projects, defaultProjectId, setDefaultProjectId } = useProjects()
   const navigate = useNavigate()
   const location = useLocation()
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const [userMenuOpen, setUserMenuOpen] = useState(false)
   const [moreSheetOpen, setMoreSheetOpen] = useState(false)
-  const currentProject = projects.find((p) => p.id === projectId) || projects[0]
+  const effectiveId = projectId ?? (defaultProjectId && projects.some(p => p.id === defaultProjectId) ? defaultProjectId : projects[0]?.id)
+  const currentProject = projects.find((p) => p.id === effectiveId) ?? projects[0]
 
   const handleLogout = async () => {
     await logout()
@@ -71,7 +72,6 @@ export default function Shell({ children, projectId, onProjectChange }: ShellPro
         gap: 8,
         width: '100%',
         boxSizing: 'border-box',
-        overflow: 'hidden',
       }}>
         {/* Logo */}
         <Link to="/dashboard" style={{ textDecoration: 'none', display: 'flex', alignItems: 'center', gap: 8, marginRight: 8, flexShrink: 0 }}>
@@ -110,34 +110,63 @@ export default function Shell({ children, projectId, onProjectChange }: ShellPro
               background: C.surface,
               border: `1px solid ${C.border}`,
               borderRadius: 8,
-              minWidth: 180,
+              minWidth: 200,
               boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
               zIndex: 300,
             }}>
-              {projects.map((p) => (
-                <button
-                  key={p.id}
-                  onClick={() => {
-                    setDropdownOpen(false)
-                    onProjectChange?.(p.id)
-                    navigate(`/dashboard/${p.id}`)
-                  }}
-                  style={{
-                    display: 'block',
-                    width: '100%',
-                    textAlign: 'left',
-                    background: p.id === currentProject?.id ? '#2a2d3a' : 'transparent',
-                    border: 'none',
-                    color: C.text,
-                    padding: '0.6rem 1rem',
-                    cursor: 'pointer',
-                    fontSize: 14,
-                    minHeight: 'unset',
-                  }}
-                >
-                  {p.name}
-                </button>
-              ))}
+              {projects.map((p) => {
+                const isDefault = p.id === defaultProjectId
+                return (
+                  <div
+                    key={p.id}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      background: p.id === currentProject?.id ? '#2a2d3a' : 'transparent',
+                    }}
+                  >
+                    <button
+                      onClick={() => {
+                        setDropdownOpen(false)
+                        onProjectChange?.(p.id)
+                        navigate(`/dashboard/${p.id}`)
+                      }}
+                      style={{
+                        flex: 1,
+                        textAlign: 'left',
+                        background: 'transparent',
+                        border: 'none',
+                        color: C.text,
+                        padding: '0.6rem 1rem',
+                        cursor: 'pointer',
+                        fontSize: 14,
+                        minHeight: 'unset',
+                      }}
+                    >
+                      {p.name}
+                    </button>
+                    {projects.length > 1 && (
+                      <button
+                        onClick={(e) => { e.stopPropagation(); setDefaultProjectId(p.id) }}
+                        title={isDefault ? 'Default project' : 'Set as default'}
+                        style={{
+                          background: 'transparent',
+                          border: 'none',
+                          cursor: 'pointer',
+                          padding: '0.6rem 0.75rem 0.6rem 0',
+                          color: isDefault ? C.amber : C.muted,
+                          display: 'flex',
+                          alignItems: 'center',
+                          minHeight: 'unset',
+                          flexShrink: 0,
+                        }}
+                      >
+                        <Star size={13} fill={isDefault ? C.amber : 'none'} />
+                      </button>
+                    )}
+                  </div>
+                )
+              })}
             </div>
           )}
         </div>
@@ -173,34 +202,63 @@ export default function Shell({ children, projectId, onProjectChange }: ShellPro
               background: C.surface,
               border: `1px solid ${C.border}`,
               borderRadius: 8,
-              minWidth: 180,
+              minWidth: 200,
               boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
               zIndex: 300,
             }}>
-              {projects.map((p) => (
-                <button
-                  key={p.id}
-                  onClick={() => {
-                    setDropdownOpen(false)
-                    onProjectChange?.(p.id)
-                    navigate(`/dashboard/${p.id}`)
-                  }}
-                  style={{
-                    display: 'block',
-                    width: '100%',
-                    textAlign: 'left',
-                    background: p.id === currentProject?.id ? '#2a2d3a' : 'transparent',
-                    border: 'none',
-                    color: C.text,
-                    padding: '0.6rem 1rem',
-                    cursor: 'pointer',
-                    fontSize: 14,
-                    minHeight: 'unset',
-                  }}
-                >
-                  {p.name}
-                </button>
-              ))}
+              {projects.map((p) => {
+                const isDefault = p.id === defaultProjectId
+                return (
+                  <div
+                    key={p.id}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      background: p.id === currentProject?.id ? '#2a2d3a' : 'transparent',
+                    }}
+                  >
+                    <button
+                      onClick={() => {
+                        setDropdownOpen(false)
+                        onProjectChange?.(p.id)
+                        navigate(`/dashboard/${p.id}`)
+                      }}
+                      style={{
+                        flex: 1,
+                        textAlign: 'left',
+                        background: 'transparent',
+                        border: 'none',
+                        color: C.text,
+                        padding: '0.6rem 1rem',
+                        cursor: 'pointer',
+                        fontSize: 14,
+                        minHeight: 'unset',
+                      }}
+                    >
+                      {p.name}
+                    </button>
+                    {projects.length > 1 && (
+                      <button
+                        onClick={(e) => { e.stopPropagation(); setDefaultProjectId(p.id) }}
+                        title={isDefault ? 'Default project' : 'Set as default'}
+                        style={{
+                          background: 'transparent',
+                          border: 'none',
+                          cursor: 'pointer',
+                          padding: '0.6rem 0.75rem 0.6rem 0',
+                          color: isDefault ? C.amber : C.muted,
+                          display: 'flex',
+                          alignItems: 'center',
+                          minHeight: 'unset',
+                          flexShrink: 0,
+                        }}
+                      >
+                        <Star size={13} fill={isDefault ? C.amber : 'none'} />
+                      </button>
+                    )}
+                  </div>
+                )
+              })}
             </div>
           )}
         </div>

--- a/web/src/lib/projects.tsx
+++ b/web/src/lib/projects.tsx
@@ -1,10 +1,14 @@
 import { createContext, useContext, useEffect, useState, ReactNode, useCallback } from 'react'
 import { api, Project } from './api'
 
+const STORAGE_KEY = 'funnelbarn_default_project'
+
 interface ProjectContextValue {
   projects: Project[]
   isLoading: boolean
   refetch: () => void
+  defaultProjectId: string | null
+  setDefaultProjectId: (id: string) => void
 }
 
 const ProjectContext = createContext<ProjectContextValue | null>(null)
@@ -12,6 +16,14 @@ const ProjectContext = createContext<ProjectContextValue | null>(null)
 export function ProjectProvider({ children }: { children: ReactNode }) {
   const [projects, setProjects] = useState<Project[]>([])
   const [isLoading, setIsLoading] = useState(true)
+  const [defaultProjectId, setDefaultProjectIdState] = useState<string | null>(
+    () => localStorage.getItem(STORAGE_KEY)
+  )
+
+  const setDefaultProjectId = useCallback((id: string) => {
+    setDefaultProjectIdState(id)
+    localStorage.setItem(STORAGE_KEY, id)
+  }, [])
 
   const refetch = useCallback(() => {
     setIsLoading(true)
@@ -24,7 +36,7 @@ export function ProjectProvider({ children }: { children: ReactNode }) {
   useEffect(() => { refetch() }, [refetch])
 
   return (
-    <ProjectContext.Provider value={{ projects, isLoading, refetch }}>
+    <ProjectContext.Provider value={{ projects, isLoading, refetch, defaultProjectId, setDefaultProjectId }}>
       {children}
     </ProjectContext.Provider>
   )
@@ -34,4 +46,12 @@ export function useProjects(): ProjectContextValue {
   const ctx = useContext(ProjectContext)
   if (!ctx) throw new Error('useProjects must be used inside ProjectProvider')
   return ctx
+}
+
+export function useEffectiveProjectId(urlProjectId?: string): string | undefined {
+  const { projects, defaultProjectId } = useProjects()
+  if (urlProjectId) return urlProjectId
+  const defaultExists = defaultProjectId && projects.some((p) => p.id === defaultProjectId)
+  if (defaultExists) return defaultProjectId!
+  return projects[0]?.id
 }


### PR DESCRIPTION
## Summary
- Default project stored in localStorage; star icon in the project switcher dropdown marks the default (only shown when multiple projects exist)
- Routes without `:projectId` now redirect to the default project (or first project if none set) instead of showing the project list page
- Fixed project dropdown being invisible — `overflow: hidden` on the nav was clipping the absolutely-positioned dropdown

## Changes
- `web/src/lib/projects.tsx` — adds `defaultProjectId` + `setDefaultProjectId` to context, persisted in localStorage
- `web/src/components/Shell.tsx` — removes `overflow: hidden` from nav; adds star button in both desktop and mobile project dropdowns; uses default project as fallback when no `projectId` in URL
- `web/src/App.tsx` — adds `DefaultProjectRoute` component that redirects `/dashboard`, `/funnels`, `/abtests`, `/live` to the corresponding route with the default (or first) project id