### PR TITLE
fix(lint): remove invalid eslint-disable for react/no-did-update-set-state

### DIFF
--- a/web/src/components/ui/ErrorBoundary.tsx
+++ b/web/src/components/ui/ErrorBoundary.tsx
@@ -23,9 +23,7 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidUpdate(_prevProps: Props, prevState: State) {
-    // After a pendingReset, clear the flag so children are rendered on the next update
     if (prevState.pendingReset && this.state.pendingReset && !this.state.hasError) {
-      // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ pendingReset: false })
     }
   }


### PR DESCRIPTION
## Summary

ESLint was failing in CI because `ErrorBoundary.tsx` referenced `react/no-did-update-set-state` in an `// eslint-disable-next-line` comment, but the `react` ESLint plugin is not installed — so ESLint errors on the unknown rule definition.

Removing the disable comment is safe: the inline `setState` inside `componentDidUpdate` is correct React pattern here (conditional reset), and TypeScript catches any real misuse.

## Test plan

- [ ] `npm run lint:eslint` produces 0 errors (5 pre-existing warnings remain, all `warn` level)
- [ ] CI quality-frontend goes green