### PR TITLE
fix(ci): pin golangci-lint to v2.1.6 for Go 1.25 compatibility

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v2.1.6
           args: --timeout=5m ./...
 
   frontend-lint:


### PR DESCRIPTION
golangci-lint `latest` resolved to v1.64.8 which was built with Go 1.24 and refuses to lint Go 1.25 code. Pin to v2.1.6 which supports Go 1.25.