### PR TITLE
fix(e2e): use --host-resolver-rules to route cluster IP (fixes ERR_INVALID_ARGUMENT)

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -9,24 +9,19 @@ export default async function globalSetup(config: FullConfig) {
 
   const clusterIP = process.env.E2E_CLUSTER_IP || ''
   const originalHostname = new URL(baseURL).hostname
-  const apiBaseURL = clusterIP
-    ? baseURL.replace(/^(https?:\/\/)[^/:]+/, `$1${clusterIP}`)
-    : baseURL
 
-  const browser = await chromium.launch()
+  // Use --host-resolver-rules to point the hostname at the cluster IP without
+  // touching the Host header (which is a restricted header Chromium refuses to set).
+  const browser = await chromium.launch({
+    args: clusterIP ? [`--host-resolver-rules=MAP ${originalHostname} ${clusterIP}`] : [],
+  })
   const context = await browser.newContext({
-    baseURL: apiBaseURL,
+    baseURL,
     ignoreHTTPSErrors: true,
-    extraHTTPHeaders: clusterIP ? { host: originalHostname } : {},
   })
   const page = await context.newPage()
 
-  // Navigate to login page and authenticate
-  const loginURL = clusterIP
-    ? apiBaseURL + '/login'
-    : baseURL + '/login'
-
-  await page.goto(loginURL)
+  await page.goto(baseURL + '/login')
   await page.getByLabel('Username').fill('wiebe')
   await page.getByLabel('Password').fill('wiebe')
   await page.getByRole('button', { name: /sign in/i }).click()

--- a/web/src/components/ui/ErrorBoundary.tsx
+++ b/web/src/components/ui/ErrorBoundary.tsx
@@ -23,9 +23,7 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidUpdate(_prevProps: Props, prevState: State) {
-    // After a pendingReset, clear the flag so children are rendered on the next update
     if (prevState.pendingReset && this.state.pendingReset && !this.state.hasError) {
-      // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ pendingReset: false })
     }
   }


### PR DESCRIPTION
## Problem

E2E global-setup was setting `extraHTTPHeaders: { host: originalHostname }` to route traffic to the k3s cluster IP while sending the correct `Host` header. The `host` header is a browser-restricted header — Playwright/Chromium refuses to set it via CDP, raising `ERR_INVALID_ARGUMENT` before the page load even starts.

## Fix

Use Chromium's `--host-resolver-rules=MAP <hostname> <clusterIP>` launch arg. This routes DNS at the browser level — the URL stays as the real hostname, the Host header is set correctly automatically, and `ignoreHTTPSErrors: true` handles the cert mismatch.

## Test plan

- [ ] E2E job completes without ERR_INVALID_ARGUMENT
- [ ] Login flow succeeds and e2e/.auth/user.json is written