### PR TITLE
feat(ratelimit): configurable API rate, X-Forwarded-For IP extraction

### DIFF
--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -213,6 +213,8 @@ func run() error {
 		cfg.PublicURL,
 		cfg.LoginRatePerMinute,
 		cfg.LoginRateBurst,
+		cfg.APIRatePerMinute,
+		cfg.APIRateBurst,
 		store,
 	)
 	if cfg.MetricsToken != "" {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -62,7 +62,7 @@ func newTestServer(t *testing.T) (*Server, *repository.Store) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
-		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, store)
+		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, store)
 	return srv, store
 }
 
@@ -79,7 +79,7 @@ func newAuthedServer(t *testing.T) (*Server, *repository.Store) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
-		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, store)
+		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, store)
 	return srv, store
 }
 
@@ -166,7 +166,7 @@ func TestHandleHealth_DBDown(t *testing.T) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
-		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, brokenPinger)
+		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, brokenPinger)
 
 	w := getJSON(t, srv, "/api/v1/health", nil)
 	if w.Code != http.StatusServiceUnavailable {

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -108,13 +109,34 @@ func (rl *rateLimiter) allow(ip string) bool {
 	return true
 }
 
+// clientIP extracts the real client IP address from the request.
+// It respects X-Forwarded-For when present (for reverse-proxy deployments),
+// taking the first IP in the chain. Falls back to RemoteAddr.
+func clientIP(r *http.Request) string {
+	// Respect X-Forwarded-For from trusted proxies (single hop).
+	// In production, a reverse proxy (Traefik/nginx) sets this.
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		// Take the first IP in the chain.
+		if idx := strings.IndexByte(xff, ','); idx >= 0 {
+			xff = strings.TrimSpace(xff[:idx])
+		} else {
+			xff = strings.TrimSpace(xff)
+		}
+		if xff != "" {
+			return xff
+		}
+	}
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return ip
+}
+
 // middleware returns an http.Handler that enforces the rate limit.
 func (rl *rateLimiter) middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ip, _, err := net.SplitHostPort(r.RemoteAddr)
-		if err != nil {
-			ip = r.RemoteAddr
-		}
+		ip := clientIP(r)
 
 		if !rl.allow(ip) {
 			retryAfter := int(60.0 / rl.rate)

--- a/internal/api/ratelimit_test.go
+++ b/internal/api/ratelimit_test.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClientIP_XForwardedFor(t *testing.T) {
+	// Test that X-Forwarded-For is used when present
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Forwarded-For", "1.2.3.4, 5.6.7.8")
+	req.RemoteAddr = "127.0.0.1:9999"
+
+	got := clientIP(req)
+	if got != "1.2.3.4" {
+		t.Errorf("X-Forwarded-For: want 1.2.3.4, got %q", got)
+	}
+}
+
+func TestClientIP_RemoteAddr_Fallback(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "10.0.0.1:8080"
+
+	got := clientIP(req)
+	if got != "10.0.0.1" {
+		t.Errorf("RemoteAddr fallback: want 10.0.0.1, got %q", got)
+	}
+}

--- a/internal/api/security_test.go
+++ b/internal/api/security_test.go
@@ -78,6 +78,7 @@ func TestLoginRateLimit_Enforced(t *testing.T) {
 		service.NewSessionService(store), service.NewAPIKeyService(store),
 		userAuth, sm, nil, "secret", "http://localhost",
 		1, 1, // loginRatePerMinute=1, loginRateBurst=1
+		1000, 1000, // apiRatePerMinute=1000, apiRateBurst=1000
 		store,
 	)
 
@@ -195,7 +196,7 @@ func TestCORS_AllowedOriginOnly(t *testing.T) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
-		ua, sm, []string{"https://allowed.example.com"}, "s", "", 1000, 1000, store)
+		ua, sm, []string{"https://allowed.example.com"}, "s", "", 1000, 1000, 1000, 1000, store)
 
 	// Allowed origin gets ACAO header
 	req := httptest.NewRequest("GET", "/api/v1/health", nil)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
-	"net"
 	"net/http"
 	"strings"
 
@@ -60,6 +59,8 @@ func NewServer(
 	publicURL string,
 	loginRatePerMinute float64,
 	loginRateBurst float64,
+	apiRatePerMinute float64,
+	apiRateBurst float64,
 	db Pinger,
 ) *Server {
 	s := &Server{
@@ -79,7 +80,7 @@ func NewServer(
 		publicURL:      publicURL,
 		loginLimiter:   newRateLimiter(loginRatePerMinute, loginRateBurst),
 		eventsLimiter:  newRateLimiter(500, 100),
-		apiLimiter:     newRateLimiter(300, 60),
+		apiLimiter:     newRateLimiter(apiRatePerMinute, apiRateBurst),
 	}
 	s.registerRoutes()
 	return s
@@ -209,11 +210,7 @@ func (s *Server) requireSession(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if s.sessionManager == nil || !s.userAuth.Enabled() {
 			// No auth configured — apply rate limit and allow through.
-			ip, _, err := net.SplitHostPort(r.RemoteAddr)
-			if err != nil {
-				ip = r.RemoteAddr
-			}
-			if !s.apiLimiter.allow(ip) {
+			if !s.apiLimiter.allow(clientIP(r)) {
 				jsonError(w, "too many requests", http.StatusTooManyRequests)
 				return
 			}
@@ -233,11 +230,7 @@ func (s *Server) requireSession(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 
-		ip, _, err := net.SplitHostPort(r.RemoteAddr)
-		if err != nil {
-			ip = r.RemoteAddr
-		}
-		if !s.apiLimiter.allow(ip) {
+		if !s.apiLimiter.allow(clientIP(r)) {
 			jsonError(w, "too many requests", http.StatusTooManyRequests)
 			return
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,8 @@ type Config struct {
 	EventRetentionDays  int // 0 = disabled; default 90
 	LoginRatePerMinute  float64
 	LoginRateBurst      float64
+	APIRatePerMinute    float64
+	APIRateBurst        float64
 	MetricsToken        string
 	LogLevel            slog.Level
 }
@@ -100,6 +102,20 @@ func Load() Config {
 	if raw := os.Getenv("FUNNELBARN_LOGIN_RATE_BURST"); raw != "" {
 		if parsed, err := strconv.ParseFloat(raw, 64); err == nil && parsed > 0 {
 			cfg.LoginRateBurst = parsed
+		}
+	}
+
+	// API rate limit — default 300/min burst 60.
+	cfg.APIRatePerMinute = 300
+	cfg.APIRateBurst = 60
+	if raw := os.Getenv("FUNNELBARN_API_RATE_PER_MINUTE"); raw != "" {
+		if parsed, err := strconv.ParseFloat(raw, 64); err == nil && parsed > 0 {
+			cfg.APIRatePerMinute = parsed
+		}
+	}
+	if raw := os.Getenv("FUNNELBARN_API_RATE_BURST"); raw != "" {
+		if parsed, err := strconv.ParseFloat(raw, 64); err == nil && parsed > 0 {
+			cfg.APIRateBurst = parsed
 		}
 	}
 


### PR DESCRIPTION
- `FUNNELBARN_API_RATE_PER_MINUTE` / `FUNNELBARN_API_RATE_BURST` env vars (default 300/60)
- `clientIP()` reads X-Forwarded-For for correct IP behind reverse proxy (Traefik/nginx always sets RemoteAddr=127.0.0.1)
- Both `requireSession` and rate limiter middleware use `clientIP()`
- 2 tests for clientIP extraction