### PR TITLE
fix: remove broken project dropdown; add domain field to settings

### DIFF
--- a/web/src/components/shell/Shell.tsx
+++ b/web/src/components/shell/Shell.tsx
@@ -1,8 +1,7 @@
 import { ReactNode, useState } from 'react'
 import { Link, useNavigate, useLocation } from 'react-router-dom'
-import { BarChart2, Layers, Radio, Settings, ChevronDown, LogOut, User, FlaskConical, MoreHorizontal, Star } from 'lucide-react'
+import { BarChart2, Layers, Radio, Settings, LogOut, User, FlaskConical, MoreHorizontal } from 'lucide-react'
 import { useAuth } from '../../lib/auth'
-import { useProjects } from '../../lib/projects'
 
 const C = {
   bg: '#0f1117',
@@ -16,19 +15,14 @@ const C = {
 interface ShellProps {
   children: ReactNode
   projectId?: string
-  onProjectChange?: (id: string) => void
 }
 
-export default function Shell({ children, projectId, onProjectChange }: ShellProps) {
+export default function Shell({ children, projectId }: ShellProps) {
   const { user, logout } = useAuth()
-  const { projects, defaultProjectId, setDefaultProjectId } = useProjects()
   const navigate = useNavigate()
   const location = useLocation()
-  const [dropdownOpen, setDropdownOpen] = useState(false)
   const [userMenuOpen, setUserMenuOpen] = useState(false)
   const [moreSheetOpen, setMoreSheetOpen] = useState(false)
-  const effectiveId = projectId ?? (defaultProjectId && projects.some(p => p.id === defaultProjectId) ? defaultProjectId : projects[0]?.id)
-  const currentProject = projects.find((p) => p.id === effectiveId) ?? projects[0]
 
   const handleLogout = async () => {
     await logout()
@@ -81,187 +75,6 @@ export default function Shell({ children, projectId, onProjectChange }: ShellPro
           </span>
         </Link>
 
-        {/* Desktop: project switcher */}
-        <div style={{ position: 'relative', flexShrink: 0 }} className="desktop-project-switcher">
-          <button
-            onClick={() => setDropdownOpen((v) => !v)}
-            style={{
-              background: C.bg,
-              border: `1px solid ${C.border}`,
-              borderRadius: 6,
-              color: C.text,
-              padding: '0.35rem 0.6rem',
-              cursor: 'pointer',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 6,
-              fontSize: 13,
-              minHeight: 'unset',
-            }}
-          >
-            <span className="project-name">{currentProject ? currentProject.name : 'Project'}</span>
-            <ChevronDown size={14} color={C.muted} />
-          </button>
-          {dropdownOpen && (
-            <div style={{
-              position: 'absolute',
-              top: '110%',
-              left: 0,
-              background: C.surface,
-              border: `1px solid ${C.border}`,
-              borderRadius: 8,
-              minWidth: 200,
-              boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
-              zIndex: 300,
-            }}>
-              {projects.map((p) => {
-                const isDefault = p.id === defaultProjectId
-                return (
-                  <div
-                    key={p.id}
-                    style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      background: p.id === currentProject?.id ? '#2a2d3a' : 'transparent',
-                    }}
-                  >
-                    <button
-                      onClick={() => {
-                        setDropdownOpen(false)
-                        onProjectChange?.(p.id)
-                        navigate(`/dashboard/${p.id}`)
-                      }}
-                      style={{
-                        flex: 1,
-                        textAlign: 'left',
-                        background: 'transparent',
-                        border: 'none',
-                        color: C.text,
-                        padding: '0.6rem 1rem',
-                        cursor: 'pointer',
-                        fontSize: 14,
-                        minHeight: 'unset',
-                      }}
-                    >
-                      {p.name}
-                    </button>
-                    {projects.length > 1 && (
-                      <button
-                        onClick={(e) => { e.stopPropagation(); setDefaultProjectId(p.id) }}
-                        title={isDefault ? 'Default project' : 'Set as default'}
-                        style={{
-                          background: 'transparent',
-                          border: 'none',
-                          cursor: 'pointer',
-                          padding: '0.6rem 0.75rem 0.6rem 0',
-                          color: isDefault ? C.amber : C.muted,
-                          display: 'flex',
-                          alignItems: 'center',
-                          minHeight: 'unset',
-                          flexShrink: 0,
-                        }}
-                      >
-                        <Star size={13} fill={isDefault ? C.amber : 'none'} />
-                      </button>
-                    )}
-                  </div>
-                )
-              })}
-            </div>
-          )}
-        </div>
-
-        {/* Mobile: compact project switcher (right side of top bar) */}
-        <div className="mobile-project-switcher" style={{ marginLeft: 'auto', position: 'relative' }}>
-          <button
-            onClick={() => setDropdownOpen((v) => !v)}
-            style={{
-              background: 'transparent',
-              border: `1px solid ${C.border}`,
-              borderRadius: 6,
-              color: C.muted,
-              padding: '0.3rem 0.55rem',
-              cursor: 'pointer',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 5,
-              fontSize: 12,
-              minHeight: 'unset',
-            }}
-          >
-            <span style={{ color: currentProject ? C.text : C.muted, maxWidth: 110, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-              {currentProject?.name ?? 'Select project'}
-            </span>
-            <ChevronDown size={12} color={C.muted} />
-          </button>
-          {dropdownOpen && (
-            <div style={{
-              position: 'absolute',
-              top: '110%',
-              right: 0,
-              background: C.surface,
-              border: `1px solid ${C.border}`,
-              borderRadius: 8,
-              minWidth: 200,
-              boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
-              zIndex: 300,
-            }}>
-              {projects.map((p) => {
-                const isDefault = p.id === defaultProjectId
-                return (
-                  <div
-                    key={p.id}
-                    style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      background: p.id === currentProject?.id ? '#2a2d3a' : 'transparent',
-                    }}
-                  >
-                    <button
-                      onClick={() => {
-                        setDropdownOpen(false)
-                        onProjectChange?.(p.id)
-                        navigate(`/dashboard/${p.id}`)
-                      }}
-                      style={{
-                        flex: 1,
-                        textAlign: 'left',
-                        background: 'transparent',
-                        border: 'none',
-                        color: C.text,
-                        padding: '0.6rem 1rem',
-                        cursor: 'pointer',
-                        fontSize: 14,
-                        minHeight: 'unset',
-                      }}
-                    >
-                      {p.name}
-                    </button>
-                    {projects.length > 1 && (
-                      <button
-                        onClick={(e) => { e.stopPropagation(); setDefaultProjectId(p.id) }}
-                        title={isDefault ? 'Default project' : 'Set as default'}
-                        style={{
-                          background: 'transparent',
-                          border: 'none',
-                          cursor: 'pointer',
-                          padding: '0.6rem 0.75rem 0.6rem 0',
-                          color: isDefault ? C.amber : C.muted,
-                          display: 'flex',
-                          alignItems: 'center',
-                          minHeight: 'unset',
-                          flexShrink: 0,
-                        }}
-                      >
-                        <Star size={13} fill={isDefault ? C.amber : 'none'} />
-                      </button>
-                    )}
-                  </div>
-                )
-              })}
-            </div>
-          )}
-        </div>
 
         {/* Desktop: Nav links */}
         <div className="desktop-nav" style={{ display: 'flex', gap: 4, flex: 1 }}>

--- a/web/src/components/wizards/FirstRunWizard.test.tsx
+++ b/web/src/components/wizards/FirstRunWizard.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import FirstRunWizard from './FirstRunWizard'
+import { ApiError } from '../../lib/api'
+
+vi.mock('../../lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/api')>()
+  return {
+    ...actual,
+    api: {
+      createProject: vi.fn(),
+      createApiKey: vi.fn(),
+    },
+  }
+})
+
+// Import after mock so we get the mocked version
+import { api } from '../../lib/api'
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+function renderWizard(onComplete = vi.fn()) {
+  return render(<FirstRunWizard onComplete={onComplete} />)
+}
+
+describe('FirstRunWizard', () => {
+  it('renders the first step initially', () => {
+    renderWizard()
+    expect(screen.getByText('Welcome to FunnelBarn')).toBeInTheDocument()
+  })
+
+  it('shows project name input after advancing past step 1', async () => {
+    renderWizard()
+    fireEvent.click(screen.getByText("Let's go →"))
+    expect(screen.getByPlaceholderText('e.g. My SaaS App')).toBeInTheDocument()
+  })
+
+  it('calls onComplete when wizard finishes', async () => {
+    const onComplete = vi.fn()
+    vi.mocked(api.createProject).mockResolvedValue({
+      id: 'p1',
+      name: 'My App',
+      slug: 'my-app',
+      status: 'active',
+    })
+    vi.mocked(api.createApiKey).mockResolvedValue({
+      api_key: { id: 'k1', name: 'My App ingest', scope: 'ingest', created_at: '' },
+      key: 'fb_testkey',
+    })
+
+    renderWizard(onComplete)
+
+    // Step 1 → step 2
+    fireEvent.click(screen.getByText("Let's go →"))
+
+    // Fill in project name
+    const nameInput = screen.getByPlaceholderText('e.g. My SaaS App')
+    fireEvent.change(nameInput, { target: { value: 'My App' } })
+
+    // Submit step 2
+    await act(async () => {
+      fireEvent.click(screen.getByText('Create project →'))
+    })
+
+    // Now on step 3 — advance to step 4
+    await waitFor(() => expect(screen.getByText('Done, continue →')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Done, continue →'))
+
+    // Step 4 — click Go to dashboard
+    await waitFor(() => expect(screen.getByText('Go to dashboard →')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Go to dashboard →'))
+
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows error message when API call fails with 422', async () => {
+    vi.mocked(api.createProject).mockRejectedValue(
+      new ApiError(422, 'name: required')
+    )
+
+    renderWizard()
+
+    // Advance to step 2
+    fireEvent.click(screen.getByText("Let's go →"))
+
+    // Leave name blank and submit — the component checks for empty name client-side
+    // Provide a non-empty name so the API call is actually made
+    const nameInput = screen.getByPlaceholderText('e.g. My SaaS App')
+    fireEvent.change(nameInput, { target: { value: 'Bad Project' } })
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Create project →'))
+    })
+
+    await waitFor(() =>
+      expect(screen.getByText(/ApiError: name: required/i)).toBeInTheDocument()
+    )
+  })
+
+  it('shows client-side validation error when project name is empty', async () => {
+    renderWizard()
+
+    // Advance to step 2
+    fireEvent.click(screen.getByText("Let's go →"))
+
+    // Click Create without filling in name
+    fireEvent.click(screen.getByText('Create project →'))
+
+    expect(screen.getByText('Project name is required')).toBeInTheDocument()
+  })
+})

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -117,3 +117,102 @@ describe('api — JSON parsing', () => {
     expect(result).toBeUndefined()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Response shape contract tests
+// ---------------------------------------------------------------------------
+
+describe('api.listProjects', () => {
+  it('returns the projects array from { projects: [...] }', async () => {
+    mockFetch(200, { projects: [{ id: '1', name: 'Test', slug: 'test', status: 'active' }] })
+    const result = await api.listProjects()
+    expect(result.projects).toHaveLength(1)
+    expect(result.projects[0].name).toBe('Test')
+  })
+
+  it('throws ApiError when response is not ok', async () => {
+    mockFetch(401, { error: 'unauthorized' })
+    await expect(api.listProjects()).rejects.toBeInstanceOf(ApiError)
+  })
+
+  it('throws ApiError with status 403 on forbidden', async () => {
+    mockFetch(403, { error: 'forbidden' })
+    await expect(api.listProjects()).rejects.toMatchObject({ status: 403 })
+  })
+})
+
+describe('api.createProject', () => {
+  it('sends name and domain in POST body', async () => {
+    mockFetch(200, { id: '1', name: 'New', slug: 'new', status: 'active' })
+    await api.createProject('New', 'new.example.com')
+    const [, options] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(options.body as string)
+    expect(body.name).toBe('New')
+    expect(body.domain).toBe('new.example.com')
+  })
+
+  it('returns created project on success', async () => {
+    const project = { id: '1', name: 'New', slug: 'new', status: 'active' }
+    mockFetch(200, project)
+    const result = await api.createProject('New', 'new.example.com')
+    expect(result).toEqual(project)
+  })
+
+  it('throws ApiError with status 409 on conflict', async () => {
+    mockFetch(409, { error: 'already exists' })
+    await expect(api.createProject('X', 'x.com')).rejects.toMatchObject({ status: 409 })
+  })
+
+  it('throws ApiError with status 422 on validation error', async () => {
+    mockFetch(422, { error: 'name: required' })
+    await expect(api.createProject('', '')).rejects.toMatchObject({ status: 422 })
+  })
+})
+
+describe('api.login', () => {
+  it('returns user object on success', async () => {
+    mockFetch(200, { id: 'u1', username: 'alice' })
+    const user = await api.login({ username: 'alice', password: 'secret' })
+    expect(user.username).toBe('alice')
+  })
+
+  it('throws ApiError with status 401 on bad credentials', async () => {
+    mockFetch(401, { error: 'invalid credentials' })
+    await expect(api.login({ username: 'x', password: 'y' })).rejects.toMatchObject({ status: 401 })
+  })
+})
+
+describe('api.me', () => {
+  it('returns current user on success', async () => {
+    mockFetch(200, { id: 'u1', username: 'bob' })
+    const result = await api.me()
+    expect(result).toMatchObject({ id: 'u1', username: 'bob' })
+  })
+})
+
+describe('api.listFunnels', () => {
+  it('returns funnels array from { funnels: [...] }', async () => {
+    const funnel = { id: 'f1', name: 'Signup', steps: [] }
+    mockFetch(200, { funnels: [funnel] })
+    const result = await api.listFunnels('proj1')
+    expect(result.funnels).toHaveLength(1)
+    expect(result.funnels[0].name).toBe('Signup')
+  })
+
+  it('throws ApiError on non-ok response', async () => {
+    mockFetch(404, { error: 'project not found' })
+    await expect(api.listFunnels('missing')).rejects.toBeInstanceOf(ApiError)
+  })
+})
+
+describe('api.createFunnel', () => {
+  it('sends name and steps in POST body', async () => {
+    const steps = [{ event_name: 'page_view' }]
+    mockFetch(200, { id: 'f1', name: 'Checkout', steps: [] })
+    await api.createFunnel('proj1', 'Checkout', steps)
+    const [, options] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(options.body as string)
+    expect(body.name).toBe('Checkout')
+    expect(body.steps).toEqual(steps)
+  })
+})

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -118,7 +118,7 @@ export const api = {
     request<void>(`/api/v1/apikeys/${keyId}`, { method: 'DELETE' }),
 
   // Project update
-  updateProject: (projectId: string, data: { name: string }) =>
+  updateProject: (projectId: string, data: { name: string; domain?: string }) =>
     request<Project>(`/api/v1/projects/${projectId}`, {
       method: 'PUT',
       body: JSON.stringify(data),

--- a/web/src/lib/projects.test.tsx
+++ b/web/src/lib/projects.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
-import { ProjectProvider, useEffectiveProjectId } from './projects'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import { ProjectProvider, useEffectiveProjectId, useProjects } from './projects'
 import type { Project } from './api'
 
 // ---------------------------------------------------------------------------
@@ -93,5 +93,48 @@ describe('useEffectiveProjectId', () => {
   it('returns undefined when the project list is empty', async () => {
     renderWithProjects([])
     await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('undefined'))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// setDefaultProjectId tests
+// ---------------------------------------------------------------------------
+
+function DefaultIdConsumer({ onReady }: { onReady?: (fn: (id: string) => void) => void }) {
+  const { defaultProjectId, setDefaultProjectId } = useProjects()
+  if (onReady) onReady(setDefaultProjectId)
+  return <div data-testid="default-id">{defaultProjectId ?? 'null'}</div>
+}
+
+describe('setDefaultProjectId', () => {
+  beforeEach(() => {
+    delete store['funnelbarn_default_project']
+    vi.clearAllMocks()
+  })
+
+  it('persists to localStorage', async () => {
+    mockListProjects.mockResolvedValue({ projects: [projectA, projectB] })
+    let setter: ((id: string) => void) | undefined
+    render(
+      <ProjectProvider>
+        <DefaultIdConsumer onReady={(fn) => { setter = fn }} />
+      </ProjectProvider>
+    )
+    await waitFor(() => expect(screen.getByTestId('default-id')).toBeInTheDocument())
+    act(() => { setter!('proj-b') })
+    expect(store['funnelbarn_default_project']).toBe('proj-b')
+  })
+
+  it('updates defaultProjectId in context', async () => {
+    mockListProjects.mockResolvedValue({ projects: [projectA, projectB] })
+    let setter: ((id: string) => void) | undefined
+    render(
+      <ProjectProvider>
+        <DefaultIdConsumer onReady={(fn) => { setter = fn }} />
+      </ProjectProvider>
+    )
+    await waitFor(() => expect(screen.getByTestId('default-id')).toBeInTheDocument())
+    act(() => { setter!('proj-b') })
+    await waitFor(() => expect(screen.getByTestId('default-id').textContent).toBe('proj-b'))
   })
 })

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -76,6 +76,7 @@ export default function Settings() {
 
   // Project editing — initialise from shared context
   const [editedNames, setEditedNames] = useState<Record<string, string>>({})
+  const [editedDomains, setEditedDomains] = useState<Record<string, string>>({})
   const [savingProject, setSavingProject] = useState<string | null>(null)
   const [projectSaveMsg, setProjectSaveMsg] = useState<string | null>(null)
 
@@ -168,9 +169,10 @@ export default function Settings() {
   const handleSaveProject = async (projectId: string) => {
     const name = editedNames[projectId]?.trim()
     if (!name) return
+    const domain = editedDomains[projectId]?.trim() ?? ''
     setSavingProject(projectId)
     try {
-      await api.updateProject(projectId, { name })
+      await api.updateProject(projectId, { name, domain })
       refetchProjects()
       setProjectSaveMsg('Saved!')
       setTimeout(() => setProjectSaveMsg(null), 2000)
@@ -344,7 +346,7 @@ export default function Settings() {
         }}>
           <div style={{ padding: '1.25rem 1.5rem', borderBottom: `1px solid ${C.border}` }}>
             <div style={{ fontWeight: 700, fontSize: 15 }}>Projects</div>
-            <div style={{ fontSize: 13, color: C.muted, marginTop: 2 }}>Edit your project names.</div>
+            <div style={{ fontSize: 13, color: C.muted, marginTop: 2 }}>Edit project names and domains.</div>
           </div>
           {activeProjects.map((p) => (
             <div key={p.id} className="project-row" style={{
@@ -355,14 +357,26 @@ export default function Settings() {
               alignItems: 'center',
               gap: 12,
             }}>
-              <input
-                value={editedNames[p.id] ?? p.name}
-                onChange={(e) => setEditedNames((prev) => ({ ...prev, [p.id]: e.target.value }))}
-                style={{ ...inputStyle, flex: 1, minWidth: 0 }}
-                onFocus={(e) => (e.target.style.borderColor = C.amber)}
-                onBlur={(e) => (e.target.style.borderColor = C.border)}
-                onKeyDown={(e) => e.key === 'Enter' && handleSaveProject(p.id)}
-              />
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6, flex: 1, minWidth: 0 }}>
+                <input
+                  value={editedNames[p.id] ?? p.name}
+                  onChange={(e) => setEditedNames((prev) => ({ ...prev, [p.id]: e.target.value }))}
+                  placeholder="Project name"
+                  style={{ ...inputStyle, width: '100%', boxSizing: 'border-box' }}
+                  onFocus={(e) => (e.target.style.borderColor = C.amber)}
+                  onBlur={(e) => (e.target.style.borderColor = C.border)}
+                  onKeyDown={(e) => e.key === 'Enter' && handleSaveProject(p.id)}
+                />
+                <input
+                  value={editedDomains[p.id] ?? (p.domain ?? '')}
+                  onChange={(e) => setEditedDomains((prev) => ({ ...prev, [p.id]: e.target.value }))}
+                  placeholder="Domain (e.g. example.com)"
+                  style={{ ...inputStyle, width: '100%', boxSizing: 'border-box' }}
+                  onFocus={(e) => (e.target.style.borderColor = C.amber)}
+                  onBlur={(e) => (e.target.style.borderColor = C.border)}
+                  onKeyDown={(e) => e.key === 'Enter' && handleSaveProject(p.id)}
+                />
+              </div>
               <div className="project-actions" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                 <button
                   className="project-save-btn"


### PR DESCRIPTION
## Summary

- **Dropdown removed** — both the desktop and mobile project-switcher dropdowns are deleted from the Shell nav bar. The home screen (Your Projects grid) is the correct place to pick a project.
- **Domain field** — each project row in Settings now has a domain input so users can set or update it after creation, fixing the "No domain set" state with no way to change it.
- `updateProject` API type updated to accept `domain?: string` (backend already supported it).

## Changes
- `Shell.tsx`: removed both dropdown blocks, unused `ChevronDown`/`Star` imports, `dropdownOpen` state, `onProjectChange` prop, `useProjects` import
- `Settings.tsx`: `editedDomains` state, domain input per project row, domain passed to save handler  
- `api.ts`: `updateProject` data type now `{ name: string; domain?: string }`