### PR TITLE
fix(ci): use latest golangci-lint for Go 1.25 compatibility

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.1.6
+          version: latest
           args: --timeout=5m ./...
 
   frontend-lint:


### PR DESCRIPTION
golangci-lint v2.1.6 was built with Go 1.24, incompatible with project Go 1.25. Use 'latest' to always get a Go-1.25-compatible build.