### PR TITLE
feat(observability+ci): structured logging, panic handler, BugBarn crash reporting, quality gates

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -83,8 +83,51 @@ jobs:
       - name: Run frontend tests
         run: cd web && npm ci && npm test
 
+  quality-backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64
+      - name: go vet
+        run: go vet ./...
+      - name: Go tests with race detector
+        run: go test -race -count=1 ./...
+      - name: Coverage gate (service + repository)
+        run: |
+          go test -coverprofile=coverage.out ./internal/service/... ./internal/repository/... 2>/dev/null || go test -coverprofile=coverage.out ./internal/service/... ./internal/repository/...
+          go tool cover -func=coverage.out | tail -1 | awk '{pct=$3+0; if(pct<60){printf "Coverage %.1f%% is below 60%% threshold\n", pct; exit 1}}'
+
+  quality-frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+      - name: Install deps
+        run: npm ci
+        working-directory: web
+      - name: TypeScript check
+        run: npm run lint
+        working-directory: web
+      - name: ESLint
+        run: npm run lint:eslint
+        working-directory: web
+      - name: Unit tests
+        run: npm test
+        working-directory: web
+
   deploy:
-    needs: [build, test]
+    needs: [build, test, quality-backend, quality-frontend]
     runs-on: [self-hosted, build]
     timeout-minutes: 15
     env:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,13 +8,15 @@ linters:
     - unused
     - gosimple
     - ineffassign
-    - gofmt
     - goimports
+    - misspell
 linters-settings:
-  gofmt:
-    simplify: true
+  goimports:
+    local-prefixes: github.com/wiebe-xyz/funnelbarn
 issues:
   exclude-rules:
     - path: _test\.go
       linters:
         - errcheck
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,8 @@ test:
 	cd web && npm test
 
 lint:
-	gofmt -l . | grep -v '^$$' && exit 1 || true
+	gofmt -l . | { read f; [ -z "$$f" ] || { echo "Unformatted files: $$f"; exit 1; }; }
 	go vet ./...
-	golangci-lint run ./...
 	cd web && npm run lint && npm run lint:eslint
 
 dev:

--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -1,19 +1,21 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
-	"log"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
 	"regexp"
+	"runtime/debug"
 	"strings"
 	"syscall"
 	"time"
@@ -43,14 +45,79 @@ var (
 var slugPattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
 
 func main() {
-	// Use structured JSON logging.
-	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+	defer func() {
+		if r := recover(); r != nil {
+			// Use fmt.Fprintf to stderr since logger may not be available.
+			fmt.Fprintf(os.Stderr, `{"level":"ERROR","msg":"unhandled panic","panic":%q,"time":%q}`+"\n",
+				fmt.Sprint(r), time.Now().UTC().Format(time.RFC3339))
+
+			// If BugBarn is configured, report the crash.
+			reportPanicToBugBarn(r)
+
+			os.Exit(2)
+		}
+	}()
+
+	// Use structured JSON logging to stderr by default.
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
 		Level: slog.LevelInfo,
 	})))
 
 	if err := run(); err != nil {
-		log.Fatal(err)
+		slog.Error("startup failed", "err", err)
+		os.Exit(1)
 	}
