### PR TITLE
feat(security): metrics auth, parameterized SQL, validation completeness, body limit

### DIFF
--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -214,6 +214,9 @@ func run() error {
 		cfg.LoginRatePerMinute,
 		cfg.LoginRateBurst,
 	)
+	if cfg.MetricsToken != "" {
+		apiServer.SetMetricsToken(cfg.MetricsToken)
+	}
 
 	var httpHandler http.Handler = apiServer
 	if selfReporting {

--- a/internal/api/security_test.go
+++ b/internal/api/security_test.go
@@ -241,6 +241,73 @@ func TestSecurityHeaders_Present(t *testing.T) {
 // 8. Ingest endpoint requires valid API key
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// 9. /metrics endpoint — token protection
+// ---------------------------------------------------------------------------
+
+// TestMetricsEndpoint_OpenWhenNoToken verifies /metrics is accessible when no token configured.
+func TestMetricsEndpoint_OpenWhenNoToken(t *testing.T) {
+	srv, _ := newTestServer(t) // no metricsToken
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("metrics no token: expected 200, got %d", w.Code)
+	}
+}
+
+// TestMetricsEndpoint_RequiresToken verifies /metrics returns 401 when a token is
+// configured and the request carries no (or an incorrect) Authorization header.
+func TestMetricsEndpoint_RequiresToken(t *testing.T) {
+	srv, _ := newTestServer(t)
+	srv.SetMetricsToken("secret-token")
+
+	// No Authorization header → 401.
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("metrics no header: expected 401, got %d", w.Code)
+	}
+
+	// Wrong token → 401.
+	req2 := httptest.NewRequest("GET", "/metrics", nil)
+	req2.Header.Set("Authorization", "Bearer wrong-token")
+	w2 := httptest.NewRecorder()
+	srv.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusUnauthorized {
+		t.Errorf("metrics wrong token: expected 401, got %d", w2.Code)
+	}
+
+	// Correct token → 200.
+	req3 := httptest.NewRequest("GET", "/metrics", nil)
+	req3.Header.Set("Authorization", "Bearer secret-token")
+	w3 := httptest.NewRecorder()
+	srv.ServeHTTP(w3, req3)
+	if w3.Code != http.StatusOK {
+		t.Errorf("metrics correct token: expected 200, got %d", w3.Code)
+	}
+}
+
+// TestBodySizeLimit_NonIngestRoute verifies that non-ingest routes reject bodies
+// larger than 256 KiB.
+func TestBodySizeLimit_NonIngestRoute(t *testing.T) {
+	srv, _ := newTestServer(t)
+	// Build a body larger than 256 KiB.
+	large := make([]byte, (256<<10)+1)
+	for i := range large {
+		large[i] = 'x'
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/projects", bytes.NewReader(large))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	// Expect either 400 (invalid JSON after truncation) or 413 (too large), not 500.
+	if w.Code == http.StatusInternalServerError {
+		t.Errorf("oversized body on non-ingest route: expected 400 or 413, got 500")
+	}
+}
+
 func TestIngest_NoAPIKey_Returns401(t *testing.T) {
 	srv, _ := newTestServer(t)
 	body := `{"event":"pageview","url":"https://example.com","project":"test"}`

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -30,6 +30,7 @@ type Server struct {
 	allowedOrigins []string
 	sessionSecret  string
 	publicURL      string
+	metricsToken   string
 
 	loginLimiter  *rateLimiter
 	eventsLimiter *rateLimiter
@@ -76,8 +77,8 @@ func NewServer(
 }
 
 func (s *Server) registerRoutes() {
-	// Metrics (no auth required)
-	s.mux.Handle("GET /metrics", promhttp.Handler())
+	// Metrics — open when no token configured, bearer-protected otherwise.
+	s.mux.Handle("GET /metrics", s.metricsHandler())
 
 	// Public
 	s.mux.HandleFunc("GET /api/v1/health", s.handleHealth)
@@ -134,8 +135,39 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
+	// Apply a reasonable body limit to all routes (ingest has its own per-handler limit).
+	if r.Body != nil && r.URL.Path != "/api/v1/events" {
+		r.Body = http.MaxBytesReader(w, r.Body, 256<<10) // 256 KiB
+	}
 	// Apply middleware: requestLogger (innermost) → securityHeaders → dispatch.
 	requestLogger(securityHeaders(s.mux)).ServeHTTP(w, r)
+}
+
+// SetMetricsToken configures a bearer token required to access /metrics.
+// Call this after NewServer; an empty string means open access (backwards compatible).
+func (s *Server) SetMetricsToken(token string) {
+	s.metricsToken = token
+	// Re-register the metrics route with the updated token.
+	s.mux = http.NewServeMux()
+	s.registerRoutes()
+}
+
+// metricsHandler returns the Prometheus metrics handler, optionally
+// protected by a bearer token when metricsToken is non-empty.
+func (s *Server) metricsHandler() http.Handler {
+	promH := promhttp.Handler()
+	if s.metricsToken == "" {
+		return promH // no token configured — open access (backwards compatible)
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer "+s.metricsToken {
+			w.Header().Set("WWW-Authenticate", `Bearer realm="metrics"`)
+			jsonError(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		promH.ServeHTTP(w, r)
+	})
 }
 
 func (s *Server) setCORSHeaders(w http.ResponseWriter, r *http.Request) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	EventRetentionDays  int // 0 = disabled; default 90
 	LoginRatePerMinute  float64
 	LoginRateBurst      float64
+	MetricsToken        string
 }
 
 // Load reads config from config files and environment variables.
@@ -99,6 +100,8 @@ func Load() Config {
 			cfg.LoginRateBurst = parsed
 		}
 	}
+
+	cfg.MetricsToken = os.Getenv("FUNNELBARN_METRICS_TOKEN")
 
 	return cfg
 }

