### PR TITLE
test(frontend): API contract tests, project context, FirstRunWizard (53 tests total)

### DIFF
--- a/web/src/components/wizards/FirstRunWizard.test.tsx
+++ b/web/src/components/wizards/FirstRunWizard.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import FirstRunWizard from './FirstRunWizard'
+import { ApiError } from '../../lib/api'
+
+vi.mock('../../lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/api')>()
+  return {
+    ...actual,
+    api: {
+      createProject: vi.fn(),
+      createApiKey: vi.fn(),
+    },
+  }
+})
+
+// Import after mock so we get the mocked version
+import { api } from '../../lib/api'
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+function renderWizard(onComplete = vi.fn()) {
+  return render(<FirstRunWizard onComplete={onComplete} />)
+}
+
+describe('FirstRunWizard', () => {
+  it('renders the first step initially', () => {
+    renderWizard()
+    expect(screen.getByText('Welcome to FunnelBarn')).toBeInTheDocument()
+  })
+
+  it('shows project name input after advancing past step 1', async () => {
+    renderWizard()
+    fireEvent.click(screen.getByText("Let's go →"))
+    expect(screen.getByPlaceholderText('e.g. My SaaS App')).toBeInTheDocument()
+  })
+
+  it('calls onComplete when wizard finishes', async () => {
+    const onComplete = vi.fn()
+    vi.mocked(api.createProject).mockResolvedValue({
+      id: 'p1',
+      name: 'My App',
+      slug: 'my-app',
+      status: 'active',
+    })
+    vi.mocked(api.createApiKey).mockResolvedValue({
+      api_key: { id: 'k1', name: 'My App ingest', scope: 'ingest', created_at: '' },
+      key: 'fb_testkey',
+    })
+
+    renderWizard(onComplete)
+
+    // Step 1 → step 2
+    fireEvent.click(screen.getByText("Let's go →"))
+
+    // Fill in project name
+    const nameInput = screen.getByPlaceholderText('e.g. My SaaS App')
+    fireEvent.change(nameInput, { target: { value: 'My App' } })
+
+    // Submit step 2
+    await act(async () => {
+      fireEvent.click(screen.getByText('Create project →'))
+    })
+
+    // Now on step 3 — advance to step 4
+    await waitFor(() => expect(screen.getByText('Done, continue →')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Done, continue →'))
+
+    // Step 4 — click Go to dashboard
+    await waitFor(() => expect(screen.getByText('Go to dashboard →')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Go to dashboard →'))
+
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows error message when API call fails with 422', async () => {
+    vi.mocked(api.createProject).mockRejectedValue(
+      new ApiError(422, 'name: required')
+    )
+
+    renderWizard()
+
+    // Advance to step 2
+    fireEvent.click(screen.getByText("Let's go →"))
+
+    // Leave name blank and submit — the component checks for empty name client-side
+    // Provide a non-empty name so the API call is actually made
+    const nameInput = screen.getByPlaceholderText('e.g. My SaaS App')
+    fireEvent.change(nameInput, { target: { value: 'Bad Project' } })
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Create project →'))
+    })
+
+    await waitFor(() =>
+      expect(screen.getByText(/ApiError: name: required/i)).toBeInTheDocument()
+    )
+  })
+
+  it('shows client-side validation error when project name is empty', async () => {
+    renderWizard()
+
+    // Advance to step 2
+    fireEvent.click(screen.getByText("Let's go →"))
+
+    // Click Create without filling in name
+    fireEvent.click(screen.getByText('Create project →'))
+
+    expect(screen.getByText('Project name is required')).toBeInTheDocument()
+  })
+})

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -117,3 +117,102 @@ describe('api — JSON parsing', () => {
     expect(result).toBeUndefined()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Response shape contract tests
+// ---------------------------------------------------------------------------
+
+describe('api.listProjects', () => {
+  it('returns the projects array from { projects: [...] }', async () => {
+    mockFetch(200, { projects: [{ id: '1', name: 'Test', slug: 'test', status: 'active' }] })
+    const result = await api.listProjects()
+    expect(result.projects).toHaveLength(1)
+    expect(result.projects[0].name).toBe('Test')
+  })
+
+  it('throws ApiError when response is not ok', async () => {
+    mockFetch(401, { error: 'unauthorized' })
+    await expect(api.listProjects()).rejects.toBeInstanceOf(ApiError)
+  })
+
+  it('throws ApiError with status 403 on forbidden', async () => {
+    mockFetch(403, { error: 'forbidden' })
+    await expect(api.listProjects()).rejects.toMatchObject({ status: 403 })
+  })
+})
+
+describe('api.createProject', () => {
+  it('sends name and domain in POST body', async () => {
+    mockFetch(200, { id: '1', name: 'New', slug: 'new', status: 'active' })
+    await api.createProject('New', 'new.example.com')
+    const [, options] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(options.body as string)
+    expect(body.name).toBe('New')
+    expect(body.domain).toBe('new.example.com')
+  })
+
+  it('returns created project on success', async () => {
+    const project = { id: '1', name: 'New', slug: 'new', status: 'active' }
+    mockFetch(200, project)
+    const result = await api.createProject('New', 'new.example.com')
+    expect(result).toEqual(project)
+  })
+
+  it('throws ApiError with status 409 on conflict', async () => {
+    mockFetch(409, { error: 'already exists' })
+    await expect(api.createProject('X', 'x.com')).rejects.toMatchObject({ status: 409 })
+  })
+
+  it('throws ApiError with status 422 on validation error', async () => {
+    mockFetch(422, { error: 'name: required' })
+    await expect(api.createProject('', '')).rejects.toMatchObject({ status: 422 })
+  })
+})
+
+describe('api.login', () => {
+  it('returns user object on success', async () => {
+    mockFetch(200, { id: 'u1', username: 'alice' })
+    const user = await api.login({ username: 'alice', password: 'secret' })
+    expect(user.username).toBe('alice')
+  })
+
+  it('throws ApiError with status 401 on bad credentials', async () => {
+    mockFetch(401, { error: 'invalid credentials' })
+    await expect(api.login({ username: 'x', password: 'y' })).rejects.toMatchObject({ status: 401 })
+  })
+})
+
+describe('api.me', () => {
+  it('returns current user on success', async () => {
+    mockFetch(200, { id: 'u1', username: 'bob' })
+    const result = await api.me()
+    expect(result).toMatchObject({ id: 'u1', username: 'bob' })
+  })
+})
+
+describe('api.listFunnels', () => {
+  it('returns funnels array from { funnels: [...] }', async () => {
+    const funnel = { id: 'f1', name: 'Signup', steps: [] }
+    mockFetch(200, { funnels: [funnel] })
+    const result = await api.listFunnels('proj1')
+    expect(result.funnels).toHaveLength(1)
+    expect(result.funnels[0].name).toBe('Signup')
+  })
+
+  it('throws ApiError on non-ok response', async () => {
+    mockFetch(404, { error: 'project not found' })
+    await expect(api.listFunnels('missing')).rejects.toBeInstanceOf(ApiError)
+  })
+})
+
+describe('api.createFunnel', () => {
+  it('sends name and steps in POST body', async () => {
+    const steps = [{ event_name: 'page_view' }]
+    mockFetch(200, { id: 'f1', name: 'Checkout', steps: [] })
+    await api.createFunnel('proj1', 'Checkout', steps)
+    const [, options] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(options.body as string)
+    expect(body.name).toBe('Checkout')
+    expect(body.steps).toEqual(steps)
+  })
+})

--- a/web/src/lib/projects.test.tsx
+++ b/web/src/lib/projects.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
-import { ProjectProvider, useEffectiveProjectId } from './projects'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import { ProjectProvider, useEffectiveProjectId, useProjects } from './projects'
 import type { Project } from './api'
 
 // ---------------------------------------------------------------------------
@@ -93,5 +93,48 @@ describe('useEffectiveProjectId', () => {
   it('returns undefined when the project list is empty', async () => {
     renderWithProjects([])
     await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('undefined'))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// setDefaultProjectId tests
+// ---------------------------------------------------------------------------
+
+function DefaultIdConsumer({ onReady }: { onReady?: (fn: (id: string) => void) => void }) {
+  const { defaultProjectId, setDefaultProjectId } = useProjects()
+  if (onReady) onReady(setDefaultProjectId)
+  return <div data-testid="default-id">{defaultProjectId ?? 'null'}</div>
+}
+
+describe('setDefaultProjectId', () => {
+  beforeEach(() => {
+    delete store['funnelbarn_default_project']
+    vi.clearAllMocks()
+  })
+
+  it('persists to localStorage', async () => {
+    mockListProjects.mockResolvedValue({ projects: [projectA, projectB] })
+    let setter: ((id: string) => void) | undefined
+    render(
+      <ProjectProvider>
+        <DefaultIdConsumer onReady={(fn) => { setter = fn }} />
+      </ProjectProvider>
+    )
+    await waitFor(() => expect(screen.getByTestId('default-id')).toBeInTheDocument())
+    act(() => { setter!('proj-b') })
+    expect(store['funnelbarn_default_project']).toBe('proj-b')
+  })
+
+  it('updates defaultProjectId in context', async () => {
+    mockListProjects.mockResolvedValue({ projects: [projectA, projectB] })
+    let setter: ((id: string) => void) | undefined
+    render(
+      <ProjectProvider>
+        <DefaultIdConsumer onReady={(fn) => { setter = fn }} />
+      </ProjectProvider>
+    )
+    await waitFor(() => expect(screen.getByTestId('default-id')).toBeInTheDocument())
+    act(() => { setter!('proj-b') })
+    await waitFor(() => expect(screen.getByTestId('default-id').textContent).toBe('proj-b'))
   })
 })


### PR DESCRIPTION
## Summary

Adds 20 new frontend tests across 3 files. All 53 frontend tests pass.

### `src/lib/api.test.ts` — API contract tests
Mocks `fetch` to assert the API client correctly handles backend response shapes and error codes:
- `listProjects` extracts the `projects` array from `{ projects: [...] }`
- `createProject` sends correct body fields; throws `ApiError(409)` on conflict, `ApiError(422)` on validation error
- `login` returns user object; throws `ApiError(401)` on bad credentials
- `me`, `listFunnels`, `createFunnel` — response shape and error contracts

### `src/lib/projects.test.tsx` — context persistence
- `setDefaultProjectId` persists the selected project ID to `localStorage`
- `setDefaultProjectId` updates `defaultProjectId` in context so consumers re-render

### `src/components/wizards/FirstRunWizard.test.tsx` (new)
- Renders first step with welcome heading
- Shows project name input after clicking through step 1
- Drives complete wizard flow: step 1 → 2 → 3 → 4 → `onComplete` called
- Shows API error message when `createProject` rejects with `ApiError(422)`
- Shows client-side "Project name is required" without API call when name is empty