### PR TITLE
feat(reliability): DB ping in /health, FUNNELBARN_LOG_LEVEL, README env docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ funnelbarn user create --username admin --password yourpassword
 | `FUNNELBARN_PUBLIC_URL` | — | Public server URL |
 | `FUNNELBARN_SELF_ENDPOINT` | — | BugBarn endpoint for self-reporting |
 | `FUNNELBARN_SELF_API_KEY` | — | BugBarn API key for self-reporting |
+| `FUNNELBARN_LOG_LEVEL` | `info` | Log verbosity: `debug`, `info`, `warn`, `error` |
+| `FUNNELBARN_LOGIN_RATE_PER_MINUTE` | `20` | Login endpoint rate limit (requests/min) |
+| `FUNNELBARN_LOGIN_RATE_BURST` | `20` | Login endpoint burst capacity |
+| `FUNNELBARN_METRICS_TOKEN` | — | Optional Bearer token to protect `/metrics` endpoint |
+| `FUNNELBARN_EVENT_RETENTION_DAYS` | `90` | Days to retain events (0 = disabled) |
 
 ## API Endpoints
 

--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -76,7 +76,7 @@ func buildLogger(cfg config.Config) *slog.Logger {
 
 	// Always: structured JSON to stderr.
 	jsonHandler := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
+		Level: cfg.LogLevel,
 	})
 	handlers = append(handlers, jsonHandler)
 
@@ -213,6 +213,7 @@ func run() error {
 		cfg.PublicURL,
 		cfg.LoginRatePerMinute,
 		cfg.LoginRateBurst,
+		store,
 	)
 	if cfg.MetricsToken != "" {
 		apiServer.SetMetricsToken(cfg.MetricsToken)

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -61,7 +62,7 @@ func newTestServer(t *testing.T) (*Server, *repository.Store) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
-		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000)
+		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, store)
 	return srv, store
 }
 
@@ -78,7 +79,7 @@ func newAuthedServer(t *testing.T) (*Server, *repository.Store) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
-		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000)
+		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, store)
 	return srv, store
 }
 
@@ -144,6 +145,37 @@ func TestHandleHealth(t *testing.T) {
 	_ = json.Unmarshal(w.Body.Bytes(), &resp)
 	if resp["status"] != "ok" {
 		t.Errorf("health status: want ok, got %v", resp["status"])
+	}
+}
+
+// failPinger is a Pinger that always returns an error.
+type failPinger struct{ err error }
+
+func (f *failPinger) Ping(_ context.Context) error { return f.err }
+
+func TestHandleHealth_DBDown(t *testing.T) {
+	store := openMemoryStore(t)
+	sp := newTestSpool(t)
+	ingestHandler := ingest.NewHandler(auth.New("test-key"), sp, 0)
+	sm := auth.NewSessionManager("test-secret", time.Hour)
+	userAuth, _ := auth.NewUserAuthenticator("", "", "")
+
+	brokenPinger := &failPinger{err: errors.New("connection refused")}
+
+	srv := NewServer(ingestHandler,
+		service.NewProjectService(store), service.NewFunnelService(store),
+		service.NewABTestService(store), service.NewEventService(store),
+		service.NewSessionService(store), service.NewAPIKeyService(store),
+		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, brokenPinger)
+
+	w := getJSON(t, srv, "/api/v1/health", nil)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("health DB down: expected 503, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["status"] != "unhealthy" {
+		t.Errorf("health status: want unhealthy, got %v", resp["status"])
 	}
 }
 

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -1,11 +1,28 @@
 package api
 
 import (
+	"context"
+	"log/slog"
 	"net/http"
 	"time"
 )
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+	defer cancel()
+
+	if s.db != nil {
+		if err := s.db.Ping(ctx); err != nil {
+			slog.ErrorContext(ctx, "health check db ping failed", "err", err)
+			writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+				"status": "unhealthy",
+				"error":  "database unavailable",
+				"time":   time.Now().UTC().Format(time.RFC3339),
+			})
+			return
+		}
+	}
+
 	writeJSON(w, http.StatusOK, map[string]any{
 		"status": "ok",
 		"time":   time.Now().UTC().Format(time.RFC3339),

--- a/internal/api/security_test.go
+++ b/internal/api/security_test.go
@@ -78,6 +78,7 @@ func TestLoginRateLimit_Enforced(t *testing.T) {
 		service.NewSessionService(store), service.NewAPIKeyService(store),
 		userAuth, sm, nil, "secret", "http://localhost",
 		1, 1, // loginRatePerMinute=1, loginRateBurst=1
+		store,
 	)
 
 	body := map[string]string{"username": "admin", "password": "wrong"}
@@ -194,7 +195,7 @@ func TestCORS_AllowedOriginOnly(t *testing.T) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
-		ua, sm, []string{"https://allowed.example.com"}, "s", "", 1000, 1000)
+		ua, sm, []string{"https://allowed.example.com"}, "s", "", 1000, 1000, store)
 
 	// Allowed origin gets ACAO header
 	req := httptest.NewRequest("GET", "/api/v1/health", nil)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -15,9 +16,15 @@ import (
 	"github.com/wiebe-xyz/funnelbarn/internal/service"
 )
 
