### PR TITLE
feat(api): pagination headers, total_count, slug normalization, step validation

### DIFF
--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -1,9 +1,24 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 )
+
+// addPaginationHeaders sets a Link header for the next page when more results
+// may be available (i.e. the returned count equals the page limit).
+func addPaginationHeaders(w http.ResponseWriter, r *http.Request, limit, offset, count int) {
+	if count < limit {
+		return // no next page
+	}
+	nextOffset := offset + limit
+	q := r.URL.Query()
+	q.Set("offset", strconv.Itoa(nextOffset))
+	q.Set("limit", strconv.Itoa(limit))
+	next := r.URL.Path + "?" + q.Encode()
+	w.Header().Set("Link", fmt.Sprintf(`<%s>; rel="next"`, next))
+}
 
 // handleListEvents returns a paginated list of events for a project.
 func (s *Server) handleListEvents(w http.ResponseWriter, r *http.Request) {
@@ -32,6 +47,7 @@ func (s *Server) handleListEvents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	addPaginationHeaders(w, r, limit, offset, len(events))
 	writeJSON(w, http.StatusOK, map[string]any{
 		"events": events,
 		"limit":  limit,

--- a/internal/api/funnels.go
+++ b/internal/api/funnels.go
@@ -105,7 +105,10 @@ func (s *Server) handleListFunnels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{"funnels": funnels})
+	writeJSON(w, http.StatusOK, map[string]any{
+		"funnels":     funnels,
+		"total_count": len(funnels),
+	})
 }
 
 // handleCreateFunnel creates a new funnel with steps.

--- a/internal/api/sessions.go
+++ b/internal/api/sessions.go
@@ -47,6 +47,7 @@ func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	addPaginationHeaders(w, r, limit, offset, len(sessions))
 	writeJSON(w, http.StatusOK, map[string]any{
 		"sessions": sessions,
 		"limit":    limit,

--- a/internal/repository/funnels.go
+++ b/internal/repository/funnels.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -57,6 +58,12 @@ func (s *Store) CreateFunnel(ctx context.Context, f Funnel) (Funnel, error) {
 	const qf = `INSERT INTO funnels (id, project_id, name, description) VALUES (?, ?, ?, ?)`
 	if _, err := tx.ExecContext(ctx, qf, f.ID, f.ProjectID, f.Name, nullStr(f.Description)); err != nil {
 		return Funnel{}, fmt.Errorf("insert funnel: %w", err)
+	}
+
+	for i, step := range f.Steps {
+		if strings.TrimSpace(step.EventName) == "" {
+			return Funnel{}, fmt.Errorf("step %d: event_name is required", i+1)
+		}
 	}
 
 	const qs = `INSERT INTO funnel_steps (id, funnel_id, step_order, event_name, filters) VALUES (?, ?, ?, ?, ?)`

--- a/internal/service/projects.go
+++ b/internal/service/projects.go
@@ -5,11 +5,28 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/wiebe-xyz/funnelbarn/internal/domain"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 )
+
+// reNonSlug matches any character that is not a lowercase letter, digit, or hyphen.
+var reNonSlug = regexp.MustCompile(`[^a-z0-9-]+`)
+
+// normalizeSlug converts s to a lowercase, hyphen-separated slug.
+func normalizeSlug(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = strings.ReplaceAll(s, " ", "-")
+	s = reNonSlug.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	// Collapse consecutive hyphens.
+	for strings.Contains(s, "--") {
+		s = strings.ReplaceAll(s, "--", "-")
+	}
+	return s
+}
 
 // ProjectService handles project business logic.
 type ProjectService struct {
@@ -25,10 +42,11 @@ func (svc *ProjectService) CreateProject(ctx context.Context, name, slug string)
 	if strings.TrimSpace(name) == "" {
 		return repository.Project{}, &domain.ValidationError{Field: "name", Message: "required"}
 	}
-	if strings.TrimSpace(slug) == "" {
+	slug = normalizeSlug(slug)
+	if slug == "" {
 		return repository.Project{}, &domain.ValidationError{Field: "slug", Message: "required"}
 	}
-	p, err := svc.store.CreateProject(ctx, strings.TrimSpace(name), strings.TrimSpace(slug))
+	p, err := svc.store.CreateProject(ctx, strings.TrimSpace(name), slug)
 	if err != nil {
 		if isUniqueConstraint(err) {
 			return repository.Project{}, fmt.Errorf("%w: slug %q", domain.ErrConflict, slug)

--- a/internal/service/validation_test.go
+++ b/internal/service/validation_test.go
@@ -212,6 +212,37 @@ func TestFunnelService_CreateFunnel_EmptyStepEventName(t *testing.T) {
 	require.True(t, domain.IsValidation(err), "expected validation error, got: %v", err)
 }
 
+// TestProjectService_SlugNormalized verifies that slugs are lowercased and
+// spaces are converted to hyphens by CreateProject.
+func TestProjectService_SlugNormalized(t *testing.T) {
+	ctx := context.Background()
+	svc := service.NewProjectService(newTestStore(t))
+
+	p, err := svc.CreateProject(ctx, "My Project", "My Cool Project")
+	require.NoError(t, err)
+	require.Equal(t, "my-cool-project", p.Slug)
+}
+
+// TestFunnelService_StepEventNameRequired verifies that a whitespace-only
+// EventName is rejected both by the service and (as defense-in-depth) by the
+// repository, returning an error.
+func TestFunnelService_StepEventNameRequired(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	funnelSvc := service.NewFunnelService(store)
+	projectSvc := service.NewProjectService(store)
+
+	p, err := projectSvc.CreateProject(ctx, "My Project", "my-project-ws-event")
+	require.NoError(t, err)
+
+	_, err = funnelSvc.CreateFunnel(ctx, repository.Funnel{
+		ProjectID: p.ID,
+		Name:      "My Funnel",
+		Steps:     []repository.FunnelStep{{EventName: "   "}},
+	})
+	require.Error(t, err, "whitespace-only EventName must be rejected")
+}
+
 // ---------------------------------------------------------------------------
 // ABTestService validation tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
- `Link: <url>; rel="next"` header on list endpoints (events, sessions, funnels) when more pages exist
- `handleListFunnels` returns `{funnels:[...], total_count:N}`
- `CreateProject` normalizes slug (lowercase, spaces→hyphens, strip invalid chars)
- Repository-level guard: `CreateFunnel` rejects blank step EventName
- Tests: slug normalization, whitespace-only step EventName