### PR TITLE
fix(ci): Shell tests + unused helper (staticcheck + frontend gate)

### DIFF
--- a/internal/service/events_test.go
+++ b/internal/service/events_test.go
@@ -11,14 +11,6 @@ import (
 	"github.com/wiebe-xyz/funnelbarn/internal/service"
 )
 
-func newTestEventSvc(t *testing.T) (*service.EventService, string) {
-	t.Helper()
-	store := newTestStore(t)
-	projSvc := service.NewProjectService(store)
-	p, err := projSvc.CreateProject(context.Background(), "Ev Project", "ev-project-"+t.Name())
-	require.NoError(t, err)
-	return service.NewEventService(store), p.ID
-}
 
 func TestEventService_InsertAndList(t *testing.T) {
 	ctx := context.Background()

--- a/web/src/components/shell/Shell.test.tsx
+++ b/web/src/components/shell/Shell.test.tsx
@@ -3,10 +3,9 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Shell from './Shell'
 import type { ReactNode } from 'react'
-import type { Project } from '../../lib/api'
 
 // ---------------------------------------------------------------------------
-// Mock the two contexts Shell depends on
+// Mocks
 // ---------------------------------------------------------------------------
 
 const mockLogout = vi.fn()
@@ -21,17 +20,6 @@ vi.mock('../../lib/auth', () => ({
   }),
 }))
 
-// Default: two projects so we can also test the single-project case by
-// overriding per test.
-let mockProjects: Project[] = [
-  { id: 'p1', name: 'Project Alpha', slug: 'alpha', status: 'active' },
-  { id: 'p2', name: 'Project Beta', slug: 'beta', status: 'active' },
-]
-
-vi.mock('../../lib/projects', () => ({
-  useProjects: () => ({ projects: mockProjects, isLoading: false, refetch: vi.fn() }),
-}))
-
 vi.mock('react-router-dom', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react-router-dom')>()
   return {
@@ -44,10 +32,10 @@ vi.mock('react-router-dom', async (importOriginal) => {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function renderShell(ui: ReactNode = <div>child content</div>, initialEntry = '/dashboard') {
+function renderShell(ui: ReactNode = <div>child content</div>, projectId?: string) {
   return render(
-    <MemoryRouter initialEntries={[initialEntry]}>
-      <Shell>{ui}</Shell>
+    <MemoryRouter initialEntries={['/dashboard']}>
+      <Shell projectId={projectId}>{ui}</Shell>
     </MemoryRouter>,
   )
 }
@@ -58,10 +46,6 @@ function renderShell(ui: ReactNode = <div>child content</div>, initialEntry = '/
 
 describe('Shell', () => {
   beforeEach(() => {
-    mockProjects = [
-      { id: 'p1', name: 'Project Alpha', slug: 'alpha', status: 'active' },
-      { id: 'p2', name: 'Project Beta', slug: 'beta', status: 'active' },
-    ]
     vi.clearAllMocks()
   })
 
@@ -72,17 +56,16 @@ describe('Shell', () => {
 
   it('shows the FunnelBarn brand name', () => {
     renderShell()
-    // "Funnel" and "Barn" are split across sibling spans — query for the
-    // parent link text or just the "Barn" amber span.
     expect(screen.getByText('Barn')).toBeInTheDocument()
     expect(screen.getByText('Funnel')).toBeInTheDocument()
   })
 
-  it('shows the current project name when projects are present', () => {
-    renderShell()
-    // project-name appears in desktop project switcher
-    const projectNameEls = screen.getAllByText('Project Alpha')
-    expect(projectNameEls.length).toBeGreaterThan(0)
+  it('uses projectId in nav link hrefs when provided', () => {
+    renderShell(undefined, 'proj-123')
+    // Nav links should include the projectId segment
+    const links = screen.getAllByRole('link')
+    const hrefs = links.map((l) => l.getAttribute('href') ?? '')
+    expect(hrefs.some((h) => h.includes('proj-123'))).toBe(true)
   })
 
   it('shows the logged-in username', () => {
@@ -92,21 +75,12 @@ describe('Shell', () => {
 
   it('shows all nav links', () => {
     renderShell()
-    // Nav labels appear in both the desktop nav and the mobile bottom tab bar,
-    // so use getAllByText and assert at least one instance is present.
     expect(screen.getAllByText('Funnels').length).toBeGreaterThan(0)
     expect(screen.getAllByText('Overview').length).toBeGreaterThan(0)
     expect(screen.getAllByText('Settings').length).toBeGreaterThan(0)
   })
 
-  it('does not show the project dropdown when there is only one project', () => {
-    // With a single project there is nothing to switch to, so the dropdown
-    // list should not render any secondary project.
-    mockProjects = [{ id: 'p1', name: 'Only Project', slug: 'only', status: 'active' }]
-    renderShell()
-    // "Only Project" appears in the switcher button but NOT as a second option
-    const matches = screen.getAllByText('Only Project')
-    // Each switcher (desktop + mobile) shows the name once — total 2 buttons
-    expect(matches.length).toBeLessThanOrEqual(2)
+  it('renders without errors when no projectId is provided', () => {
+    expect(() => renderShell()).not.toThrow()
   })
 })


### PR DESCRIPTION
Fixes two CI failures introduced by recent PRs:
- Shell.test.tsx: PR #21 removed the project dropdown; update 2 failing tests to match current behavior (nav href verification, single-project render)
- events_test.go: remove `newTestEventSvc` helper that was declared but never called — was failing staticcheck U1000 gate