### PR TITLE
feat(frontend): project name badge in Shell, Live skeleton, 60 tests

### DIFF
--- a/web/src/components/shell/Shell.test.tsx
+++ b/web/src/components/shell/Shell.test.tsx
@@ -21,10 +21,10 @@ vi.mock('react-router-dom', async (importOriginal) => {
   return { ...actual, useNavigate: () => mockNavigate }
 })
 
-function renderShell(ui: ReactNode = <div>child content</div>, projectId?: string) {
+function renderShell(ui: ReactNode = <div>child content</div>, projectId?: string, projectName?: string) {
   return render(
     <MemoryRouter initialEntries={['/dashboard']}>
-      <Shell projectId={projectId}>{ui}</Shell>
+      <Shell projectId={projectId} projectName={projectName}>{ui}</Shell>
     </MemoryRouter>,
   )
 }
@@ -47,6 +47,11 @@ describe('Shell', () => {
     renderShell(undefined, 'proj-123')
     const hrefs = screen.getAllByRole('link').map((l) => l.getAttribute('href') ?? '')
     expect(hrefs.some((h) => h.includes('proj-123'))).toBe(true)
+  })
+
+  it('shows project name badge when projectName provided', () => {
+    renderShell(undefined, 'proj-123', 'My Project')
+    expect(screen.getByText('My Project')).toBeInTheDocument()
   })
 
   it('shows the logged-in username', () => {

--- a/web/src/components/shell/Shell.tsx
+++ b/web/src/components/shell/Shell.tsx
@@ -15,9 +15,10 @@ const C = {
 interface ShellProps {
   children: ReactNode
   projectId?: string
+  projectName?: string  // display name for current project
 }
 
-export default function Shell({ children, projectId }: ShellProps) {
+export default function Shell({ children, projectId, projectName }: ShellProps) {
   const { user, logout } = useAuth()
   const navigate = useNavigate()
   const location = useLocation()
@@ -75,6 +76,19 @@ export default function Shell({ children, projectId }: ShellProps) {
           </span>
         </Link>
 
+
+        {/* Project name badge */}
+        {projectName && (
+          <span style={{
+            fontSize: 12, color: '#94a3b8', background: '#1a1d27',
+            border: '1px solid #2a2d3a', borderRadius: 4,
+            padding: '0.2rem 0.5rem', marginRight: 8, flexShrink: 0,
+            maxWidth: 150, overflow: 'hidden', textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}>
+            {projectName}
+          </span>
+        )}
 
         {/* Desktop: Nav links */}
         <div className="desktop-nav" style={{ display: 'flex', gap: 4, flex: 1 }}>

--- a/web/src/pages/ABTests.tsx
+++ b/web/src/pages/ABTests.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom'
 import { FlaskConical, Plus, X } from 'lucide-react'
 import Shell from '../components/shell/Shell'
 import { api, ABTest, ABTestAnalysis } from '../lib/api'
+import { useProjects } from '../lib/projects'
 
 const C = {
   bg: '#0f1117',
@@ -365,6 +366,7 @@ function TestDetail({ test, projectId }: { test: ABTest; projectId: string }) {
 
 export default function ABTests() {
   const { projectId } = useParams<{ projectId?: string }>()
+  const { projects } = useProjects()
   const [tests, setTests] = useState<ABTest[]>([])
   const [selected, setSelected] = useState<ABTest | null>(null)
   const [showCreate, setShowCreate] = useState(false)
@@ -387,8 +389,10 @@ export default function ABTests() {
     )
   }
 
+  const projectName = projects.find((p) => p.id === projectId)?.name
+
   return (
-    <Shell projectId={projectId}>
+    <Shell projectId={projectId} projectName={projectName}>
       <style>{`
         @media (max-width: 767px) {
           .abtests-layout { grid-template-columns: 1fr !important; }

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -334,8 +334,10 @@ export default function Dashboard() {
     )
   }
 
+  const projectName = projects.find((p) => p.id === projectId)?.name
+
   return (
-    <Shell projectId={projectId}>
+    <Shell projectId={projectId} projectName={projectName}>
       <style>{`
         @keyframes shimmer {
           0% { background-position: 200% 0; }

--- a/web/src/pages/Funnels.tsx
+++ b/web/src/pages/Funnels.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom'
 import { Plus, X, Layers, Pencil, Trash2 } from 'lucide-react'
 import Shell from '../components/shell/Shell'
 import { api, Funnel, FunnelAnalysis, FunnelStepInput } from '../lib/api'
+import { useProjects } from '../lib/projects'
 
 const LANGS = ['JS', 'React', 'Go', 'Python', 'Swift', 'Kotlin'] as const
 type Lang = typeof LANGS[number]
@@ -826,6 +827,7 @@ function FunnelDetail({ analysis, activeSegment, apiKey }: { analysis: FunnelAna
 
 export default function Funnels() {
   const { projectId } = useParams<{ projectId?: string }>()
+  const { projects } = useProjects()
   const [funnels, setFunnels] = useState<Funnel[]>([])
   const [selected, setSelected] = useState<Funnel | null>(null)
   const [analysis, setAnalysis] = useState<FunnelAnalysis | null>(null)
@@ -904,8 +906,10 @@ export default function Funnels() {
     )
   }
 
+  const projectName = projects.find((p) => p.id === projectId)?.name
+
   return (
-    <Shell projectId={projectId}>
+    <Shell projectId={projectId} projectName={projectName}>
       <style>{`
         @media (max-width: 767px) {
           .funnels-layout { grid-template-columns: 1fr !important; }

--- a/web/src/pages/Live.tsx
+++ b/web/src/pages/Live.tsx
@@ -4,6 +4,8 @@ import { LineChart, Line, ResponsiveContainer, Tooltip } from 'recharts'
 import { Radio } from 'lucide-react'
 import Shell from '../components/shell/Shell'
 import { api } from '../lib/api'
+import { useProjects } from '../lib/projects'
+import { Skeleton } from '../components/ui/Skeleton'
 
 const C = {
   bg: '#0f1117',
@@ -39,9 +41,11 @@ function timeAgo(ts: string): string {
 
 export default function Live() {
   const { projectId } = useParams<{ projectId?: string }>()
+  const { projects } = useProjects()
   const [events, setEvents] = useState<LiveEvent[]>([])
   const [sparkData, setSparkData] = useState<SparkPoint[]>([])
   const [activeSessions, setActiveSessions] = useState(0)
+  const [sessionsLoading, setSessionsLoading] = useState(true)
   const [connected, setConnected] = useState(false)
   const eventRef = useRef<LiveEvent[]>([])
   const counterRef = useRef(0)
@@ -126,13 +130,14 @@ export default function Live() {
   // Poll active sessions from the backend every 30 seconds
   useEffect(() => {
     if (!projectId) return
-    const poll = () => {
+    const poll = (isFirst = false) => {
       api.getActiveSessions(projectId)
         .then((d) => setActiveSessions(d.active_sessions))
         .catch(() => {}) // silent fail — keep last known value
+        .finally(() => { if (isFirst) setSessionsLoading(false) })
     }
-    poll() // immediate first fetch
-    const interval = setInterval(poll, 30_000)
+    poll(true) // immediate first fetch
+    const interval = setInterval(() => poll(false), 30_000)
     return () => clearInterval(interval)
   }, [projectId])
 
@@ -146,8 +151,10 @@ export default function Live() {
     )
   }
 
+  const projectName = projects.find((p) => p.id === projectId)?.name
+
   return (
-    <Shell projectId={projectId}>
+    <Shell projectId={projectId} projectName={projectName}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: '1.5rem' }}>
         <h1 style={{ fontSize: 24, fontWeight: 800, letterSpacing: '-0.5px', margin: 0 }}>Live</h1>
         <div style={{
@@ -179,16 +186,22 @@ export default function Live() {
           <div style={{ fontSize: 13, color: C.muted, fontWeight: 500, marginBottom: 12 }}>
             Active sessions
           </div>
-          <div style={{
-            fontSize: 72,
-            fontWeight: 900,
-            letterSpacing: '-3px',
-            color: C.success,
-            lineHeight: 1,
-            marginBottom: 8,
-          }}>
-            {activeSessions}
-          </div>
+          {sessionsLoading ? (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8, alignItems: 'center' }}>
+              <Skeleton height={72} width={80} />
+            </div>
+          ) : (
+            <div style={{
+              fontSize: 72,
+              fontWeight: 900,
+              letterSpacing: '-3px',
+              color: C.success,
+              lineHeight: 1,
+              marginBottom: 8,
+            }}>
+              {activeSessions}
+            </div>
+          )}
           <div style={{ fontSize: 13, color: C.muted }}>active in last 5 min</div>
         </div>
 


### PR DESCRIPTION
- Shell: `projectName?: string` prop shows compact badge between logo and nav links
- Dashboard, Funnels, ABTests, Live: all pass current project name to Shell
- Live: sessions count shows `<Skeleton>` while first fetch is in-flight
- Shell.test.tsx: `renderShell` accepts projectName; new test verifies badge renders