### PR TITLE
fix(sdk): add missing tsconfig configs and fix Python build backend

### DIFF
--- a/sdks/js/tsconfig.cjs.json
+++ b/sdks/js/tsconfig.cjs.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "outDir": "./dist/cjs",
+    "declaration": false,
+    "declarationMap": false
+  },
+  "include": ["src/index.ts"]
+}

--- a/sdks/js/tsconfig.esm.json
+++ b/sdks/js/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ES2020",
+    "moduleResolution": "bundler",
+    "outDir": "./dist/esm"
+  },
+  "include": ["src/index.ts"]
+}

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=68", "wheel"]
-build-backend = "setuptools.backends.legacy:build"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "funnelbarn"


### PR DESCRIPTION
## Problem

PR #44 (SDK publishing) broke the Binary Release workflow:
- `publish-npm`: `tsconfig.esm.json` and `tsconfig.cjs.json` were missing — the build script references them but they weren't in the repo
- `publish-pypi`: `setuptools.backends.legacy:build` is not a valid build backend in the isolated environment — should be `setuptools.build_meta`

## Fix

- Add `sdks/js/tsconfig.esm.json` (module: ES2020, out: dist/esm)
- Add `sdks/js/tsconfig.cjs.json` (module: CommonJS, out: dist/cjs)
- Fix `sdks/python/pyproject.toml`: `build-backend = "setuptools.build_meta"`

Verified all three JS targets (`build:esm`, `build:cjs`, `build:iife`) compile locally.