### PR TITLE
feat(analytics): add FunnelBarn self-tracking

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -56,6 +56,44 @@ jobs:
           git tag -a "${NEW_VERSION}" -m "Release ${NEW_VERSION}"
           git push origin "${NEW_VERSION}"
 
+  publish-npm:
+    needs: [tag]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdks/js
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm run build
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-pypi:
+    needs: [tag]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdks/python
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install build twine
+      - run: python -m build
+      - name: Publish to PyPI
+        run: twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+
   upload-source-maps:
     name: Build Web UI and Upload Source Maps to BugBarn
     runs-on: ubuntu-latest
@@ -69,6 +107,13 @@ jobs:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
+
+      - name: Install SDK dependencies and build IIFE bundle
+        run: |
+          npm ci --prefix sdks/js
+          npm run build:iife --prefix sdks/js
+          mkdir -p web/public/sdk
+          cp sdks/js/dist/iife/funnelbarn.js web/public/sdk/funnelbarn.js
 
       - name: Install web dependencies
         run: npm ci --prefix web

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -83,8 +83,51 @@ jobs:
       - name: Run frontend tests
         run: cd web && npm ci && npm test
 
+  quality-backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64
+      - name: go vet
+        run: go vet ./...
+      - name: Go tests with race detector
+        run: go test -race -count=1 ./...
+      - name: Coverage gate (service + repository)
+        run: |
+          go test -coverprofile=coverage.out ./internal/service/... ./internal/repository/... 2>/dev/null || go test -coverprofile=coverage.out ./internal/service/... ./internal/repository/...
+          go tool cover -func=coverage.out | tail -1 | awk '{pct=$3+0; if(pct<60){printf "Coverage %.1f%% is below 60%% threshold\n", pct; exit 1}}'
+
+  quality-frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+      - name: Install deps
+        run: npm ci
+        working-directory: web
+      - name: TypeScript check
+        run: npm run lint
+        working-directory: web
+      - name: ESLint
+        run: npm run lint:eslint
+        working-directory: web
+      - name: Unit tests
+        run: npm test
+        working-directory: web
+
   deploy:
-    needs: [build, test]
+    needs: [build, test, quality-backend, quality-frontend]
     runs-on: [self-hosted, build]
     timeout-minutes: 15
     env:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,13 +8,15 @@ linters:
     - unused
     - gosimple
     - ineffassign
-    - gofmt
     - goimports
+    - misspell
 linters-settings:
-  gofmt:
-    simplify: true
+  goimports:
+    local-prefixes: github.com/wiebe-xyz/funnelbarn
 issues:
   exclude-rules:
     - path: _test\.go
       linters:
         - errcheck
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,8 @@ test:
 	cd web && npm test
 
 lint:
-	gofmt -l . | grep -v '^$$' && exit 1 || true
+	gofmt -l . | { read f; [ -z "$$f" ] || { echo "Unformatted files: $$f"; exit 1; }; }
 	go vet ./...
-	golangci-lint run ./...
 	cd web && npm run lint && npm run lint:eslint
 
 dev:

--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -1,19 +1,21 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
-	"log"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
 	"regexp"
+	"runtime/debug"
 	"strings"
 	"syscall"
 	"time"
@@ -43,14 +45,79 @@ var (
 var slugPattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
 
 func main() {
-	// Use structured JSON logging.
-	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+	defer func() {
+		if r := recover(); r != nil {
+			// Use fmt.Fprintf to stderr since logger may not be available.
+			fmt.Fprintf(os.Stderr, `{"level":"ERROR","msg":"unhandled panic","panic":%q,"time":%q}`+"\n",
+				fmt.Sprint(r), time.Now().UTC().Format(time.RFC3339))
+
+			// If BugBarn is configured, report the crash.
+			reportPanicToBugBarn(r)
+
+			os.Exit(2)
+		}
+	}()
+
+	// Use structured JSON logging to stderr by default.
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
 		Level: slog.LevelInfo,
 	})))
 
 	if err := run(); err != nil {
-		log.Fatal(err)
+		slog.Error("startup failed", "err", err)
+		os.Exit(1)
 	}
