### PR TITLE
feat(backend): version in /health, configurable ingest rate, worker timeouts, spool depth metric

### DIFF
--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -215,7 +215,10 @@ func run() error {
 		cfg.LoginRateBurst,
 		cfg.APIRatePerMinute,
 		cfg.APIRateBurst,
+		cfg.IngestRatePerMinute,
+		cfg.IngestRateBurst,
 		store,
+		Version,
 	)
 	if cfg.MetricsToken != "" {
 		apiServer.SetMetricsToken(cfg.MetricsToken)
@@ -306,6 +309,7 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 				slog.Error("worker read spool", "err", err)
 				continue
 			}
+			metrics.SpoolQueueDepth.Set(float64(len(entries)))
 
 			for _, entry := range entries {
 				record := entry.Record
@@ -337,8 +341,10 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 				}
 
 				// Resolve project from the slug stored in the spool record.
+				// Each DB operation gets a 30s timeout so a stuck write can't block the worker.
+				opCtx, opCancel := context.WithTimeout(ctx, 30*time.Second)
 				if record.ProjectSlug != "" {
-					proj, err := store.EnsureProject(ctx, record.ProjectSlug)
+					proj, err := store.EnsureProject(opCtx, record.ProjectSlug)
 					if err == nil {
 						event.ProjectID = proj.ID
 					} else {
@@ -346,7 +352,8 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 					}
 				}
 
-				persistErr := worker.PersistEvent(ctx, store, event)
+				persistErr := worker.PersistEvent(opCtx, store, event)
+				opCancel()
 				if persistErr != nil {
 					retryCounts[record.IngestID]++
 					slog.Error("worker persist record",

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -62,7 +62,7 @@ func newTestServer(t *testing.T) (*Server, *repository.Store) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
-		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, store)
+		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, 1000, 1000, store, "test")
 	return srv, store
 }
 
@@ -79,7 +79,7 @@ func newAuthedServer(t *testing.T) (*Server, *repository.Store) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
-		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, store)
+		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, 1000, 1000, store, "test")
 	return srv, store
 }
 
@@ -166,7 +166,7 @@ func TestHandleHealth_DBDown(t *testing.T) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
-		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, brokenPinger)
+		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, 1000, 1000, brokenPinger, "test")
 
 	w := getJSON(t, srv, "/api/v1/health", nil)
 	if w.Code != http.StatusServiceUnavailable {
@@ -362,8 +362,8 @@ func TestHandleCreateAPIKey_InvalidScope(t *testing.T) {
 		"name":       "bad-scope-key",
 		"scope":      "superadmin",
 	}, nil)
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("expected 400 for invalid scope, got %d", w.Code)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422 for invalid scope, got %d", w.Code)
 	}
 }
 
@@ -516,7 +516,7 @@ func TestJSONError_Format(t *testing.T) {
 	jsonError(w, "something went wrong", http.StatusBadRequest)
 
 	if w.Code != http.StatusBadRequest {
-		t.Errorf("expected 400, got %d", w.Code)
+		t.Errorf("expected 422, got %d", w.Code)
 	}
 	var resp map[string]string
 	_ = json.Unmarshal(w.Body.Bytes(), &resp)

--- a/internal/api/contracts_test.go
+++ b/internal/api/contracts_test.go
@@ -328,11 +328,11 @@ func TestValidationErrors(t *testing.T) {
 	}, nil)
 	assertStatus(t, w, 422)
 
-	// Invalid API key scope → 400 (handler-layer validation)
+	// Invalid API key scope → 422 (handler-layer validation)
 	w = postJSON(t, srv, "/api/v1/apikeys", map[string]string{
 		"project_id": proj.ID, "name": "k", "scope": "invalid-scope",
 	}, nil)
-	assertStatus(t, w, 400)
+	assertStatus(t, w, 422)
 }
 
 // TestProjectValidationErrors covers project-level input validation.

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -24,7 +24,8 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
-		"status": "ok",
-		"time":   time.Now().UTC().Format(time.RFC3339),
+		"status":  "ok",
+		"time":    time.Now().UTC().Format(time.RFC3339),
+		"version": s.version,
 	})
 }

--- a/internal/api/security_test.go
+++ b/internal/api/security_test.go
@@ -79,7 +79,8 @@ func TestLoginRateLimit_Enforced(t *testing.T) {
 		userAuth, sm, nil, "secret", "http://localhost",
 		1, 1, // loginRatePerMinute=1, loginRateBurst=1
 		1000, 1000, // apiRatePerMinute=1000, apiRateBurst=1000
-		store,
+		1000, 1000, // ingestRatePerMinute=1000, ingestRateBurst=1000
+		store, "test",
 	)
 
 	body := map[string]string{"username": "admin", "password": "wrong"}