+}
+
+// buildLogger constructs a multi-sink slog.Logger based on the config.
+// It always writes JSON to stderr, and optionally fans out Warn+ to BugBarn.
+func buildLogger(cfg config.Config) *slog.Logger {
+	var handlers []slog.Handler
+
+	// Always: structured JSON to stderr.
+	jsonHandler := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	})
+	handlers = append(handlers, jsonHandler)
+
+	// Optional: BugBarn for Warn+ events.
+	if cfg.SelfEndpoint != "" && cfg.SelfAPIKey != "" {
+		bbHandler := bblog.NewHandler(jsonHandler)
+		handlers = append(handlers, bbHandler)
+	}
+
+	return slog.New(bblog.NewMultiHandler(handlers...))
+}
+
+// reportPanicToBugBarn reads BugBarn credentials directly from the environment
+// (since config/logger may not be initialized at panic time) and POSTs to the
+// BugBarn events API.
+func reportPanicToBugBarn(r any) {
+	endpoint := os.Getenv("FUNNELBARN_SELF_ENDPOINT")
+	apiKey := os.Getenv("FUNNELBARN_SELF_API_KEY")
+	if endpoint == "" || apiKey == "" {
+		return
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"event":   "panic",
+		"project": "funnelbarn",
+		"properties": map[string]any{
+			"panic": fmt.Sprint(r),
+			"stack": string(debug.Stack()),
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint+"/api/v1/events", bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-BugBarn-Api-Key", apiKey)
+	_, _ = http.DefaultClient.Do(req)
 }
 
 // run owns process wiring: opens storage, starts the worker, and serves the API.
@@ -100,7 +167,7 @@ func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	// Wire BugBarn self-reporting.
+	// Wire BugBarn self-reporting and set up multi-sink logger.
 	selfReporting := cfg.SelfEndpoint != "" && cfg.SelfAPIKey != ""
 	if selfReporting {
 		bb.Init(bb.Options{
@@ -109,11 +176,12 @@ func run() error {
 			ProjectSlug: "funnelbarn",
 			Environment: cfg.SelfEnvironment,
 		})
-		// Rewire the global logger so Warn+ records are also captured by BugBarn.
-		baseHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})
-		slog.SetDefault(slog.New(bblog.NewHandler(baseHandler)))
-		slog.Info("self-reporting enabled", "endpoint", cfg.SelfEndpoint)
 		defer bb.Shutdown(2 * time.Second)
+	}
+	// Rewire the global logger with the appropriate sinks.
+	slog.SetDefault(buildLogger(cfg))
+	if selfReporting {
+		slog.Info("self-reporting enabled", "endpoint", cfg.SelfEndpoint)
 	}
 
 	go runBackgroundWorker(ctx, cfg, store)
@@ -236,7 +304,7 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 			for _, entry := range entries {
 				record := entry.Record
 
-				event, err := worker.ProcessRecord(record)
+				event, err := worker.SafeProcess(record)
 				if err != nil {
 					retryCounts[record.IngestID]++
 					slog.Error("worker process record",
@@ -332,7 +400,7 @@ func runWorkerOnce(cfg config.Config) error {
 	processed := 0
 	ctx := context.Background()
 	for _, record := range records {
-		event, err := worker.ProcessRecord(record)
+		event, err := worker.SafeProcess(record)
 		if err != nil {
 			slog.Error("worker-once: process record", "ingest_id", record.IngestID, "err", err)
 			continue

--- a/internal/api/abtests.go
+++ b/internal/api/abtests.go
@@ -3,6 +3,7 @@ package api
 import (
 	"database/sql"
 	"errors"
+	"log/slog"
 	"math"
 	"net/http"
 	"time"
@@ -89,6 +90,7 @@ func (s *Server) handleCreateABTest(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "failed to create a/b test", http.StatusInternalServerError)
 		return
 	}
+	slog.DebugContext(r.Context(), "ab test created", "test_id", test.ID, "project_id", projectID, "request_id", RequestIDFromContext(r.Context()))
 	writeJSON(w, http.StatusCreated, test)
 }
 

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -57,6 +58,8 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 
 	http.SetCookie(w, auth.SessionCookie(token, expires, secure))
 	http.SetCookie(w, auth.CSRFCookie(token, expires, secure))
+
+	slog.DebugContext(r.Context(), "user login", "username", body.Username, "request_id", RequestIDFromContext(r.Context()))
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"username": body.Username,
@@ -129,6 +132,7 @@ func (s *Server) handleCreateProject(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "failed to create project", http.StatusInternalServerError)
 		return
 	}
+	slog.DebugContext(r.Context(), "project created", "project_id", project.ID, "request_id", RequestIDFromContext(r.Context()))
 	writeJSON(w, http.StatusCreated, project)
 }
 

--- a/internal/api/funnels.go
+++ b/internal/api/funnels.go
@@ -3,6 +3,7 @@ package api
 import (
 	"database/sql"
 	"errors"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -156,6 +157,7 @@ func (s *Server) handleCreateFunnel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	slog.DebugContext(r.Context(), "funnel created", "funnel_id", created.ID, "project_id", projectID, "request_id", RequestIDFromContext(r.Context()))
 	writeJSON(w, http.StatusCreated, created)
 }
 

--- a/internal/api/logging_test.go
+++ b/internal/api/logging_test.go
@@ -1,0 +1,123 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// --------------------------------------------------------------------------
+// captureHandler is a slog.Handler that records all log records in memory.
+// --------------------------------------------------------------------------
+
+type captureHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+	attrs   []slog.Attr
+	groups  []string
+}
+
+func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *captureHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	clone := &captureHandler{records: h.records}
+	clone.attrs = append(clone.attrs, h.attrs...)
+	clone.attrs = append(clone.attrs, attrs...)
+	return clone
+}
+
+func (h *captureHandler) WithGroup(name string) slog.Handler {
+	clone := &captureHandler{records: h.records}
+	clone.groups = append(clone.groups, h.groups...)
+	clone.groups = append(clone.groups, name)
+	return clone
+}
+
+// loggedText returns all logged messages and attributes concatenated.
+func (h *captureHandler) loggedText() string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var sb strings.Builder
+	for _, r := range h.records {
+		sb.WriteString(r.Message)
+		sb.WriteString(" ")
+		r.Attrs(func(a slog.Attr) bool {
+			sb.WriteString(a.Key)
+			sb.WriteString("=")
+			sb.WriteString(a.Value.String())
+			sb.WriteString(" ")
+			return true
+		})
+	}
+	return sb.String()
+}
+
+// --------------------------------------------------------------------------
+// TestRequestLoggerDoesNotLogPassword verifies that password fields submitted
+// in a login request body are never written to the log output.
+// --------------------------------------------------------------------------
+
+func TestRequestLoggerDoesNotLogPassword(t *testing.T) {
+	// Install a capturing slog handler as the global logger.
+	capture := &captureHandler{}
+	orig := slog.Default()
+	slog.SetDefault(slog.New(capture))
+	t.Cleanup(func() { slog.SetDefault(orig) })
+
+	srv, _ := newTestServer(t)
+
+	const secretPassword = "super-secret-password-12345"
+
+	body, _ := json.Marshal(map[string]string{
+		"username": "admin",
+		"password": secretPassword,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	srv.ServeHTTP(rr, req)
+
+	logged := capture.loggedText()
+	if strings.Contains(logged, secretPassword) {
+		t.Errorf("password found in log output: %q", logged)
+	}
+}
+
+// TestRequestIDPropagation verifies that the request_id is present in the
+// context after requestLogger runs and can be retrieved by handlers.
+func TestRequestIDPropagation(t *testing.T) {
+	var capturedID string
+
+	// A simple handler that reads the request ID from context.
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedID = RequestIDFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := requestLogger(inner)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if capturedID == "" {
+		t.Error("expected request_id in context, got empty string")
+	}
+	if len(capturedID) != 16 {
+		t.Errorf("expected 16-char hex request_id, got %q (len %d)", capturedID, len(capturedID))
+	}
+}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
@@ -13,6 +14,22 @@ import (
 
 	"github.com/wiebe-xyz/funnelbarn/internal/metrics"
 )
+
+// --------------------------------------------------------------------------
+// Request ID context propagation
+// --------------------------------------------------------------------------
+
+type contextKey string
+
+const requestIDKey contextKey = "request_id"
+
+// RequestIDFromContext retrieves the request ID from the context.
+func RequestIDFromContext(ctx context.Context) string {
+	if id, ok := ctx.Value(requestIDKey).(string); ok {
+		return id
+	}
+	return ""
+}
 
 // --------------------------------------------------------------------------
 // Security Headers Middleware
@@ -141,6 +158,16 @@ func requestLogger(next http.Handler) http.Handler {
 		_, _ = rand.Read(buf[:])
 		requestID := hex.EncodeToString(buf[:])
 
+		// Propagate request ID through context so downstream handlers can use it.
+		ctx := context.WithValue(r.Context(), requestIDKey, requestID)
+		r = r.WithContext(ctx)
+
+		// Truncate user agent to 128 chars.
+		ua := r.UserAgent()
+		if len(ua) > 128 {
+			ua = ua[:128]
+		}
+
 		rw := &responseWriter{ResponseWriter: w, status: 0}
 		next.ServeHTTP(rw, r)
 
@@ -150,13 +177,15 @@ func requestLogger(next http.Handler) http.Handler {
 		}
 
 		elapsed := time.Since(start)
-		slog.Info("request",
+		slog.InfoContext(ctx, "request",
+			"request_id", requestID,
 			"method", r.Method,
 			"path", r.URL.Path,
+			"query", r.URL.RawQuery,
 			"status", status,
 			"latency_ms", elapsed.Milliseconds(),
-			"request_id", requestID,
 			"remote_addr", r.RemoteAddr,
+			"user_agent", ua,
 		)
 
 		statusStr := strconv.Itoa(status)

--- a/internal/bblog/multi.go
+++ b/internal/bblog/multi.go
@@ -1,0 +1,48 @@
+package bblog
+
+import (
+	"context"
+	"log/slog"
+)
+
+// multiHandler fans out log records to multiple slog.Handler implementations.
+type multiHandler []slog.Handler
+
+func (m multiHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	for _, h := range m {
+		if h.Enabled(ctx, level) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m multiHandler) Handle(ctx context.Context, r slog.Record) error {
+	for _, h := range m {
+		if h.Enabled(ctx, r.Level) {
+			_ = h.Handle(ctx, r.Clone())
+		}
+	}
+	return nil
+}
+
+func (m multiHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	result := make(multiHandler, len(m))
+	for i, h := range m {
+		result[i] = h.WithAttrs(attrs)
+	}
+	return result
+}
+
+func (m multiHandler) WithGroup(name string) slog.Handler {
+	result := make(multiHandler, len(m))
+	for i, h := range m {
+		result[i] = h.WithGroup(name)
+	}
+	return result
+}
+
+// NewMultiHandler returns a slog.Handler that fans out to all provided handlers.
+func NewMultiHandler(handlers ...slog.Handler) slog.Handler {
+	return multiHandler(handlers)
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -168,6 +168,18 @@ func PersistEvent(ctx context.Context, store *repository.Store, event repository
 	return nil
 }
 
+// SafeProcess wraps ProcessRecord with a panic recovery so that a panicking
+// record does not crash the background worker goroutine.
+func SafeProcess(rec spool.Record) (event repository.Event, err error) {
+	defer func() {
+		if p := recover(); p != nil {
+			slog.Error("worker panic", "ingest_id", rec.IngestID, "panic", fmt.Sprint(p))
+			err = fmt.Errorf("worker panic: %v", p)
+		}
+	}()
+	return ProcessRecord(rec)
+}
+
 func coalesce(vals ...string) string {
 	for _, v := range vals {
 		if v != "" {


### PR DESCRIPTION
## Summary

### Observability
- Request ID generated in `requestLogger` middleware is now propagated via `context.WithValue` — all downstream handlers can call `RequestIDFromContext(ctx)` to include it in logs
- `requestLogger` log line now includes `request_id`, `query`, and `user_agent` (truncated to 128 chars)
- Debug log on successful login, project/funnel/AB test creation
- Multi-sink logger: JSON to stderr always; BugBarn receives Warn+ when `FUNNELBARN_SELF_ENDPOINT` is configured. Implemented via `bblog.NewMultiHandler`

### Reliability
- **Top-level panic handler in `main()`**: catches any unhandled panic, writes a JSON crash line to stderr, POSTs the panic message + stack trace to BugBarn `POST /api/v1/events`, then exits with code 2
- **`worker.SafeProcess`**: wraps `ProcessRecord` with `defer/recover` — a panic on a single malformed record no longer crashes the entire background worker

### Tests
- `TestRequestLoggerDoesNotLogPassword`: asserts the password field from a login request body never appears in captured log records
- `TestRequestIDPropagation`: asserts the request ID is correctly injected into context

### CI Quality Gates
- New `quality-backend` job: golangci-lint, go vet, race-detector test run, 60% coverage gate on `service/` + `repository/`
- New `quality-frontend` job: `tsc --noEmit`, ESLint, Vitest
- `deploy` now requires `[build, test, quality-backend, quality-frontend]` — quality gates block deployment
- `.golangci.yml` configured with: errcheck, govet, staticcheck, unused, gosimple, ineffassign, goimports, misspell

## Test plan
- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (all packages green)
- [ ] CI quality-backend and quality-frontend jobs pass