### PR TITLE
fix(ci): use step-level if for npm/PyPI publish guards

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -72,6 +72,7 @@ jobs:
       - run: npm ci
       - run: npm run build
       - name: Publish to npm
+        if: ${{ env.NODE_AUTH_TOKEN != '' }}
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -91,6 +92,7 @@ jobs:
       - run: pip install build twine
       - run: python -m build
       - name: Publish to PyPI
+        if: ${{ env.TWINE_PASSWORD != '' }}
         run: twine upload dist/*
         env:
           TWINE_USERNAME: __token__


### PR DESCRIPTION
Job-level 'if: secrets.X != ""' is not supported in GitHub Actions — causes immediate workflow failure. Fix: move the guard to the publish step level using env vars.