### PR TITLE
fix(ci): migrate golangci-lint config to v2.x schema

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,13 +10,15 @@ linters:
     - ineffassign
     - goimports
     - misspell
-linters-settings:
-  goimports:
-    local-prefixes: github.com/wiebe-xyz/funnelbarn
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/wiebe-xyz/funnelbarn
 issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - errcheck
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - errcheck
   max-issues-per-linter: 0
   max-same-issues: 0


### PR DESCRIPTION
golangci-lint v2.x renamed linters-settings→linters.settings and issues.exclude-rules→issues.exclusions.rules.