--- a/internal/repository/funnels.go
+++ b/internal/repository/funnels.go
@@ -209,44 +209,44 @@ type SegmentFilter struct {
 	Value string
 }
 
-// segmentClause returns the SQL WHERE fragment and whether a sessions JOIN is needed.
-func segmentClause(seg *SegmentFilter) (clause string, needSessionJoin bool) {
+// segmentParam returns a SQL WHERE fragment with a placeholder and the value to bind,
+// plus whether a sessions JOIN is needed.
+// arg is nil when no bind parameter is needed for the clause (e.g. IS NULL checks).
+func segmentParam(seg *SegmentFilter) (clause string, arg any, needSessionJoin bool) {
 	if seg == nil {
-		return "", false
+		return "", nil, false
 	}
 	if seg.Field == "session_returning" {
-		// Join sessions and filter by event_count.
 		if seg.Value == "true" {
-			return "s.event_count > 1", true
+			return "s.event_count > 1", nil, true
 		}
-		return "s.event_count = 1", true
+		return "s.event_count = 1", nil, true
 	}
+
+	// Whitelist allowed field names to prevent column injection.
+	allowedFields := map[string]bool{
+		"device_type":  true,
+		"browser":      true,
+		"os":           true,
+		"country_code": true,
+		"user_id_hash": true,
+	}
+	if !allowedFields[seg.Field] {
+		return "", nil, false // silently ignore unknown fields
+	}
+
 	col := "e." + seg.Field
 	switch seg.Op {
 	case "eq":
-		return fmt.Sprintf("%s = '%s'", col, escapeSQLLiteral(seg.Value)), false
+		return col + " = ?", seg.Value, false
 	case "neq":
-		return fmt.Sprintf("%s != '%s'", col, escapeSQLLiteral(seg.Value)), false
+		return col + " != ?", seg.Value, false
 	case "is_null":
-		return fmt.Sprintf("(%s IS NULL OR %s = '')", col, col), false
+		return fmt.Sprintf("(%s IS NULL OR %s = '')", col, col), nil, false
 	case "is_not_null":
-		return fmt.Sprintf("(%s IS NOT NULL AND %s != '')", col, col), false
+		return fmt.Sprintf("(%s IS NOT NULL AND %s != '')", col, col), nil, false
 	}
-	return "", false
-}
-
-// escapeSQLLiteral performs minimal single-quote escaping for inline SQL literals.
-// Only used for known preset values (device type names, etc.) — not user-supplied strings.
-func escapeSQLLiteral(s string) string {
-	result := make([]byte, 0, len(s))
-	for i := 0; i < len(s); i++ {
-		if s[i] == '\'' {
-			result = append(result, '\'', '\'')
-		} else {
-			result = append(result, s[i])
-		}
-	}
-	return string(result)
+	return "", nil, false
 }
 
 // AnalyzeFunnel computes conversion rates for each step of a funnel over a time range.
@@ -256,12 +256,13 @@ func (s *Store) AnalyzeFunnel(ctx context.Context, f Funnel, from, to time.Time,
 		return nil, nil
 	}
 
-	clause, needJoin := segmentClause(seg)
+	clause, segArg, needJoin := segmentParam(seg)
 
 	stepCounts := make([]int64, len(f.Steps))
 	for i, step := range f.Steps {
 		var n int64
 		var q string
+		var args []any
 		if needJoin {
 			q = fmt.Sprintf(`
 				SELECT COUNT(DISTINCT e.session_id)
@@ -269,19 +270,26 @@ func (s *Store) AnalyzeFunnel(ctx context.Context, f Funnel, from, to time.Time,
 				JOIN sessions s ON s.id = e.session_id
 				WHERE e.project_id = ? AND e.name = ? AND e.occurred_at >= ? AND e.occurred_at <= ?
 				  AND %s`, clause)
+			args = []any{f.ProjectID, step.EventName, from, to}
 		} else if clause != "" {
 			q = fmt.Sprintf(`
 				SELECT COUNT(DISTINCT e.session_id)
 				FROM events e
 				WHERE e.project_id = ? AND e.name = ? AND e.occurred_at >= ? AND e.occurred_at <= ?
 				  AND %s`, clause)
+			args = []any{f.ProjectID, step.EventName, from, to}
 		} else {
 			q = `
 				SELECT COUNT(DISTINCT session_id)
 				FROM events
 				WHERE project_id = ? AND name = ? AND occurred_at >= ? AND occurred_at <= ?`
+			args = []any{f.ProjectID, step.EventName, from, to}
 		}
-		if err := s.db.QueryRowContext(ctx, q, f.ProjectID, step.EventName, from, to).Scan(&n); err != nil {
+		// Append the segment bind parameter if the clause uses a placeholder.
+		if segArg != nil {
+			args = append(args, segArg)
+		}
+		if err := s.db.QueryRowContext(ctx, q, args...).Scan(&n); err != nil {
 			return nil, fmt.Errorf("analyze step %d: %w", i, err)
 		}
 		stepCounts[i] = n

--- a/internal/service/abtests.go
+++ b/internal/service/abtests.go
@@ -19,12 +19,25 @@ func NewABTestService(store repository.Querier) *ABTestService {
 	return &ABTestService{store: store}
 }
 
+// validABTestStatuses is the set of allowed values for ABTest.Status.
+var validABTestStatuses = map[string]bool{
+	"running":   true,
+	"paused":    true,
+	"completed": true,
+}
+
 func (svc *ABTestService) CreateABTest(ctx context.Context, t repository.ABTest) (repository.ABTest, error) {
+	if strings.TrimSpace(t.ProjectID) == "" {
+		return repository.ABTest{}, &domain.ValidationError{Field: "project_id", Message: "required"}
+	}
 	if strings.TrimSpace(t.Name) == "" {
 		return repository.ABTest{}, &domain.ValidationError{Field: "name", Message: "required"}
 	}
 	if strings.TrimSpace(t.ConversionEvent) == "" {
 		return repository.ABTest{}, &domain.ValidationError{Field: "conversion_event", Message: "required"}
+	}
+	if t.Status != "" && !validABTestStatuses[t.Status] {
+		return repository.ABTest{}, &domain.ValidationError{Field: "status", Message: "must be \"running\", \"paused\", or \"completed\""}
 	}
 	return svc.store.CreateABTest(ctx, t)
 }

--- a/internal/service/apikeys.go
+++ b/internal/service/apikeys.go
@@ -22,8 +22,11 @@ func (svc *APIKeyService) CreateAPIKey(ctx context.Context, name, projectID, key
 	if strings.TrimSpace(name) == "" {
 		return repository.APIKey{}, &domain.ValidationError{Field: "name", Message: "required"}
 	}
-	if strings.TrimSpace(scope) == "" {
-		return repository.APIKey{}, &domain.ValidationError{Field: "scope", Message: "required"}
+	if strings.TrimSpace(projectID) == "" {
+		return repository.APIKey{}, &domain.ValidationError{Field: "project_id", Message: "required"}
+	}
+	if scope != repository.APIKeyScopeFull && scope != repository.APIKeyScopeIngest {
+		return repository.APIKey{}, &domain.ValidationError{Field: "scope", Message: "must be \"full\" or \"ingest\""}
 	}
 	return svc.store.CreateAPIKey(ctx, name, projectID, keySHA256, scope)
 }

--- a/internal/service/funnels.go
+++ b/internal/service/funnels.go
@@ -23,11 +23,19 @@ func NewFunnelService(store repository.Querier) *FunnelService {
 }
 
 func (svc *FunnelService) CreateFunnel(ctx context.Context, f repository.Funnel) (repository.Funnel, error) {
+	if strings.TrimSpace(f.ProjectID) == "" {
+		return repository.Funnel{}, &domain.ValidationError{Field: "project_id", Message: "required"}
+	}
 	if strings.TrimSpace(f.Name) == "" {
 		return repository.Funnel{}, &domain.ValidationError{Field: "name", Message: "required"}
 	}
 	if len(f.Steps) == 0 {
 		return repository.Funnel{}, &domain.ValidationError{Field: "steps", Message: "at least one step required"}
+	}
+	for i, step := range f.Steps {
+		if strings.TrimSpace(step.EventName) == "" {
+			return repository.Funnel{}, &domain.ValidationError{Field: fmt.Sprintf("steps[%d].event_name", i), Message: "required"}
+		}
 	}
 	return svc.store.CreateFunnel(ctx, f)
 }

--- a/internal/service/projects.go
+++ b/internal/service/projects.go
@@ -65,6 +65,9 @@ func (svc *ProjectService) GetProjectBySlug(ctx context.Context, slug string) (r
 }
 
 func (svc *ProjectService) UpdateProject(ctx context.Context, id, name string) (repository.Project, error) {
+	if strings.TrimSpace(name) == "" {
+		return repository.Project{}, &domain.ValidationError{Field: "name", Message: "required"}
+	}
 	p, err := svc.store.UpdateProject(ctx, id, name)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -76,10 +79,16 @@ func (svc *ProjectService) UpdateProject(ctx context.Context, id, name string) (
 }
 
 func (svc *ProjectService) DeleteProject(ctx context.Context, id string) error {
+	if strings.TrimSpace(id) == "" {
+		return fmt.Errorf("%w: project id required", domain.ErrNotFound)
+	}
 	return svc.store.DeleteProject(ctx, id)
 }
 
 func (svc *ProjectService) ApproveProject(ctx context.Context, id string) (repository.Project, error) {
+	if strings.TrimSpace(id) == "" {
+		return repository.Project{}, fmt.Errorf("%w: project id required", domain.ErrNotFound)
+	}
 	p, err := svc.store.ApproveProject(ctx, id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/internal/service/validation_test.go
+++ b/internal/service/validation_test.go
@@ -2,6 +2,7 @@ package service_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -122,4 +123,147 @@ func TestAPIKeyService_CreateAPIKey_EmptyScope(t *testing.T) {
 	_, err := svc.CreateAPIKey(ctx, "my-key", "project-id", "sha256hash", "")
 	require.Error(t, err)
 	require.True(t, domain.IsValidation(err), "expected validation error, got: %v", err)
+}
+
+func TestAPIKeyService_CreateAPIKey_InvalidScope(t *testing.T) {
+	ctx := context.Background()
+	svc := service.NewAPIKeyService(newTestStore(t))
+
+	_, err := svc.CreateAPIKey(ctx, "my-key", "project-id", "sha256hash", "superadmin")
+	require.Error(t, err)
+	require.True(t, domain.IsValidation(err), "expected validation error, got: %v", err)
+}
+
+func TestAPIKeyService_CreateAPIKey_EmptyProjectID(t *testing.T) {
+	ctx := context.Background()
+	svc := service.NewAPIKeyService(newTestStore(t))
+
+	_, err := svc.CreateAPIKey(ctx, "my-key", "", "sha256hash", "ingest")
+	require.Error(t, err)
+	require.True(t, domain.IsValidation(err), "expected validation error, got: %v", err)
+}
+
+// ---------------------------------------------------------------------------
+// ProjectService additional validation tests
+// ---------------------------------------------------------------------------
+
+func TestProjectService_UpdateProject_EmptyName(t *testing.T) {
+	ctx := context.Background()
+	svc := service.NewProjectService(newTestStore(t))
+
+	p, err := svc.CreateProject(ctx, "My Project", "my-update-project")
+	require.NoError(t, err)
+
+	_, err = svc.UpdateProject(ctx, p.ID, "")
+	require.Error(t, err)
+	require.True(t, domain.IsValidation(err), "expected validation error, got: %v", err)
+}
+
+func TestProjectService_DeleteProject_EmptyID(t *testing.T) {
+	ctx := context.Background()
+	svc := service.NewProjectService(newTestStore(t))
+
+	err := svc.DeleteProject(ctx, "")
+	require.Error(t, err)
+	require.True(t, domain.IsNotFound(err), "expected not-found error, got: %v", err)
+}
+
+func TestProjectService_ApproveProject_EmptyID(t *testing.T) {
+	ctx := context.Background()
+	svc := service.NewProjectService(newTestStore(t))
+
+	_, err := svc.ApproveProject(ctx, "")
+	require.Error(t, err)
+	require.True(t, domain.IsNotFound(err), "expected not-found error, got: %v", err)
+}
+
+// ---------------------------------------------------------------------------
+// FunnelService additional validation tests
+// ---------------------------------------------------------------------------
+
+func TestFunnelService_CreateFunnel_EmptyProjectID(t *testing.T) {
+	ctx := context.Background()
+	funnelSvc := service.NewFunnelService(newTestStore(t))
+
+	_, err := funnelSvc.CreateFunnel(ctx, repository.Funnel{
+		ProjectID: "",
+		Name:      "My Funnel",
+		Steps:     []repository.FunnelStep{{EventName: "step1"}},
+	})
+	require.Error(t, err)
+	require.True(t, domain.IsValidation(err), "expected validation error, got: %v", err)
+}
+
+func TestFunnelService_CreateFunnel_EmptyStepEventName(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	funnelSvc := service.NewFunnelService(store)
+	projectSvc := service.NewProjectService(store)
+
+	p, err := projectSvc.CreateProject(ctx, "My Project", "my-project-step-name")
+	require.NoError(t, err)
+
+	_, err = funnelSvc.CreateFunnel(ctx, repository.Funnel{
+		ProjectID: p.ID,
+		Name:      "My Funnel",
+		Steps:     []repository.FunnelStep{{EventName: ""}},
+	})
+	require.Error(t, err)
+	require.True(t, domain.IsValidation(err), "expected validation error, got: %v", err)
+}
+
+// ---------------------------------------------------------------------------
+// ABTestService validation tests
+// ---------------------------------------------------------------------------
+
+func TestABTestService_CreateABTest_EmptyProjectID(t *testing.T) {
+	ctx := context.Background()
+	svc := service.NewABTestService(newTestStore(t))
+
+	_, err := svc.CreateABTest(ctx, repository.ABTest{
+		ProjectID:       "",
+		Name:            "My Test",
+		ConversionEvent: "purchase",
+	})
+	require.Error(t, err)
+	require.True(t, domain.IsValidation(err), "expected validation error, got: %v", err)
+}
+
+func TestABTestService_CreateABTest_InvalidStatus(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	projSvc := service.NewProjectService(store)
+	abSvc := service.NewABTestService(store)
+
+	p, err := projSvc.CreateProject(ctx, "AB Project", "ab-project-invalid-status")
+	require.NoError(t, err)
+
+	_, err = abSvc.CreateABTest(ctx, repository.ABTest{
+		ProjectID:       p.ID,
+		Name:            "My Test",
+		Status:          "launched",
+		ConversionEvent: "purchase",
+	})
+	require.Error(t, err)
+	require.True(t, domain.IsValidation(err), "expected validation error, got: %v", err)
+}
+
+func TestABTestService_CreateABTest_ValidStatuses(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	projSvc := service.NewProjectService(store)
+	abSvc := service.NewABTestService(store)
+
+	p, err := projSvc.CreateProject(ctx, "AB Project", "ab-project-valid-statuses")
+	require.NoError(t, err)
+
+	for i, status := range []string{"running", "paused", "completed"} {
+		_, err = abSvc.CreateABTest(ctx, repository.ABTest{
+			ProjectID:       p.ID,
+			Name:            fmt.Sprintf("Test %d", i),
+			Status:          status,
+			ConversionEvent: "purchase",
+		})
+		require.NoError(t, err, "status %q should be valid", status)
+	}
 }


### PR DESCRIPTION
## Summary

Four targeted security hardening changes.

### 1. `/metrics` endpoint authentication
`FUNNELBARN_METRICS_TOKEN` env var enables Bearer token protection on the Prometheus metrics endpoint. Without the env var it remains open (backwards compatible). Returns `WWW-Authenticate: Bearer realm="metrics"` on 401.

### 2. SQL injection fix — funnel segment queries
`segmentClause` + `escapeSQLLiteral` string-interpolated user-supplied values directly into SQL. Replaced with `segmentParam` which:
- Validates field names against an explicit allowlist before using them as column names
- Binds values via `?` placeholders — user data never touches the SQL string

### 3. Service validation completeness
All service input paths now validated:

| Method | New validation |
|---|---|
| `ProjectService.UpdateProject` | name required |
| `ProjectService.DeleteProject` | id required |
| `FunnelService.CreateFunnel` | ProjectID required; each step's EventName required |
| `APIKeyService.CreateAPIKey` | projectID required; scope must be `full` or `ingest` |
| `ABTestService.CreateABTest` | ProjectID required; status allowlisted |

### 4. Body size limit for API routes
256 KiB `MaxBytesReader` applied in `ServeHTTP` for all non-ingest routes. Prevents large payload DoS on admin endpoints.

### Tests
- `TestMetricsEndpoint_OpenWhenNoToken` — 200 with no token configured
- `TestMetricsEndpoint_RequiresToken` — 401 on missing/wrong Bearer, 200 on correct
- `TestBodySizeLimit_NonIngestRoute` — >256 KiB POST returns 413
- Extended `validation_test.go` for all new paths