### PR TITLE
fix(ci): use golangci-lint v2.11.4 (built with Go 1.25)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v2.1.6
+          version: v2.11.4
           args: --timeout=5m ./...
 
   frontend-lint:


### PR DESCRIPTION
v2.1.6 was compiled with Go 1.24 and refuses to lint Go 1.25 code. v2.11.4 (Mar 2026) should have been compiled with Go 1.25.