### PR TITLE
fix(e2e): make login rate limit configurable; raise default 5→20/min

### DIFF
--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -143,6 +143,8 @@ func run() error {
 		cfg.AllowedOrigins,
 		cfg.SessionSecret,
 		cfg.PublicURL,
+		cfg.LoginRatePerMinute,
+		cfg.LoginRateBurst,
 	)
 
 	var httpHandler http.Handler = apiServer

--- a/deploy/k8s/testing/deployment.yaml
+++ b/deploy/k8s/testing/deployment.yaml
@@ -31,6 +31,10 @@ spec:
               value: :8080
             - name: FUNNELBARN_PUBLIC_URL
               value: https://funnelbarn.test.wiebe.xyz
+            - name: FUNNELBARN_LOGIN_RATE_PER_MINUTE
+              value: "1000"
+            - name: FUNNELBARN_LOGIN_RATE_BURST
+              value: "1000"
             - name: FUNNELBARN_SPOOL_DIR
               value: /var/lib/funnelbarn/spool
             - name: FUNNELBARN_DB_PATH

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -61,7 +61,7 @@ func newTestServer(t *testing.T) (*Server, *repository.Store) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
-		userAuth, sm, nil, "test-secret", "http://localhost")
+		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000)
 	return srv, store
 }
 
@@ -78,7 +78,7 @@ func newAuthedServer(t *testing.T) (*Server, *repository.Store) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
-		userAuth, sm, nil, "test-secret", "http://localhost")
+		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000)
 	return srv, store
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -46,6 +46,8 @@ func NewServer(
 	allowedOrigins []string,
 	sessionSecret string,
 	publicURL string,
+	loginRatePerMinute float64,
+	loginRateBurst float64,
 ) *Server {
 	s := &Server{
 		mux:            http.NewServeMux(),
@@ -61,7 +63,7 @@ func NewServer(
 		allowedOrigins: allowedOrigins,
 		sessionSecret:  sessionSecret,
 		publicURL:      publicURL,
-		loginLimiter:   newRateLimiter(5, 5),
+		loginLimiter:   newRateLimiter(loginRatePerMinute, loginRateBurst),
 		eventsLimiter:  newRateLimiter(500, 100),
 	}
 	s.registerRoutes()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,8 @@ type Config struct {
 	SelfAPIKey          string
 	SelfEnvironment     string
 	EventRetentionDays  int // 0 = disabled; default 90
+	LoginRatePerMinute  float64
+	LoginRateBurst      float64
 }
 
 // Load reads config from config files and environment variables.
@@ -80,6 +82,21 @@ func Load() Config {
 	if raw := os.Getenv("FUNNELBARN_EVENT_RETENTION_DAYS"); raw != "" {
 		if parsed, err := strconv.Atoi(raw); err == nil && parsed >= 0 {
 			cfg.EventRetentionDays = parsed
+		}
+	}
+
+	// Login rate limit — default 20/min burst 20.
+	// Set higher (e.g. 1000) in test environments to avoid blocking E2E suites.
+	cfg.LoginRatePerMinute = 20
+	cfg.LoginRateBurst = 20
+	if raw := os.Getenv("FUNNELBARN_LOGIN_RATE_PER_MINUTE"); raw != "" {
+		if parsed, err := strconv.ParseFloat(raw, 64); err == nil && parsed > 0 {
+			cfg.LoginRatePerMinute = parsed
+		}
+	}
+	if raw := os.Getenv("FUNNELBARN_LOGIN_RATE_BURST"); raw != "" {
+		if parsed, err := strconv.ParseFloat(raw, 64); err == nil && parsed > 0 {
+			cfg.LoginRateBurst = parsed
 		}
 	}
 


### PR DESCRIPTION
## Summary
- E2E tests run 4+ parallel workers, each logging in independently — burst-5 token bucket is exhausted instantly, causing all subsequent login attempts to get 429 and fail URL assertions
- Default login rate raised 5→20/min burst 20 (still blocks brute-force; 20 attempts/min means ~50 years per 8-char password)
- `FUNNELBARN_LOGIN_RATE_PER_MINUTE` and `FUNNELBARN_LOGIN_RATE_BURST` are now configurable via env var
- Testing k8s deployment sets both to 1000 so the E2E suite never hits the limit

## Test plan
- [ ] CI build passes
- [ ] E2E tests pass (no more 429s on login)