### PR TITLE
fix(ci): upgrade to golangci-lint-action@v7 + v2.1.6 for Go 1.25

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -91,7 +91,7 @@ jobs:
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.1.6
           args: --timeout=5m ./...


### PR DESCRIPTION
golangci-lint-action@v6 doesn't support v2.x versions. Upgrade to action v7 which does, and pin golangci-lint to v2.1.6 which supports Go 1.25.