### PR TITLE
fix(dashboard): blank black screen when no projects exist

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,7 +2,6 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { ReactNode, useState } from 'react'
 import { AuthProvider, useAuth } from './lib/auth'
 import { ProjectProvider, useProjects } from './lib/projects'
-import Shell from './components/shell/Shell'
 import Landing from './pages/Landing'
 import Login from './pages/Login'
 import Dashboard from './pages/Dashboard'
@@ -80,12 +79,31 @@ function RootRedirect() {
 function DefaultProjectRoute({ base }: { base: string }) {
   const { projects, isLoading, defaultProjectId } = useProjects()
 
-  if (isLoading || projects.length === 0) {
+  if (isLoading) {
     return (
-      <Shell>
-        <div />
-      </Shell>
+      <div style={{
+        minHeight: '100vh',
+        background: '#0f1117',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}>
+        <div style={{
+          width: 32,
+          height: 32,
+          border: '3px solid #2a2d3a',
+          borderTopColor: '#f59e0b',
+          borderRadius: '50%',
+          animation: 'spin 0.7s linear infinite',
+        }} />
+        <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+      </div>
     )
+  }
+
+  if (projects.length === 0) {
+    // No projects yet — render Dashboard which handles the empty/create-project state
+    return <Dashboard />
   }
 
   const target =


### PR DESCRIPTION
Supersedes #62 (rebased on current main).

**Root cause:** `DefaultProjectRoute` merged loading and empty-list states into one branch that rendered an invisible empty div — permanent black screen for any user with no project selected.

**Fix:**
- `isLoading` → amber spinner (matches existing loading UX)
- `projects.length === 0` after load → renders `<Dashboard />` without a projectId, which already has a complete empty state ("No project selected", activity icon, "Create a project" button)

All 43 frontend unit tests pass, TypeScript clean.