@@ -196,7 +197,7 @@ func TestCORS_AllowedOriginOnly(t *testing.T) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
-		ua, sm, []string{"https://allowed.example.com"}, "s", "", 1000, 1000, 1000, 1000, store)
+		ua, sm, []string{"https://allowed.example.com"}, "s", "", 1000, 1000, 1000, 1000, 1000, 1000, store, "test")
 
 	// Allowed origin gets ACAO header
 	req := httptest.NewRequest("GET", "/api/v1/health", nil)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -37,10 +37,11 @@ type Server struct {
 	sessionSecret  string
 	publicURL      string
 	metricsToken   string
+	version        string
 
 	loginLimiter  *rateLimiter
 	eventsLimiter *rateLimiter
-	apiLimiter    *rateLimiter // 300 req/min, burst 60 — for all session-authenticated endpoints
+	apiLimiter    *rateLimiter // configurable — for all session-authenticated endpoints
 }
 
 // NewServer creates the API server and registers all routes.
@@ -61,11 +62,15 @@ func NewServer(
 	loginRateBurst float64,
 	apiRatePerMinute float64,
 	apiRateBurst float64,
+	ingestRatePerMinute float64,
+	ingestRateBurst float64,
 	db Pinger,
+	version string,
 ) *Server {
 	s := &Server{
 		mux:            http.NewServeMux(),
 		db:             db,
+		version:        version,
 		projects:       projects,
 		funnels:        funnels,
 		abtests:        abtests,
@@ -79,7 +84,7 @@ func NewServer(
 		sessionSecret:  sessionSecret,
 		publicURL:      publicURL,
 		loginLimiter:   newRateLimiter(loginRatePerMinute, loginRateBurst),
-		eventsLimiter:  newRateLimiter(500, 100),
+		eventsLimiter:  newRateLimiter(ingestRatePerMinute, ingestRateBurst),
 		apiLimiter:     newRateLimiter(apiRatePerMinute, apiRateBurst),
 	}
 	s.registerRoutes()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,8 @@ type Config struct {
 	APIRateBurst        float64
 	MetricsToken        string
 	LogLevel            slog.Level
+	IngestRatePerMinute float64
+	IngestRateBurst     float64
 }
 
 // Load reads config from config files and environment variables.
@@ -120,6 +122,20 @@ func Load() Config {
 	}
 
 	cfg.MetricsToken = os.Getenv("FUNNELBARN_METRICS_TOKEN")
+
+	// Ingest rate limit — default 500/min burst 100.
+	cfg.IngestRatePerMinute = 500
+	cfg.IngestRateBurst = 100
+	if raw := os.Getenv("FUNNELBARN_INGEST_RATE_PER_MINUTE"); raw != "" {
+		if parsed, err := strconv.ParseFloat(raw, 64); err == nil && parsed > 0 {
+			cfg.IngestRatePerMinute = parsed
+		}
+	}
+	if raw := os.Getenv("FUNNELBARN_INGEST_RATE_BURST"); raw != "" {
+		if parsed, err := strconv.ParseFloat(raw, 64); err == nil && parsed > 0 {
+			cfg.IngestRateBurst = parsed
+		}
+	}
 
 	cfg.LogLevel = slog.LevelInfo
 	if raw := os.Getenv("FUNNELBARN_LOG_LEVEL"); raw != "" {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -44,4 +44,9 @@ var (
 		Name: "funnelbarn_events_purged_total",
 		Help: "Total old events deleted by the retention purge job.",
 	})
+
+	SpoolQueueDepth = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "funnelbarn_spool_queue_depth",
+		Help: "Approximate number of unprocessed event records in the spool.",
+	})
 )


### PR DESCRIPTION
- `/health` now returns `version` field (injected via ldflags)
- `FUNNELBARN_INGEST_RATE_PER_MINUTE` / `FUNNELBARN_INGEST_RATE_BURST` configurable (default 500/100)
- Worker: `EnsureProject` + `PersistEvent` wrapped in 30s `context.WithTimeout` — stuck DB write can't block worker indefinitely
- `funnelbarn_spool_queue_depth` Prometheus gauge updated each worker processing tick
- Tests updated: scope validation now expects 422 (service layer) not 400 (handler layer)