### PR TITLE
fix(ci): skip npm/PyPI publish when secrets not configured; add missing tsconfig files

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -58,6 +58,7 @@ jobs:
 
   publish-npm:
     needs: [tag]
+    if: ${{ secrets.NPM_TOKEN != '' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -77,6 +78,7 @@ jobs:
 
   publish-pypi:
     needs: [tag]
+    if: ${{ secrets.PYPI_TOKEN != '' }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/sdks/js/tsconfig.cjs.json
+++ b/sdks/js/tsconfig.cjs.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "outDir": "./dist/cjs",
+    "declaration": false,
+    "declarationMap": false
+  },
+  "include": ["src/index.ts"]
+}

--- a/sdks/js/tsconfig.esm.json
+++ b/sdks/js/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ES2020",
+    "moduleResolution": "bundler",
+    "outDir": "./dist/esm"
+  },
+  "include": ["src/index.ts"]
+}

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=68", "wheel"]
-build-backend = "setuptools.backends.legacy:build"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "funnelbarn"


### PR DESCRIPTION
## Summary

Two fixes for the Binary Release workflow introduced in PR #44:

**1. Missing tsconfig files** (build fix)
- Add `sdks/js/tsconfig.esm.json` and `sdks/js/tsconfig.cjs.json`
- `npm run build` was failing because `build:esm` and `build:cjs` scripts referenced these missing files
- Fix Python build backend: `setuptools.backends.legacy:build` → `setuptools.build_meta`

**2. Skip publish when secrets absent** (CI fix)
- Add `if: secrets.NPM_TOKEN != ''` guard to `publish-npm` job
- Add `if: secrets.PYPI_TOKEN != ''` guard to `publish-pypi` job
- Without these secrets, the job runs and fails with 403 — now it's skipped cleanly

Secrets can be added later when ready to publish to npm/PyPI registries.