### PR TITLE
fix(ci): upgrade golangci-lint-action to v7

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -91,7 +91,7 @@ jobs:
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.1.6
           args: --timeout=5m ./...


### PR DESCRIPTION
golangci-lint-action v6 does not support golangci-lint v2.x. Upgrade action to v7.