+// Pinger is satisfied by any type with a Ping method (e.g. *repository.Store).
+type Pinger interface {
+	Ping(ctx context.Context) error
+}
+
 // Server is the main HTTP API server.
 type Server struct {
 	mux            *http.ServeMux
+	db             Pinger
 	projects       service.Projects
 	funnels        service.Funnels
 	abtests        service.ABTests
@@ -53,9 +60,11 @@ func NewServer(
 	publicURL string,
 	loginRatePerMinute float64,
 	loginRateBurst float64,
+	db Pinger,
 ) *Server {
 	s := &Server{
 		mux:            http.NewServeMux(),
+		db:             db,
 		projects:       projects,
 		funnels:        funnels,
 		abtests:        abtests,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bufio"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -32,6 +33,7 @@ type Config struct {
 	LoginRatePerMinute  float64
 	LoginRateBurst      float64
 	MetricsToken        string
+	LogLevel            slog.Level
 }
 
 // Load reads config from config files and environment variables.
@@ -102,6 +104,18 @@ func Load() Config {
 	}
 
 	cfg.MetricsToken = os.Getenv("FUNNELBARN_METRICS_TOKEN")
+
+	cfg.LogLevel = slog.LevelInfo
+	if raw := os.Getenv("FUNNELBARN_LOG_LEVEL"); raw != "" {
+		switch strings.ToLower(raw) {
+		case "debug":
+			cfg.LogLevel = slog.LevelDebug
+		case "warn", "warning":
+			cfg.LogLevel = slog.LevelWarn
+		case "error":
+			cfg.LogLevel = slog.LevelError
+		}
+	}
 
 	return cfg
 }

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"database/sql"
 	"embed"
 	"fmt"
@@ -57,4 +58,9 @@ func (s *Store) Close() error {
 // DB returns the underlying *sql.DB for use by other packages.
 func (s *Store) DB() *sql.DB {
 	return s.db
+}
+
+// Ping verifies the database connection is alive.
+func (s *Store) Ping(ctx context.Context) error {
+	return s.db.PingContext(ctx)
 }

--- a/internal/repository/interface.go
+++ b/internal/repository/interface.go
@@ -8,6 +8,9 @@ import (
 // Querier is the interface implemented by *Store.
 // It enables service-layer tests to use test doubles instead of a real SQLite instance.
 type Querier interface {
+	// Ping verifies the database connection is alive.
+	Ping(ctx context.Context) error
+
 	// Projects
 	CreateProject(ctx context.Context, name, slug string) (Project, error)
 	ProjectByID(ctx context.Context, id string) (Project, error)

--- a/internal/repository/mock/mock.go
+++ b/internal/repository/mock/mock.go
@@ -567,3 +567,5 @@ func (s *Store) PurgeOldEvents(ctx context.Context, cutoff time.Time) (int64, er
 	s.events = kept
 	return deleted, nil
 }
+
+func (s *Store) Ping(_ context.Context) error { return nil }


### PR DESCRIPTION
## /health with DB connectivity check
`/health` now pings the database before returning 200. Returns `503 {"status":"unhealthy","error":"database unavailable"}` if the ping times out (2s) or fails — making it safe to use as a readiness probe.

`repository.Store.Ping(ctx)` added; `Querier` interface updated; `repository/mock` updated.

## Configurable log level
`FUNNELBARN_LOG_LEVEL` env var (debug/info/warn/error, default: info). Previously hardcoded to Info in `buildLogger`.

## README documentation
Added 5 missing env vars to the configuration table: `FUNNELBARN_LOG_LEVEL`, `FUNNELBARN_LOGIN_RATE_PER_MINUTE`, `FUNNELBARN_LOGIN_RATE_BURST`, `FUNNELBARN_METRICS_TOKEN`, `FUNNELBARN_EVENT_RETENTION_DAYS`.