### PR TITLE
feat(arch): service interfaces, domain errors, validation, per-route rate limiting

### DIFF
--- a/internal/api/abtests.go
+++ b/internal/api/abtests.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"database/sql"
-	"errors"
 	"log/slog"
 	"math"
 	"net/http"
@@ -42,7 +40,7 @@ func (s *Server) handleListABTests(w http.ResponseWriter, r *http.Request) {
 
 	tests, err := s.abtests.ListABTests(r.Context(), projectID)
 	if err != nil {
-		jsonError(w, "failed to list a/b tests", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleListABTests")
 		return
 	}
 	if tests == nil {
@@ -69,14 +67,6 @@ func (s *Server) handleCreateABTest(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
-	if body.Name == "" {
-		jsonError(w, "name is required", http.StatusBadRequest)
-		return
-	}
-	if body.ConversionEvent == "" {
-		jsonError(w, "conversion_event is required", http.StatusBadRequest)
-		return
-	}
 
 	test, err := s.abtests.CreateABTest(r.Context(), repository.ABTest{
 		ProjectID:       projectID,
@@ -87,7 +77,7 @@ func (s *Server) handleCreateABTest(w http.ResponseWriter, r *http.Request) {
 		ConversionEvent: body.ConversionEvent,
 	})
 	if err != nil {
-		jsonError(w, "failed to create a/b test", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleCreateABTest")
 		return
 	}
 	slog.DebugContext(r.Context(), "ab test created", "test_id", test.ID, "project_id", projectID, "request_id", RequestIDFromContext(r.Context()))
@@ -105,11 +95,7 @@ func (s *Server) handleABTestAnalysis(w http.ResponseWriter, r *http.Request) {
 
 	test, err := s.abtests.GetABTest(r.Context(), testID)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			jsonError(w, "a/b test not found", http.StatusNotFound)
-			return
-		}
-		jsonError(w, "failed to load a/b test", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleABTestAnalysis.getABTest")
 		return
 	}
 	if test.ProjectID != projectID {
@@ -141,7 +127,7 @@ func (s *Server) handleABTestAnalysis(w http.ResponseWriter, r *http.Request) {
 
 	results, err := s.abtests.AnalyzeABTest(r.Context(), test, from, to)
 	if err != nil {
-		jsonError(w, "failed to analyze a/b test", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleABTestAnalysis")
 		return
 	}
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -226,9 +226,10 @@ func TestHandleCreateProject(t *testing.T) {
 
 func TestHandleCreateProject_MissingName(t *testing.T) {
 	srv, _ := newTestServer(t)
+	// Empty name should now return 422 Unprocessable Entity (service-layer validation).
 	w := postJSON(t, srv, "/api/v1/projects", map[string]string{"slug": "test"}, nil)
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("expected 400, got %d", w.Code)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d (body: %s)", w.Code, w.Body.String())
 	}
 }
 
@@ -492,6 +493,57 @@ func TestJSONError_Format(t *testing.T) {
 	}
 }
 
+
+// ---------------------------------------------------------------------------
+// Domain error mapping
+// ---------------------------------------------------------------------------
+
+func TestHandleCreateProject_EmptyName_Returns422(t *testing.T) {
+	srv, _ := newTestServer(t)
+	// Sending an empty name should return 422 via service-layer validation.
+	w := postJSON(t, srv, "/api/v1/projects", map[string]string{"name": "", "slug": "my-slug"}, nil)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422 for empty name, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleCreateProject_DuplicateSlug_Returns409(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	// Create the first project successfully.
+	w1 := postJSON(t, srv, "/api/v1/projects", map[string]string{
+		"name": "First Project",
+		"slug": "dup-slug",
+	}, nil)
+	if w1.Code != http.StatusCreated {
+		t.Fatalf("first create: expected 201, got %d (body: %s)", w1.Code, w1.Body.String())
+	}
+
+	// Creating with the same slug should return 409 Conflict.
+	w2 := postJSON(t, srv, "/api/v1/projects", map[string]string{
+		"name": "Second Project",
+		"slug": "dup-slug",
+	}, nil)
+	if w2.Code != http.StatusConflict {
+		t.Errorf("duplicate slug: expected 409, got %d (body: %s)", w2.Code, w2.Body.String())
+	}
+}
+
+func TestHandleGetProject_UnknownID_Returns404(t *testing.T) {
+	srv, _ := newTestServer(t)
+	// Use a non-existent project ID in a project-scoped route.
+	w := getJSON(t, srv, "/api/v1/projects/nonexistent-id/sessions", nil)
+	// The endpoint returns 200 with empty sessions (it doesn't look up the project).
+	// Use the funnels endpoint which calls GetFunnel internally on a specific funnel ID.
+	// Instead, test via the approve endpoint which calls GetProject.
+	_ = w
+
+	// POST approve on a non-existent project ID.
+	wa := postJSON(t, srv, "/api/v1/projects/nonexistent-id/approve", nil, nil)
+	if wa.Code != http.StatusNotFound {
+		t.Errorf("unknown project approve: expected 404, got %d (body: %s)", wa.Code, wa.Body.String())
+	}
+}
 
 // ---------------------------------------------------------------------------
 // Active session count

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -3,9 +3,7 @@ package api
 import (
 	"crypto/rand"
 	"crypto/sha256"
-	"database/sql"
 	"encoding/hex"
-	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -99,7 +97,7 @@ func (s *Server) handleMe(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleListProjects(w http.ResponseWriter, r *http.Request) {
 	projects, err := s.projects.ListProjects(r.Context())
 	if err != nil {
-		jsonError(w, "failed to list projects", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleListProjects")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"projects": projects})
@@ -116,20 +114,17 @@ func (s *Server) handleCreateProject(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
-	if body.Name == "" {
-		jsonError(w, "name is required", http.StatusBadRequest)
-		return
-	}
+	// Derive slug from domain or name if not provided; service validates emptiness.
 	if body.Slug == "" && body.Domain != "" {
 		body.Slug = toSlug(body.Domain)
 	}
-	if body.Slug == "" {
+	if body.Slug == "" && body.Name != "" {
 		body.Slug = toSlug(body.Name)
 	}
 
 	project, err := s.projects.CreateProject(r.Context(), body.Name, body.Slug)
 	if err != nil {
-		jsonError(w, "failed to create project", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleCreateProject")
 		return
 	}
 	slog.DebugContext(r.Context(), "project created", "project_id", project.ID, "request_id", RequestIDFromContext(r.Context()))
@@ -150,7 +145,7 @@ func (s *Server) handleListAPIKeys(w http.ResponseWriter, r *http.Request) {
 		keys, err = s.apikeys.ListAllAPIKeys(r.Context())
 	}
 	if err != nil {
-		jsonError(w, "failed to list api keys", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleListAPIKeys")
 		return
 	}
 
@@ -219,11 +214,7 @@ func (s *Server) handleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 
 	// Verify project exists.
 	if _, err := s.projects.GetProject(r.Context(), body.ProjectID); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			jsonError(w, "project not found", http.StatusNotFound)
-			return
-		}
-		jsonError(w, "failed to look up project", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleCreateAPIKey.getProject")
 		return
 	}
 
@@ -239,7 +230,7 @@ func (s *Server) handleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 
 	key, err := s.apikeys.CreateAPIKey(r.Context(), body.Name, body.ProjectID, keySHA256, body.Scope)
 	if err != nil {
-		jsonError(w, "failed to create api key", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleCreateAPIKey")
 		return
 	}
 
@@ -269,7 +260,7 @@ func (s *Server) handleDeleteAPIKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := s.apikeys.DeleteAPIKey(r.Context(), keyID); err != nil {
-		jsonError(w, "failed to delete api key", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleDeleteAPIKey")
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -283,7 +274,7 @@ func (s *Server) handleDeleteProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := s.projects.DeleteProject(r.Context(), projectID); err != nil {
-		jsonError(w, "failed to delete project", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleDeleteProject")
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -309,11 +300,7 @@ func (s *Server) handleUpdateProject(w http.ResponseWriter, r *http.Request) {
 	}
 	project, err := s.projects.UpdateProject(r.Context(), projectID, body.Name)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			jsonError(w, "project not found", http.StatusNotFound)
-			return
-		}
-		jsonError(w, "failed to update project", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleUpdateProject")
 		return
 	}
 	writeJSON(w, http.StatusOK, project)
@@ -330,11 +317,7 @@ func (s *Server) handleApproveProject(w http.ResponseWriter, r *http.Request) {
 	}
 	project, err := s.projects.ApproveProject(r.Context(), projectID)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			jsonError(w, "project not found", http.StatusNotFound)
-			return
-		}
-		jsonError(w, "failed to approve project", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleApproveProject")
 		return
 	}
 	writeJSON(w, http.StatusOK, project)

--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -40,73 +40,73 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 
 	totalEvents, err := s.events.CountEvents(ctx, projectID, from, to)
 	if err != nil {
-		jsonError(w, "failed to count events", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleDashboard.countEvents")
 		return
 	}
 
 	uniqueSessions, err := s.events.UniqueSessionCount(ctx, projectID, from, to)
 	if err != nil {
-		jsonError(w, "failed to count sessions", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleDashboard.uniqueSessionCount")
 		return
 	}
 
 	topPages, err := s.events.TopPages(ctx, projectID, from, to, 10)
 	if err != nil {
-		jsonError(w, "failed to get top pages", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleDashboard.topPages")
 		return
 	}
 
 	topReferrers, err := s.events.TopReferrers(ctx, projectID, from, to, 10)
 	if err != nil {
-		jsonError(w, "failed to get top referrers", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleDashboard.topReferrers")
 		return
 	}
 
 	timeSeries, err := s.events.DailyEventCounts(ctx, projectID, from, to)
 	if err != nil {
-		jsonError(w, "failed to get time series", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleDashboard.dailyEventCounts")
 		return
 	}
 
 	sessionTimeSeries, err := s.events.DailyUniqueSessions(ctx, projectID, from, to)
 	if err != nil {
-		jsonError(w, "failed to get session time series", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleDashboard.dailyUniqueSessions")
 		return
 	}
 
 	topBrowsers, err := s.events.TopBrowsers(ctx, projectID, from, to, 5)
 	if err != nil {
-		jsonError(w, "failed to get browsers", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleDashboard.topBrowsers")
 		return
 	}
 
 	deviceTypes, err := s.events.TopDeviceTypes(ctx, projectID, from, to)
 	if err != nil {
-		jsonError(w, "failed to get device types", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleDashboard.topDeviceTypes")
 		return
 	}
 
 	topEventNames, err := s.events.TopEventNames(ctx, projectID, from, to, 10)
 	if err != nil {
-		jsonError(w, "failed to get event names", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleDashboard.topEventNames")
 		return
 	}
 
 	topUTMSources, err := s.events.TopUTMSources(ctx, projectID, from, to, 5)
 	if err != nil {
-		jsonError(w, "failed to get utm sources", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleDashboard.topUTMSources")
 		return
 	}
 
 	bounceRate, err := s.events.BounceRate(ctx, projectID, from, to)
 	if err != nil {
-		jsonError(w, "failed to compute bounce rate", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleDashboard.bounceRate")
 		return
 	}
 
 	avgEventsPerSession, err := s.events.AvgEventsPerSession(ctx, projectID, from, to)
 	if err != nil {
-		jsonError(w, "failed to compute avg events per session", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleDashboard.avgEventsPerSession")
 		return
 	}
 

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -28,7 +28,7 @@ func (s *Server) handleListEvents(w http.ResponseWriter, r *http.Request) {
 
 	events, err := s.events.ListEvents(r.Context(), projectID, limit, offset)
 	if err != nil {
-		jsonError(w, "failed to list events", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleListEvents")
 		return
 	}
 

--- a/internal/api/funnels.go
+++ b/internal/api/funnels.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"database/sql"
-	"errors"
 	"log/slog"
 	"net/http"
 	"time"
@@ -22,11 +20,7 @@ func (s *Server) handleUpdateFunnel(w http.ResponseWriter, r *http.Request) {
 	// Verify funnel belongs to project.
 	existing, err := s.funnels.GetFunnel(r.Context(), funnelID)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			jsonError(w, "funnel not found", http.StatusNotFound)
-			return
-		}
-		jsonError(w, "failed to load funnel", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleUpdateFunnel.getFunnel")
 		return
 	}
 	if existing.ProjectID != projectID {
@@ -35,8 +29,8 @@ func (s *Server) handleUpdateFunnel(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body struct {
-		Name        string                `json:"name"`
-		Description string                `json:"description"`
+		Name        string                  `json:"name"`
+		Description string                  `json:"description"`
 		Steps       []repository.FunnelStep `json:"steps"`
 	}
 	if err := readJSON(r, &body); err != nil {
@@ -62,7 +56,7 @@ func (s *Server) handleUpdateFunnel(w http.ResponseWriter, r *http.Request) {
 
 	updated, err := s.funnels.UpdateFunnel(r.Context(), funnel)
 	if err != nil {
-		jsonError(w, "failed to update funnel", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleUpdateFunnel")
 		return
 	}
 
@@ -81,11 +75,7 @@ func (s *Server) handleDeleteFunnel(w http.ResponseWriter, r *http.Request) {
 	// Verify funnel belongs to project.
 	existing, err := s.funnels.GetFunnel(r.Context(), funnelID)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			jsonError(w, "funnel not found", http.StatusNotFound)
-			return
-		}
-		jsonError(w, "failed to load funnel", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleDeleteFunnel.getFunnel")
 		return
 	}
 	if existing.ProjectID != projectID {
@@ -94,7 +84,7 @@ func (s *Server) handleDeleteFunnel(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.funnels.DeleteFunnel(r.Context(), funnelID); err != nil {
-		jsonError(w, "failed to delete funnel", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleDeleteFunnel")
 		return
 	}
 
@@ -111,7 +101,7 @@ func (s *Server) handleListFunnels(w http.ResponseWriter, r *http.Request) {
 
 	funnels, err := s.funnels.ListFunnels(r.Context(), projectID)
 	if err != nil {
-		jsonError(w, "failed to list funnels", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleListFunnels")
 		return
 	}
 
@@ -127,20 +117,12 @@ func (s *Server) handleCreateFunnel(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body struct {
-		Name        string                `json:"name"`
-		Description string                `json:"description"`
+		Name        string                  `json:"name"`
+		Description string                  `json:"description"`
 		Steps       []repository.FunnelStep `json:"steps"`
 	}
 	if err := readJSON(r, &body); err != nil {
 		jsonError(w, "invalid request body", http.StatusBadRequest)
-		return
-	}
-	if body.Name == "" {
-		jsonError(w, "name is required", http.StatusBadRequest)
-		return
-	}
-	if len(body.Steps) == 0 {
-		jsonError(w, "at least one step is required", http.StatusBadRequest)
 		return
 	}
 
@@ -153,7 +135,7 @@ func (s *Server) handleCreateFunnel(w http.ResponseWriter, r *http.Request) {
 
 	created, err := s.funnels.CreateFunnel(r.Context(), funnel)
 	if err != nil {
-		jsonError(w, "failed to create funnel", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleCreateFunnel")
 		return
 	}
 
@@ -195,11 +177,7 @@ func (s *Server) handleFunnelAnalysis(w http.ResponseWriter, r *http.Request) {
 
 	funnel, err := s.funnels.GetFunnel(r.Context(), funnelID)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			jsonError(w, "funnel not found", http.StatusNotFound)
-			return
-		}
-		jsonError(w, "failed to load funnel", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleFunnelAnalysis.getFunnel")
 		return
 	}
 	if funnel.ProjectID != projectID {
@@ -226,7 +204,7 @@ func (s *Server) handleFunnelAnalysis(w http.ResponseWriter, r *http.Request) {
 
 	results, err := s.funnels.AnalyzeFunnel(r.Context(), funnel, from, to, seg)
 	if err != nil {
-		jsonError(w, "failed to analyze funnel", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleFunnelAnalysis")
 		return
 	}
 
@@ -250,11 +228,7 @@ func (s *Server) handleFunnelSegments(w http.ResponseWriter, r *http.Request) {
 	// Verify funnel belongs to project.
 	funnel, err := s.funnels.GetFunnel(r.Context(), funnelID)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			jsonError(w, "funnel not found", http.StatusNotFound)
-			return
-		}
-		jsonError(w, "failed to load funnel", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleFunnelSegments.getFunnel")
 		return
 	}
 	if funnel.ProjectID != projectID {
@@ -264,7 +238,7 @@ func (s *Server) handleFunnelSegments(w http.ResponseWriter, r *http.Request) {
 
 	segs, err := s.funnels.FunnelSegmentData(r.Context(), projectID)
 	if err != nil {
-		jsonError(w, "failed to load segment data", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleFunnelSegments")
 		return
 	}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -2,12 +2,15 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"log/slog"
+	"net"
 	"net/http"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/wiebe-xyz/funnelbarn/internal/auth"
+	"github.com/wiebe-xyz/funnelbarn/internal/domain"
 	"github.com/wiebe-xyz/funnelbarn/internal/ingest"
 	"github.com/wiebe-xyz/funnelbarn/internal/service"
 )
@@ -15,12 +18,12 @@ import (
 // Server is the main HTTP API server.
 type Server struct {
 	mux            *http.ServeMux
-	projects       *service.ProjectService
-	funnels        *service.FunnelService
-	abtests        *service.ABTestService
-	events         *service.EventService
-	sessions       *service.SessionService
-	apikeys        *service.APIKeyService
+	projects       service.Projects
+	funnels        service.Funnels
+	abtests        service.ABTests
+	events         service.Events
+	sessions       service.Sessions
+	apikeys        service.APIKeys
 	ingest         *ingest.Handler
 	userAuth       *auth.UserAuthenticator
 	sessionManager *auth.SessionManager
@@ -30,17 +33,18 @@ type Server struct {
 
 	loginLimiter  *rateLimiter
 	eventsLimiter *rateLimiter
+	apiLimiter    *rateLimiter // 300 req/min, burst 60 — for all session-authenticated endpoints
 }
 
 // NewServer creates the API server and registers all routes.
 func NewServer(
 	ingestHandler *ingest.Handler,
-	projects *service.ProjectService,
-	funnels *service.FunnelService,
-	abtests *service.ABTestService,
-	events *service.EventService,
-	sessions *service.SessionService,
-	apikeys *service.APIKeyService,
+	projects service.Projects,
+	funnels service.Funnels,
+	abtests service.ABTests,
+	events service.Events,
+	sessions service.Sessions,
+	apikeys service.APIKeys,
 	userAuth *auth.UserAuthenticator,
 	sessionManager *auth.SessionManager,
 	allowedOrigins []string,
@@ -65,6 +69,7 @@ func NewServer(
 		publicURL:      publicURL,
 		loginLimiter:   newRateLimiter(loginRatePerMinute, loginRateBurst),
 		eventsLimiter:  newRateLimiter(500, 100),
+		apiLimiter:     newRateLimiter(300, 60),
 	}
 	s.registerRoutes()
 	return s
@@ -158,10 +163,19 @@ func (s *Server) setCORSHeaders(w http.ResponseWriter, r *http.Request) {
 }
 
 // requireSession wraps a handler to enforce session cookie authentication.
+// It also applies the apiLimiter rate limit for authenticated endpoints.
 func (s *Server) requireSession(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if s.sessionManager == nil || !s.userAuth.Enabled() {
-			// No auth configured — allow through.
+			// No auth configured — apply rate limit and allow through.
+			ip, _, err := net.SplitHostPort(r.RemoteAddr)
+			if err != nil {
+				ip = r.RemoteAddr
+			}
+			if !s.apiLimiter.allow(ip) {
+				jsonError(w, "too many requests", http.StatusTooManyRequests)
+				return
+			}
 			next(w, r)
 			return
 		}
@@ -178,8 +192,38 @@ func (s *Server) requireSession(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 
+		ip, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			ip = r.RemoteAddr
+		}
+		if !s.apiLimiter.allow(ip) {
+			jsonError(w, "too many requests", http.StatusTooManyRequests)
+			return
+		}
+
 		slog.Debug("session valid", "username", username)
 		next(w, r)
+	}
+}
+
+// mapServiceError maps domain/service errors to appropriate HTTP status codes.
+// It never leaks internal error details to the client.
+func mapServiceError(w http.ResponseWriter, err error, op string) {
+	switch {
+	case domain.IsNotFound(err):
+		jsonError(w, "not found", http.StatusNotFound)
+	case domain.IsConflict(err):
+		jsonError(w, "already exists", http.StatusConflict)
+	case domain.IsValidation(err):
+		var ve *domain.ValidationError
+		if errors.As(err, &ve) {
+			jsonError(w, ve.Error(), http.StatusUnprocessableEntity)
+		} else {
+			jsonError(w, "invalid request", http.StatusUnprocessableEntity)
+		}
+	default:
+		slog.Error("unexpected service error", "op", op, "err", err)
+		jsonError(w, "internal server error", http.StatusInternalServerError)
 	}
 }
 

--- a/internal/api/sessions.go
+++ b/internal/api/sessions.go
@@ -14,7 +14,7 @@ func (s *Server) handleActiveSessionCount(w http.ResponseWriter, r *http.Request
 	}
 	count, err := s.sessions.ActiveSessionCount(r.Context(), projectID, 5)
 	if err != nil {
-		jsonError(w, "failed to count sessions", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleActiveSessionCount")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"active_sessions": count, "window_minutes": 5})
@@ -43,7 +43,7 @@ func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
 
 	sessions, err := s.sessions.ListSessions(r.Context(), projectID, limit, offset)
 	if err != nil {
-		jsonError(w, "failed to list sessions", http.StatusInternalServerError)
+		mapServiceError(w, err, "handleListSessions")
 		return
 	}
 

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -1,0 +1,36 @@
+package domain
+
+import "errors"
+
+// Sentinel errors that the service layer returns.
+// Handlers map these to HTTP status codes.
+var (
+	ErrNotFound   = errors.New("not found")
+	ErrConflict   = errors.New("already exists")
+	ErrForbidden  = errors.New("forbidden")
+	ErrValidation = errors.New("validation error")
+)
+
+// ValidationError wraps a field-level validation message.
+type ValidationError struct {
+	Field   string
+	Message string
+}
+
+func (e *ValidationError) Error() string {
+	if e.Field != "" {
+		return e.Field + ": " + e.Message
+	}
+	return e.Message
+}
+
+func (e *ValidationError) Unwrap() error { return ErrValidation }
+
+// IsNotFound reports whether err is or wraps ErrNotFound.
+func IsNotFound(err error) bool { return errors.Is(err, ErrNotFound) }
+
+// IsConflict reports whether err is or wraps ErrConflict.
+func IsConflict(err error) bool { return errors.Is(err, ErrConflict) }
+
+// IsValidation reports whether err is or wraps ErrValidation.
+func IsValidation(err error) bool { return errors.Is(err, ErrValidation) }

--- a/internal/domain/errors_test.go
+++ b/internal/domain/errors_test.go
@@ -1,0 +1,97 @@
+package domain_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/wiebe-xyz/funnelbarn/internal/domain"
+)
+
+func TestIsNotFound(t *testing.T) {
+	t.Run("direct sentinel", func(t *testing.T) {
+		if !domain.IsNotFound(domain.ErrNotFound) {
+			t.Error("expected IsNotFound(ErrNotFound) to be true")
+		}
+	})
+
+	t.Run("wrapped sentinel", func(t *testing.T) {
+		wrapped := fmt.Errorf("project abc: %w", domain.ErrNotFound)
+		if !domain.IsNotFound(wrapped) {
+			t.Error("expected IsNotFound(wrapped ErrNotFound) to be true")
+		}
+	})
+
+	t.Run("unrelated error", func(t *testing.T) {
+		if domain.IsNotFound(errors.New("something else")) {
+			t.Error("expected IsNotFound to be false for unrelated error")
+		}
+	})
+}
+
+func TestIsConflict(t *testing.T) {
+	t.Run("direct sentinel", func(t *testing.T) {
+		if !domain.IsConflict(domain.ErrConflict) {
+			t.Error("expected IsConflict(ErrConflict) to be true")
+		}
+	})
+
+	t.Run("wrapped sentinel", func(t *testing.T) {
+		wrapped := fmt.Errorf("slug %q: %w", "my-slug", domain.ErrConflict)
+		if !domain.IsConflict(wrapped) {
+			t.Error("expected IsConflict(wrapped ErrConflict) to be true")
+		}
+	})
+
+	t.Run("unrelated error", func(t *testing.T) {
+		if domain.IsConflict(domain.ErrNotFound) {
+			t.Error("expected IsConflict to be false for ErrNotFound")
+		}
+	})
+}
+
+func TestIsValidation(t *testing.T) {
+	t.Run("direct sentinel", func(t *testing.T) {
+		if !domain.IsValidation(domain.ErrValidation) {
+			t.Error("expected IsValidation(ErrValidation) to be true")
+		}
+	})
+
+	t.Run("ValidationError unwraps to ErrValidation", func(t *testing.T) {
+		ve := &domain.ValidationError{Field: "name", Message: "required"}
+		if !domain.IsValidation(ve) {
+			t.Error("expected IsValidation(ValidationError) to be true")
+		}
+	})
+
+	t.Run("unrelated error", func(t *testing.T) {
+		if domain.IsValidation(domain.ErrNotFound) {
+			t.Error("expected IsValidation to be false for ErrNotFound")
+		}
+	})
+}
+
+func TestValidationError_Error(t *testing.T) {
+	t.Run("with field", func(t *testing.T) {
+		ve := &domain.ValidationError{Field: "name", Message: "required"}
+		want := "name: required"
+		if got := ve.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("without field", func(t *testing.T) {
+		ve := &domain.ValidationError{Message: "something invalid"}
+		want := "something invalid"
+		if got := ve.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestValidationError_Unwrap(t *testing.T) {
+	ve := &domain.ValidationError{Field: "slug", Message: "required"}
+	if !errors.Is(ve, domain.ErrValidation) {
+		t.Error("expected ValidationError to unwrap to ErrValidation")
+	}
+}

--- a/internal/service/abtests.go
+++ b/internal/service/abtests.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"context"
+	"strings"
 	"time"
 
+	"github.com/wiebe-xyz/funnelbarn/internal/domain"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 )
 
@@ -18,6 +20,12 @@ func NewABTestService(store *repository.Store) *ABTestService {
 }
 
 func (svc *ABTestService) CreateABTest(ctx context.Context, t repository.ABTest) (repository.ABTest, error) {
+	if strings.TrimSpace(t.Name) == "" {
+		return repository.ABTest{}, &domain.ValidationError{Field: "name", Message: "required"}
+	}
+	if strings.TrimSpace(t.ConversionEvent) == "" {
+		return repository.ABTest{}, &domain.ValidationError{Field: "conversion_event", Message: "required"}
+	}
 	return svc.store.CreateABTest(ctx, t)
 }
 

--- a/internal/service/apikeys.go
+++ b/internal/service/apikeys.go
@@ -2,7 +2,9 @@ package service
 
 import (
 	"context"
+	"strings"
 
+	"github.com/wiebe-xyz/funnelbarn/internal/domain"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 )
 
@@ -17,6 +19,12 @@ func NewAPIKeyService(store *repository.Store) *APIKeyService {
 }
 
 func (svc *APIKeyService) CreateAPIKey(ctx context.Context, name, projectID, keySHA256, scope string) (repository.APIKey, error) {
+	if strings.TrimSpace(name) == "" {
+		return repository.APIKey{}, &domain.ValidationError{Field: "name", Message: "required"}
+	}
+	if strings.TrimSpace(scope) == "" {
+		return repository.APIKey{}, &domain.ValidationError{Field: "scope", Message: "required"}
+	}
 	return svc.store.CreateAPIKey(ctx, name, projectID, keySHA256, scope)
 }
 

--- a/internal/service/funnels.go
+++ b/internal/service/funnels.go
@@ -2,8 +2,13 @@ package service
 
 import (
 	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
 	"time"
 
+	"github.com/wiebe-xyz/funnelbarn/internal/domain"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 )
 
@@ -18,6 +23,12 @@ func NewFunnelService(store *repository.Store) *FunnelService {
 }
 
 func (svc *FunnelService) CreateFunnel(ctx context.Context, f repository.Funnel) (repository.Funnel, error) {
+	if strings.TrimSpace(f.Name) == "" {
+		return repository.Funnel{}, &domain.ValidationError{Field: "name", Message: "required"}
+	}
+	if len(f.Steps) == 0 {
+		return repository.Funnel{}, &domain.ValidationError{Field: "steps", Message: "at least one step required"}
+	}
 	return svc.store.CreateFunnel(ctx, f)
 }
 
@@ -26,7 +37,14 @@ func (svc *FunnelService) ListFunnels(ctx context.Context, projectID string) ([]
 }
 
 func (svc *FunnelService) GetFunnel(ctx context.Context, id string) (repository.Funnel, error) {
-	return svc.store.FunnelByID(ctx, id)
+	f, err := svc.store.FunnelByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return repository.Funnel{}, fmt.Errorf("%w: funnel %s", domain.ErrNotFound, id)
+		}
+		return repository.Funnel{}, err
+	}
+	return f, nil
 }
 
 func (svc *FunnelService) UpdateFunnel(ctx context.Context, f repository.Funnel) (repository.Funnel, error) {

--- a/internal/service/helpers.go
+++ b/internal/service/helpers.go
@@ -1,0 +1,8 @@
+package service
+
+import "strings"
+
+// isUniqueConstraint reports whether err is a SQLite UNIQUE constraint violation.
+func isUniqueConstraint(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "UNIQUE constraint failed")
+}

--- a/internal/service/interfaces.go
+++ b/internal/service/interfaces.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/wiebe-xyz/funnelbarn/internal/repository"
+)
+
+// Projects is the interface for project-related operations.
+type Projects interface {
+	CreateProject(ctx context.Context, name, slug string) (repository.Project, error)
+	ListProjects(ctx context.Context) ([]repository.Project, error)
+	GetProject(ctx context.Context, id string) (repository.Project, error)
+	GetProjectBySlug(ctx context.Context, slug string) (repository.Project, error)
+	UpdateProject(ctx context.Context, id, name string) (repository.Project, error)
+	DeleteProject(ctx context.Context, id string) error
+	ApproveProject(ctx context.Context, id string) (repository.Project, error)
+	EnsureProjectPending(ctx context.Context, name, slug string) (repository.Project, error)
+	EnsureSetupAPIKey(ctx context.Context, projectID, keySHA256 string) error
+	EnsureProject(ctx context.Context, slug string) (repository.Project, error)
+	HasProjects(ctx context.Context) (bool, error)
+	UserByUsername(ctx context.Context, username string) (repository.User, error)
+}
+
+// Funnels is the interface for funnel-related operations.
+type Funnels interface {
+	CreateFunnel(ctx context.Context, f repository.Funnel) (repository.Funnel, error)
+	ListFunnels(ctx context.Context, projectID string) ([]repository.Funnel, error)
+	GetFunnel(ctx context.Context, id string) (repository.Funnel, error)
+	UpdateFunnel(ctx context.Context, f repository.Funnel) (repository.Funnel, error)
+	DeleteFunnel(ctx context.Context, id string) error
+	AnalyzeFunnel(ctx context.Context, f repository.Funnel, from, to time.Time, seg *repository.SegmentFilter) ([]repository.FunnelStepResult, error)
+	FunnelSegmentData(ctx context.Context, projectID string) (repository.FunnelSegments, error)
+}
+
+// ABTests is the interface for A/B test-related operations.
+type ABTests interface {
+	CreateABTest(ctx context.Context, t repository.ABTest) (repository.ABTest, error)
+	ListABTests(ctx context.Context, projectID string) ([]repository.ABTest, error)
+	GetABTest(ctx context.Context, id string) (repository.ABTest, error)
+	AnalyzeABTest(ctx context.Context, t repository.ABTest, from, to time.Time) ([]repository.ABTestResult, error)
+}
+
+// Events is the interface for event-related operations.
+type Events interface {
+	InsertEvent(ctx context.Context, e repository.Event) error
+	ListEvents(ctx context.Context, projectID string, limit, offset int) ([]repository.Event, error)
+	CountEvents(ctx context.Context, projectID string, from, to time.Time) (int64, error)
+	TopPages(ctx context.Context, projectID string, from, to time.Time, limit int) ([]repository.PageStat, error)
+	TopReferrers(ctx context.Context, projectID string, from, to time.Time, limit int) ([]repository.ReferrerStat, error)
+	DailyEventCounts(ctx context.Context, projectID string, from, to time.Time) ([]repository.TimeSeriesPoint, error)
+	DailyUniqueSessions(ctx context.Context, projectID string, from, to time.Time) ([]repository.TimeSeriesPoint, error)
+	TopBrowsers(ctx context.Context, projectID string, from, to time.Time, limit int) ([]repository.BrowserStat, error)
+	TopDeviceTypes(ctx context.Context, projectID string, from, to time.Time) ([]repository.DeviceStat, error)
+	TopEventNames(ctx context.Context, projectID string, from, to time.Time, limit int) ([]repository.EventNameStat, error)
+	TopUTMSources(ctx context.Context, projectID string, from, to time.Time, limit int) ([]repository.UTMStat, error)
+	BounceRate(ctx context.Context, projectID string, from, to time.Time) (float64, error)
+	AvgEventsPerSession(ctx context.Context, projectID string, from, to time.Time) (float64, error)
+	UniqueSessionCount(ctx context.Context, projectID string, from, to time.Time) (int64, error)
+	GetEventByIngestID(ctx context.Context, ingestID string) (*repository.Event, error)
+}
+
+// Sessions is the interface for session-related operations.
+type Sessions interface {
+	UpsertSession(ctx context.Context, sess repository.Session) error
+	SessionByID(ctx context.Context, id string) (repository.Session, error)
+	ListSessions(ctx context.Context, projectID string, limit, offset int) ([]repository.Session, error)
+	ActiveSessionCount(ctx context.Context, projectID string, withinMinutes int) (int64, error)
+}
+
+// APIKeys is the interface for API key-related operations.
+type APIKeys interface {
+	CreateAPIKey(ctx context.Context, name, projectID, keySHA256, scope string) (repository.APIKey, error)
+	ListAPIKeys(ctx context.Context, projectID string) ([]repository.APIKey, error)
+	ListAllAPIKeys(ctx context.Context) ([]repository.APIKey, error)
+	DeleteAPIKey(ctx context.Context, id string) error
+	ValidAPIKeySHA256(ctx context.Context, keySHA256 string) (projectID string, scope string, found bool, err error)
+	TouchAPIKey(ctx context.Context, keySHA256 string) error
+}

--- a/internal/service/projects.go
+++ b/internal/service/projects.go
@@ -2,7 +2,12 @@ package service
 
 import (
 	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
 
+	"github.com/wiebe-xyz/funnelbarn/internal/domain"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 )
 
@@ -17,7 +22,20 @@ func NewProjectService(store *repository.Store) *ProjectService {
 }
 
 func (svc *ProjectService) CreateProject(ctx context.Context, name, slug string) (repository.Project, error) {
-	return svc.store.CreateProject(ctx, name, slug)
+	if strings.TrimSpace(name) == "" {
+		return repository.Project{}, &domain.ValidationError{Field: "name", Message: "required"}
+	}
+	if strings.TrimSpace(slug) == "" {
+		return repository.Project{}, &domain.ValidationError{Field: "slug", Message: "required"}
+	}
+	p, err := svc.store.CreateProject(ctx, strings.TrimSpace(name), strings.TrimSpace(slug))
+	if err != nil {
+		if isUniqueConstraint(err) {
+			return repository.Project{}, fmt.Errorf("%w: slug %q", domain.ErrConflict, slug)
+		}
+		return repository.Project{}, err
+	}
+	return p, nil
 }
 
 func (svc *ProjectService) ListProjects(ctx context.Context) ([]repository.Project, error) {
@@ -25,15 +43,36 @@ func (svc *ProjectService) ListProjects(ctx context.Context) ([]repository.Proje
 }
 
 func (svc *ProjectService) GetProject(ctx context.Context, id string) (repository.Project, error) {
-	return svc.store.ProjectByID(ctx, id)
+	p, err := svc.store.ProjectByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return repository.Project{}, fmt.Errorf("%w: project %s", domain.ErrNotFound, id)
+		}
+		return repository.Project{}, err
+	}
+	return p, nil
 }
 
 func (svc *ProjectService) GetProjectBySlug(ctx context.Context, slug string) (repository.Project, error) {
-	return svc.store.ProjectBySlug(ctx, slug)
+	p, err := svc.store.ProjectBySlug(ctx, slug)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return repository.Project{}, fmt.Errorf("%w: project slug %s", domain.ErrNotFound, slug)
+		}
+		return repository.Project{}, err
+	}
+	return p, nil
 }
 
 func (svc *ProjectService) UpdateProject(ctx context.Context, id, name string) (repository.Project, error) {
-	return svc.store.UpdateProject(ctx, id, name)
+	p, err := svc.store.UpdateProject(ctx, id, name)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return repository.Project{}, fmt.Errorf("%w: project %s", domain.ErrNotFound, id)
+		}
+		return repository.Project{}, err
+	}
+	return p, nil
 }
 
 func (svc *ProjectService) DeleteProject(ctx context.Context, id string) error {
@@ -41,7 +80,14 @@ func (svc *ProjectService) DeleteProject(ctx context.Context, id string) error {
 }
 
 func (svc *ProjectService) ApproveProject(ctx context.Context, id string) (repository.Project, error) {
-	return svc.store.ApproveProject(ctx, id)
+	p, err := svc.store.ApproveProject(ctx, id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return repository.Project{}, fmt.Errorf("%w: project %s", domain.ErrNotFound, id)
+		}
+		return repository.Project{}, err
+	}
+	return p, nil
 }
 
 func (svc *ProjectService) EnsureProjectPending(ctx context.Context, name, slug string) (repository.Project, error) {

--- a/internal/service/validation_test.go
+++ b/internal/service/validation_test.go
@@ -1,0 +1,125 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wiebe-xyz/funnelbarn/internal/domain"
+	"github.com/wiebe-xyz/funnelbarn/internal/repository"
+	"github.com/wiebe-xyz/funnelbarn/internal/service"
+)
+
+// ---------------------------------------------------------------------------
+// ProjectService validation tests
+// ---------------------------------------------------------------------------
+
+func TestProjectService_CreateProject_EmptyName(t *testing.T) {
+	ctx := context.Background()
+	svc := service.NewProjectService(newTestStore(t))
+
+	_, err := svc.CreateProject(ctx, "", "my-slug")
+	require.Error(t, err)
+	require.True(t, domain.IsValidation(err), "expected validation error, got: %v", err)
+}
+
+func TestProjectService_CreateProject_EmptySlug(t *testing.T) {
+	ctx := context.Background()
+	svc := service.NewProjectService(newTestStore(t))
+
+	_, err := svc.CreateProject(ctx, "My Project", "")
+	require.Error(t, err)
+	require.True(t, domain.IsValidation(err), "expected validation error, got: %v", err)
+}
+
+func TestProjectService_CreateProject_WhitespaceOnlyName(t *testing.T) {
+	ctx := context.Background()
+	svc := service.NewProjectService(newTestStore(t))
+
+	_, err := svc.CreateProject(ctx, "   ", "my-slug")
+	require.Error(t, err)
+	require.True(t, domain.IsValidation(err), "expected validation error, got: %v", err)
+}
+
+func TestProjectService_CreateProject_DuplicateSlug_ReturnsConflict(t *testing.T) {
+	ctx := context.Background()
+	svc := service.NewProjectService(newTestStore(t))
+
+	_, err := svc.CreateProject(ctx, "Project A", "same-slug")
+	require.NoError(t, err)
+
+	_, err = svc.CreateProject(ctx, "Project B", "same-slug")
+	require.Error(t, err)
+	require.True(t, domain.IsConflict(err), "expected conflict error, got: %v", err)
+}
+
+func TestProjectService_GetProject_NotFound(t *testing.T) {
+	ctx := context.Background()
+	svc := service.NewProjectService(newTestStore(t))
+
+	_, err := svc.GetProject(ctx, "nonexistent-id")
+	require.Error(t, err)
+	require.True(t, domain.IsNotFound(err), "expected not found error, got: %v", err)
+}
+
+// ---------------------------------------------------------------------------
+// FunnelService validation tests
+// ---------------------------------------------------------------------------
+
+func TestFunnelService_CreateFunnel_EmptyName(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	funnelSvc := service.NewFunnelService(store)
+	projectSvc := service.NewProjectService(store)
+
+	p, err := projectSvc.CreateProject(ctx, "My Project", "my-project")
+	require.NoError(t, err)
+
+	_, err = funnelSvc.CreateFunnel(ctx, repository.Funnel{
+		ProjectID: p.ID,
+		Name:      "",
+		Steps:     []repository.FunnelStep{{EventName: "step1"}},
+	})
+	require.Error(t, err)
+	require.True(t, domain.IsValidation(err), "expected validation error, got: %v", err)
+}
+
+func TestFunnelService_CreateFunnel_NoSteps(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	funnelSvc := service.NewFunnelService(store)
+	projectSvc := service.NewProjectService(store)
+
+	p, err := projectSvc.CreateProject(ctx, "My Project", "my-project-2")
+	require.NoError(t, err)
+
+	_, err = funnelSvc.CreateFunnel(ctx, repository.Funnel{
+		ProjectID: p.ID,
+		Name:      "My Funnel",
+		Steps:     []repository.FunnelStep{},
+	})
+	require.Error(t, err)
+	require.True(t, domain.IsValidation(err), "expected validation error, got: %v", err)
+}
+
+// ---------------------------------------------------------------------------
+// APIKeyService validation tests
+// ---------------------------------------------------------------------------
+
+func TestAPIKeyService_CreateAPIKey_EmptyName(t *testing.T) {
+	ctx := context.Background()
+	svc := service.NewAPIKeyService(newTestStore(t))
+
+	_, err := svc.CreateAPIKey(ctx, "", "project-id", "sha256hash", "ingest")
+	require.Error(t, err)
+	require.True(t, domain.IsValidation(err), "expected validation error, got: %v", err)
+}
+
+func TestAPIKeyService_CreateAPIKey_EmptyScope(t *testing.T) {
+	ctx := context.Background()
+	svc := service.NewAPIKeyService(newTestStore(t))
+
+	_, err := svc.CreateAPIKey(ctx, "my-key", "project-id", "sha256hash", "")
+	require.Error(t, err)
+	require.True(t, domain.IsValidation(err), "expected validation error, got: %v", err)
+}


### PR DESCRIPTION
## Summary

### Ports-and-adapters boundary
- **`internal/domain/errors.go`**: `ErrNotFound`, `ErrConflict`, `ErrForbidden`, `ErrValidation` sentinels + `ValidationError` with `Unwrap()`. `IsNotFound`/`IsConflict`/`IsValidation` helpers for error classification without type switches.
- **`internal/service/interfaces.go`**: `Projects`, `Funnels`, `ABTests`, `Events`, `Sessions`, `APIKeys` interfaces. `Server` in `internal/api/` now depends on these interfaces — concrete `*service.XxxService` types are only referenced in `main.go`. Makes all services mockable for testing.

### Validation in service layer
Input validation moved out of HTTP handlers and into services where it belongs:
- `ProjectService.CreateProject`: name and slug required, whitespace trimmed
- `FunnelService.CreateFunnel`: name required, at least 1 step required  
- `ABTestService.CreateABTest`: name and conversion_event required
- `APIKeyService.CreateAPIKey`: name and scope required
- `sql.ErrNoRows` → `domain.ErrNotFound`; SQLite UNIQUE violations → `domain.ErrConflict`

### Handler error mapping
`mapServiceError()` in `server.go` routes domain errors to correct HTTP status codes — no more generic 500s where 404/409/422 are appropriate. Sensitive database details never reach the client.

| Domain error | HTTP status |
|---|---|
| `ErrNotFound` | 404 |
| `ErrConflict` | 409 |
| `ErrValidation` / `ValidationError` | 422 |
| unexpected | 500 (no detail) |

### Rate limiting
`apiLimiter` (300 req/min, burst 60) applied inside `requireSession` — all authenticated endpoints are now protected, not just login/ingest.

### Worker safety
`safeProcessRecord` wraps `ProcessRecord` with `defer/recover` — a panic on a single malformed record no longer brings down the background worker.

## Test plan
- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (domain, service, api packages)
- [ ] POST /api/v1/projects with empty name → 422
- [ ] POST /api/v1/projects with duplicate slug → 409
- [ ] GET /api/v1/projects/:unknown-id → 404