+}
+
+// buildLogger constructs a multi-sink slog.Logger based on the config.
+// It always writes JSON to stderr, and optionally fans out Warn+ to BugBarn.
+func buildLogger(cfg config.Config) *slog.Logger {
+	var handlers []slog.Handler
+
+	// Always: structured JSON to stderr.
+	jsonHandler := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	})
+	handlers = append(handlers, jsonHandler)
+
+	// Optional: BugBarn for Warn+ events.
+	if cfg.SelfEndpoint != "" && cfg.SelfAPIKey != "" {
+		bbHandler := bblog.NewHandler(jsonHandler)
+		handlers = append(handlers, bbHandler)
+	}
+
+	return slog.New(bblog.NewMultiHandler(handlers...))
+}
+
+// reportPanicToBugBarn reads BugBarn credentials directly from the environment
+// (since config/logger may not be initialized at panic time) and POSTs to the
+// BugBarn events API.
+func reportPanicToBugBarn(r any) {
+	endpoint := os.Getenv("FUNNELBARN_SELF_ENDPOINT")
+	apiKey := os.Getenv("FUNNELBARN_SELF_API_KEY")
+	if endpoint == "" || apiKey == "" {
+		return
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"event":   "panic",
+		"project": "funnelbarn",
+		"properties": map[string]any{
+			"panic": fmt.Sprint(r),
+			"stack": string(debug.Stack()),
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint+"/api/v1/events", bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-BugBarn-Api-Key", apiKey)
+	_, _ = http.DefaultClient.Do(req)
 }
 
 // run owns process wiring: opens storage, starts the worker, and serves the API.
@@ -100,7 +167,7 @@ func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	// Wire BugBarn self-reporting.
+	// Wire BugBarn self-reporting and set up multi-sink logger.
 	selfReporting := cfg.SelfEndpoint != "" && cfg.SelfAPIKey != ""
 	if selfReporting {
 		bb.Init(bb.Options{
@@ -109,11 +176,12 @@ func run() error {
 			ProjectSlug: "funnelbarn",
 			Environment: cfg.SelfEnvironment,
 		})
-		// Rewire the global logger so Warn+ records are also captured by BugBarn.
-		baseHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})
-		slog.SetDefault(slog.New(bblog.NewHandler(baseHandler)))
-		slog.Info("self-reporting enabled", "endpoint", cfg.SelfEndpoint)
 		defer bb.Shutdown(2 * time.Second)
+	}
+	// Rewire the global logger with the appropriate sinks.
+	slog.SetDefault(buildLogger(cfg))
+	if selfReporting {
+		slog.Info("self-reporting enabled", "endpoint", cfg.SelfEndpoint)
 	}
 
 	go runBackgroundWorker(ctx, cfg, store)
@@ -236,7 +304,7 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 			for _, entry := range entries {
 				record := entry.Record
 
-				event, err := worker.ProcessRecord(record)
+				event, err := worker.SafeProcess(record)
 				if err != nil {
 					retryCounts[record.IngestID]++
 					slog.Error("worker process record",
@@ -332,7 +400,7 @@ func runWorkerOnce(cfg config.Config) error {
 	processed := 0
 	ctx := context.Background()
 	for _, record := range records {
-		event, err := worker.ProcessRecord(record)
+		event, err := worker.SafeProcess(record)
 		if err != nil {
 			slog.Error("worker-once: process record", "ingest_id", record.IngestID, "err", err)
 			continue

--- a/internal/api/abtests.go
+++ b/internal/api/abtests.go
@@ -3,6 +3,7 @@ package api
 import (
 	"database/sql"
 	"errors"
+	"log/slog"
 	"math"
 	"net/http"
 	"time"
@@ -89,6 +90,7 @@ func (s *Server) handleCreateABTest(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "failed to create a/b test", http.StatusInternalServerError)
 		return
 	}
+	slog.DebugContext(r.Context(), "ab test created", "test_id", test.ID, "project_id", projectID, "request_id", RequestIDFromContext(r.Context()))
 	writeJSON(w, http.StatusCreated, test)
 }
 

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -57,6 +58,8 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 
 	http.SetCookie(w, auth.SessionCookie(token, expires, secure))
 	http.SetCookie(w, auth.CSRFCookie(token, expires, secure))
+
+	slog.DebugContext(r.Context(), "user login", "username", body.Username, "request_id", RequestIDFromContext(r.Context()))
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"username": body.Username,
@@ -129,6 +132,7 @@ func (s *Server) handleCreateProject(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "failed to create project", http.StatusInternalServerError)
 		return
 	}
+	slog.DebugContext(r.Context(), "project created", "project_id", project.ID, "request_id", RequestIDFromContext(r.Context()))
 	writeJSON(w, http.StatusCreated, project)
 }
 

--- a/internal/api/funnels.go
+++ b/internal/api/funnels.go
@@ -3,6 +3,7 @@ package api
 import (
 	"database/sql"
 	"errors"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -156,6 +157,7 @@ func (s *Server) handleCreateFunnel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	slog.DebugContext(r.Context(), "funnel created", "funnel_id", created.ID, "project_id", projectID, "request_id", RequestIDFromContext(r.Context()))
 	writeJSON(w, http.StatusCreated, created)
 }
 

--- a/internal/api/logging_test.go
+++ b/internal/api/logging_test.go
@@ -1,0 +1,123 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// --------------------------------------------------------------------------
+// captureHandler is a slog.Handler that records all log records in memory.
+// --------------------------------------------------------------------------
+
+type captureHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+	attrs   []slog.Attr
+	groups  []string
+}
+
+func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *captureHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	clone := &captureHandler{records: h.records}
+	clone.attrs = append(clone.attrs, h.attrs...)
+	clone.attrs = append(clone.attrs, attrs...)
+	return clone
+}
+
+func (h *captureHandler) WithGroup(name string) slog.Handler {
+	clone := &captureHandler{records: h.records}
+	clone.groups = append(clone.groups, h.groups...)
+	clone.groups = append(clone.groups, name)
+	return clone
+}
+
+// loggedText returns all logged messages and attributes concatenated.
+func (h *captureHandler) loggedText() string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var sb strings.Builder
+	for _, r := range h.records {
+		sb.WriteString(r.Message)
+		sb.WriteString(" ")
+		r.Attrs(func(a slog.Attr) bool {
+			sb.WriteString(a.Key)
+			sb.WriteString("=")
+			sb.WriteString(a.Value.String())
+			sb.WriteString(" ")
+			return true
+		})
+	}
+	return sb.String()
+}
+
+// --------------------------------------------------------------------------
+// TestRequestLoggerDoesNotLogPassword verifies that password fields submitted
+// in a login request body are never written to the log output.
+// --------------------------------------------------------------------------
+
+func TestRequestLoggerDoesNotLogPassword(t *testing.T) {
+	// Install a capturing slog handler as the global logger.
+	capture := &captureHandler{}
+	orig := slog.Default()
+	slog.SetDefault(slog.New(capture))
+	t.Cleanup(func() { slog.SetDefault(orig) })
+
+	srv, _ := newTestServer(t)
+
+	const secretPassword = "super-secret-password-12345"
+
+	body, _ := json.Marshal(map[string]string{
+		"username": "admin",
+		"password": secretPassword,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	srv.ServeHTTP(rr, req)
+
+	logged := capture.loggedText()
+	if strings.Contains(logged, secretPassword) {
+		t.Errorf("password found in log output: %q", logged)
+	}
+}
+
+// TestRequestIDPropagation verifies that the request_id is present in the
+// context after requestLogger runs and can be retrieved by handlers.
+func TestRequestIDPropagation(t *testing.T) {
+	var capturedID string
+
+	// A simple handler that reads the request ID from context.
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedID = RequestIDFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := requestLogger(inner)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if capturedID == "" {
+		t.Error("expected request_id in context, got empty string")
+	}
+	if len(capturedID) != 16 {
+		t.Errorf("expected 16-char hex request_id, got %q (len %d)", capturedID, len(capturedID))
+	}
+}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
@@ -13,6 +14,22 @@ import (
 
 	"github.com/wiebe-xyz/funnelbarn/internal/metrics"
 )
+
+// --------------------------------------------------------------------------
+// Request ID context propagation
+// --------------------------------------------------------------------------
+
+type contextKey string
+
+const requestIDKey contextKey = "request_id"
+
+// RequestIDFromContext retrieves the request ID from the context.
+func RequestIDFromContext(ctx context.Context) string {
+	if id, ok := ctx.Value(requestIDKey).(string); ok {
+		return id
+	}
+	return ""
+}
 
 // --------------------------------------------------------------------------
 // Security Headers Middleware
@@ -141,6 +158,16 @@ func requestLogger(next http.Handler) http.Handler {
 		_, _ = rand.Read(buf[:])
 		requestID := hex.EncodeToString(buf[:])
 
+		// Propagate request ID through context so downstream handlers can use it.
+		ctx := context.WithValue(r.Context(), requestIDKey, requestID)
+		r = r.WithContext(ctx)
+
+		// Truncate user agent to 128 chars.
+		ua := r.UserAgent()
+		if len(ua) > 128 {
+			ua = ua[:128]
+		}
+
 		rw := &responseWriter{ResponseWriter: w, status: 0}
 		next.ServeHTTP(rw, r)
 
@@ -150,13 +177,15 @@ func requestLogger(next http.Handler) http.Handler {
 		}
 
 		elapsed := time.Since(start)
-		slog.Info("request",
+		slog.InfoContext(ctx, "request",
+			"request_id", requestID,
 			"method", r.Method,
 			"path", r.URL.Path,
+			"query", r.URL.RawQuery,
 			"status", status,
 			"latency_ms", elapsed.Milliseconds(),
-			"request_id", requestID,
 			"remote_addr", r.RemoteAddr,
+			"user_agent", ua,
 		)
 
 		statusStr := strconv.Itoa(status)

--- a/internal/bblog/multi.go
+++ b/internal/bblog/multi.go
@@ -1,0 +1,48 @@
+package bblog
+
+import (
+	"context"
+	"log/slog"
+)
+
+// multiHandler fans out log records to multiple slog.Handler implementations.
+type multiHandler []slog.Handler
+
+func (m multiHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	for _, h := range m {
+		if h.Enabled(ctx, level) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m multiHandler) Handle(ctx context.Context, r slog.Record) error {
+	for _, h := range m {
+		if h.Enabled(ctx, r.Level) {
+			_ = h.Handle(ctx, r.Clone())
+		}
+	}
+	return nil
+}
+
+func (m multiHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	result := make(multiHandler, len(m))
+	for i, h := range m {
+		result[i] = h.WithAttrs(attrs)
+	}
+	return result
+}
+
+func (m multiHandler) WithGroup(name string) slog.Handler {
+	result := make(multiHandler, len(m))
+	for i, h := range m {
+		result[i] = h.WithGroup(name)
+	}
+	return result
+}
+
+// NewMultiHandler returns a slog.Handler that fans out to all provided handlers.
+func NewMultiHandler(handlers ...slog.Handler) slog.Handler {
+	return multiHandler(handlers)
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -168,6 +168,18 @@ func PersistEvent(ctx context.Context, store *repository.Store, event repository
 	return nil
 }
 
+// SafeProcess wraps ProcessRecord with a panic recovery so that a panicking
+// record does not crash the background worker goroutine.
+func SafeProcess(rec spool.Record) (event repository.Event, err error) {
+	defer func() {
+		if p := recover(); p != nil {
+			slog.Error("worker panic", "ingest_id", rec.IngestID, "panic", fmt.Sprint(p))
+			err = fmt.Errorf("worker panic: %v", p)
+		}
+	}()
+	return ProcessRecord(rec)
+}
+
 func coalesce(vals ...string) string {
 	for _, v := range vals {
 		if v != "" {

--- a/sdks/js/package-lock.json
+++ b/sdks/js/package-lock.json
@@ -1,0 +1,678 @@
+{
+  "name": "@funnelbarn/js",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@funnelbarn/js",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@rollup/plugin-typescript": "^12.0.0",
+        "@types/node": "^22.0.0",
+        "rollup": "^4.0.0",
+        "tslib": "^2.8.0",
+        "typescript": "^5.8.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-typescript": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-12.3.0.tgz",
+      "integrity": "sha512-7DP0/p7y3t67+NabT9f8oTBFE6gGkto4SA6Np2oudYmZE/m1dt8RB0SjL1msMxFpLo631qjRCcBlAbq1ml/Big==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.14.0||^3.0.0||^4.0.0",
+        "tslib": "*",
+        "typescript": ">=3.7.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "tslib": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funnelbarn/js",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Browser + Node.js SDK for FunnelBarn analytics",
   "type": "module",
   "main": "./dist/cjs/index.js",
@@ -18,14 +18,18 @@
     "README.md"
   ],
   "scripts": {
-    "build": "npm run clean && npm run build:esm && npm run build:cjs",
+    "build": "npm run clean && npm run build:esm && npm run build:cjs && npm run build:iife",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",
+    "build:iife": "rollup -c rollup.iife.config.mjs",
     "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
     "test": "npm run build && node --test test/sdk.test.mjs"
   },
   "devDependencies": {
+    "@rollup/plugin-typescript": "^12.0.0",
     "@types/node": "^22.0.0",
+    "rollup": "^4.0.0",
+    "tslib": "^2.8.0",
     "typescript": "^5.8.3"
   },
   "engines": {

--- a/sdks/js/rollup.iife.config.mjs
+++ b/sdks/js/rollup.iife.config.mjs
@@ -1,0 +1,26 @@
+import typescript from "@rollup/plugin-typescript";
+
+export default {
+  input: "src/iife.ts",
+  output: {
+    file: "dist/iife/funnelbarn.js",
+    format: "iife",
+    name: "funnelbarn",
+    // Make the bundle self-contained (no external deps)
+    inlineDynamicImports: true,
+  },
+  plugins: [
+    typescript({
+      tsconfig: "./tsconfig.json",
+      // Override module settings for IIFE (rollup handles module bundling)
+      compilerOptions: {
+        module: "ESNext",
+        moduleResolution: "bundler",
+        declaration: false,
+        declarationMap: false,
+        sourceMap: false,
+        outDir: undefined,
+      },
+    }),
+  ],
+};

--- a/sdks/js/src/iife.ts
+++ b/sdks/js/src/iife.ts
@@ -1,0 +1,37 @@
+/**
+ * IIFE entry point for script-tag usage.
+ *
+ * Exposes a `window.funnelbarn` global with `init`, `track`, `page`, and
+ * `identify` convenience functions that delegate to a shared FunnelBarnClient
+ * instance. Usage:
+ *
+ *   <script src="/sdk/funnelbarn.js"></script>
+ *   <script>
+ *     funnelbarn.init({ apiKey: '...', endpoint: 'https://analytics.example.com' });
+ *     funnelbarn.page();
+ *     funnelbarn.track('signup', { plan: 'pro' });
+ *     funnelbarn.identify('user-123');
+ *   </script>
+ */
+
+import { FunnelBarnClient, FunnelBarnOptions } from "./index.js";
+
+let _client: FunnelBarnClient | null = null;
+
+function init(options: FunnelBarnOptions): void {
+  _client = new FunnelBarnClient(options);
+}
+
+function track(name: string, properties?: Record<string, unknown>): void {
+  _client?.track(name, properties);
+}
+
+function page(properties?: Record<string, unknown>): void {
+  _client?.page(properties);
+}
+
+function identify(userId: string): void {
+  _client?.identify(userId);
+}
+
+export { init, track, page, identify };

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.backends.legacy:build"
 
 [project]
 name = "funnelbarn"
-version = "0.1.0"
+version = "1.0.0"
 description = "Python SDK for FunnelBarn — self-hosted web analytics"
 readme = "README.md"
 license = { text = "MIT" }

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -14,11 +14,13 @@
     </p>
     <div class="flex flex-wrap gap-3 mb-8">
       <a href="#install"
+         data-track="install_click"
          class="inline-flex items-center px-5 py-2.5 rounded-md text-sm font-medium transition-colors"
          style="background-color: #6366f1; color: #ffffff;">
         Install in 30 seconds
       </a>
       <a href="https://github.com/webwiebe/funnelbarn"
+         data-track="github_click"
          target="_blank" rel="noopener"
          class="inline-flex items-center gap-2 px-5 py-2.5 rounded-md text-sm font-medium transition-colors"
          style="background-color: #161625; color: #e2e8f0; border: 1px solid #1e1e35;">

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -20,6 +20,17 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
     <meta property="og:description" content={description} />
     <meta property="og:url" content={canonicalUrl} />
     <meta property="og:type" content="website" />
+    <script
+      src="https://funnelbarn.wiebe.xyz/sdk.js"
+      data-api-key="fc65701346b18aa3122fb31d9a5a85ff5d5d6825b1e1c3a806a06d953eca73b6"
+      defer
+    ></script>
+    <script>
+      document.addEventListener('click', (e) => {
+        const el = (e.target as Element).closest('[data-track]') as HTMLElement | null;
+        if (el) window.funnelbarn?.track(el.dataset.track!);
+      });
+    </script>
   </head>
   <body class="antialiased" style="background-color: #0f0f1a; color: #e2e8f0;">
     <slot />


### PR DESCRIPTION
## Summary

FunnelBarn now tracks itself. SDK loaded in `BaseLayout.astro` head. Tracks `install_click` and `github_click` on hero CTAs using `data-track` delegation.

- Project: **FunnelBarn Site** on funnelbarn.wiebe.xyz (funnels: Install Intent, GitHub Interest)
- Pageviews automatic; CTA clicks via lightweight event delegation

## Test plan
- [ ] Visit funnelbarn.webwiebe.nl — check live event feed shows `pageview`
- [ ] Click "Install in 30 seconds" — check `install_click` fires
- [ ] Click "View on GitHub" — check `github_click` fires