### PR TITLE
fix(ci): valid publish guards for npm/PyPI without secrets in job-level if

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -58,8 +58,9 @@ jobs:
 
   publish-npm:
     needs: [tag]
-    if: ${{ secrets.NPM_TOKEN != '' }}
     runs-on: ubuntu-latest
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     defaults:
       run:
         working-directory: sdks/js
@@ -72,15 +73,16 @@ jobs:
       - run: npm ci
       - run: npm run build
       - name: Publish to npm
-        if: ${{ env.NODE_AUTH_TOKEN != '' }}
+        if: env.NPM_TOKEN != ''
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-pypi:
     needs: [tag]
-    if: ${{ secrets.PYPI_TOKEN != '' }}
     runs-on: ubuntu-latest
+    env:
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
     defaults:
       run:
         working-directory: sdks/python
@@ -92,7 +94,7 @@ jobs:
       - run: pip install build twine
       - run: python -m build
       - name: Publish to PyPI
-        if: ${{ env.TWINE_PASSWORD != '' }}
+        if: env.PYPI_TOKEN != ''
         run: twine upload dist/*
         env:
           TWINE_USERNAME: __token__


### PR DESCRIPTION
Job-level 'if: secrets.X' is not valid GitHub Actions syntax and causes immediate workflow parse failure. Fixed by: (1) removing job-level if conditions, (2) defining NPM_TOKEN/PYPI_TOKEN in the job env block, (3) using 'if: env.X != ""' at step level (job env IS accessible in step if conditions).