### PR TITLE
fix(test): remove unused beforeEach import from auth.test.tsx

### DIFF
--- a/web/src/lib/auth.test.tsx
+++ b/web/src/lib/auth.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, act, fireEvent } from '@testing-library/react'
 import { AuthProvider, useAuth } from './auth'
 import { api } from './api'


### PR DESCRIPTION
## Summary
- Removes unused `beforeEach` import from `web/src/lib/auth.test.tsx` — this caused a TS6133 error that failed the Docker image build step in CI.

## Test plan
- [ ] CI build job passes