### PR TITLE
feat(backend): version in health, configurable ingest rate, worker timeouts, spool depth metric

### DIFF
--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -213,6 +213,9 @@ func run() error {
 		cfg.PublicURL,
 		cfg.LoginRatePerMinute,
 		cfg.LoginRateBurst,
+		cfg.IngestRatePerMinute,
+		cfg.IngestRateBurst,
+		Version,
 		store,
 	)
 	if cfg.MetricsToken != "" {
@@ -334,17 +337,22 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 					break
 				}
 
+				// Wrap each DB operation in a per-record timeout to prevent a
+				// single slow write from blocking the worker indefinitely.
+				opCtx, opCancel := context.WithTimeout(ctx, 30*time.Second)
+
 				// Resolve project from the slug stored in the spool record.
 				if record.ProjectSlug != "" {
-					proj, err := store.EnsureProject(ctx, record.ProjectSlug)
-					if err == nil {
+					proj, projErr := store.EnsureProject(opCtx, record.ProjectSlug)
+					if projErr == nil {
 						event.ProjectID = proj.ID
 					} else {
-						slog.Warn("worker ensure project", "slug", record.ProjectSlug, "err", err)
+						slog.Warn("worker ensure project", "slug", record.ProjectSlug, "err", projErr)
 					}
 				}
 
-				persistErr := worker.PersistEvent(ctx, store, event)
+				persistErr := worker.PersistEvent(opCtx, store, event)
+				opCancel()
 				if persistErr != nil {
 					retryCounts[record.IngestID]++
 					slog.Error("worker persist record",
@@ -376,6 +384,8 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 					slog.Error("worker write cursor", "err", err)
 				}
 			}
+
+			metrics.SpoolQueueDepth.Set(float64(len(entries)))
 
 			if err := spool.RotateIfExceedsPath(cfg.SpoolDir, workerRotateThreshold); err != nil {
 				slog.Error("worker rotate spool", "err", err)

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -62,7 +62,7 @@ func newTestServer(t *testing.T) (*Server, *repository.Store) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
-		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, store)
+		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, "test", store)
 	return srv, store
 }
 
@@ -79,7 +79,7 @@ func newAuthedServer(t *testing.T) (*Server, *repository.Store) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
-		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, store)
+		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, "test", store)
 	return srv, store
 }
 
@@ -148,6 +148,19 @@ func TestHandleHealth(t *testing.T) {
 	}
 }
 
+func TestHandleHealth_IncludesVersion(t *testing.T) {
+	srv, _ := newTestServer(t) // passes "test" as version
+	w := getJSON(t, srv, "/api/v1/health", nil)
+	if w.Code != http.StatusOK {
+		t.Errorf("health: expected 200, got %d", w.Code)
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["version"] == nil {
+		t.Error("health response missing version field")
+	}
+}
+
 // failPinger is a Pinger that always returns an error.
 type failPinger struct{ err error }
 
@@ -166,7 +179,7 @@ func TestHandleHealth_DBDown(t *testing.T) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
-		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, brokenPinger)
+		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, "test", brokenPinger)
 
 	w := getJSON(t, srv, "/api/v1/health", nil)
 	if w.Code != http.StatusServiceUnavailable {

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -24,7 +24,8 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
-		"status": "ok",
-		"time":   time.Now().UTC().Format(time.RFC3339),
+		"status":  "ok",
+		"time":    time.Now().UTC().Format(time.RFC3339),
+		"version": s.version,
 	})
 }

--- a/internal/api/security_test.go
+++ b/internal/api/security_test.go
@@ -78,6 +78,7 @@ func TestLoginRateLimit_Enforced(t *testing.T) {
 		service.NewSessionService(store), service.NewAPIKeyService(store),
 		userAuth, sm, nil, "secret", "http://localhost",
 		1, 1, // loginRatePerMinute=1, loginRateBurst=1
+		1000, 1000, "test",
 		store,
 	)
 
@@ -195,7 +196,7 @@ func TestCORS_AllowedOriginOnly(t *testing.T) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
-		ua, sm, []string{"https://allowed.example.com"}, "s", "", 1000, 1000, store)
+		ua, sm, []string{"https://allowed.example.com"}, "s", "", 1000, 1000, 1000, 1000, "test", store)
 
 	// Allowed origin gets ACAO header
 	req := httptest.NewRequest("GET", "/api/v1/health", nil)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -38,6 +38,7 @@ type Server struct {
 	sessionSecret  string
 	publicURL      string
 	metricsToken   string
+	version        string
 
 	loginLimiter  *rateLimiter
 	eventsLimiter *rateLimiter
@@ -60,6 +61,9 @@ func NewServer(
 	publicURL string,
 	loginRatePerMinute float64,
 	loginRateBurst float64,
+	ingestRatePerMinute float64,
+	ingestRateBurst float64,
+	version string,
 	db Pinger,
 ) *Server {
 	s := &Server{
@@ -77,8 +81,9 @@ func NewServer(
 		allowedOrigins: allowedOrigins,
 		sessionSecret:  sessionSecret,
 		publicURL:      publicURL,
+		version:        version,
 		loginLimiter:   newRateLimiter(loginRatePerMinute, loginRateBurst),
-		eventsLimiter:  newRateLimiter(500, 100),
+		eventsLimiter:  newRateLimiter(ingestRatePerMinute, ingestRateBurst),
 		apiLimiter:     newRateLimiter(300, 60),
 	}
 	s.registerRoutes()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,8 @@ type Config struct {
 	EventRetentionDays  int // 0 = disabled; default 90
 	LoginRatePerMinute  float64
 	LoginRateBurst      float64
+	IngestRatePerMinute float64 // default 500
+	IngestRateBurst     float64 // default 100
 	MetricsToken        string
 	LogLevel            slog.Level
 }
@@ -100,6 +102,20 @@ func Load() Config {
 	if raw := os.Getenv("FUNNELBARN_LOGIN_RATE_BURST"); raw != "" {
 		if parsed, err := strconv.ParseFloat(raw, 64); err == nil && parsed > 0 {
 			cfg.LoginRateBurst = parsed
+		}
+	}
+
+	// Ingest rate limit — default 500/min burst 100.
+	cfg.IngestRatePerMinute = 500
+	cfg.IngestRateBurst = 100
+	if raw := os.Getenv("FUNNELBARN_INGEST_RATE_PER_MINUTE"); raw != "" {
+		if parsed, err := strconv.ParseFloat(raw, 64); err == nil && parsed > 0 {
+			cfg.IngestRatePerMinute = parsed
+		}
+	}
+	if raw := os.Getenv("FUNNELBARN_INGEST_RATE_BURST"); raw != "" {
+		if parsed, err := strconv.ParseFloat(raw, 64); err == nil && parsed > 0 {
+			cfg.IngestRateBurst = parsed
 		}
 	}
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -44,4 +44,9 @@ var (
 		Name: "funnelbarn_events_purged_total",
 		Help: "Total old events deleted by the retention purge job.",
 	})
+
+	SpoolQueueDepth = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "funnelbarn_spool_queue_depth",
+		Help: "Approximate number of unprocessed events in the spool.",
+	})
 )


### PR DESCRIPTION
- `/health` includes `version` field (injected via ldflags at build time)
- `FUNNELBARN_INGEST_RATE_PER_MINUTE` / `FUNNELBARN_INGEST_RATE_BURST` configurable (default 500/100)
- Worker: each `PersistEvent` call has a 30s `context.WithTimeout` — a stuck DB write can't block the worker forever
- Metrics: `funnelbarn_spool_queue_depth` gauge updated after each processing batch