### PR TITLE
fix(ci): increase rollout timeout to 360s for large image pulls

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -198,8 +198,8 @@ jobs:
               funnelbarn=${SERVICE_IMAGE}:${{ github.sha }}
             kubectl -n ${NAMESPACE} set image deployment/funnelbarn-web \
               funnelbarn-web=${WEB_IMAGE}:${{ github.sha }}
-            kubectl -n ${NAMESPACE} rollout status deployment/funnelbarn --timeout=180s
-            kubectl -n ${NAMESPACE} rollout status deployment/funnelbarn-web --timeout=180s
+            kubectl -n ${NAMESPACE} rollout status deployment/funnelbarn --timeout=360s
+            kubectl -n ${NAMESPACE} rollout status deployment/funnelbarn-web --timeout=360s
           "
 
       - name: Post release marker to BugBarn
@@ -279,8 +279,8 @@ jobs:
               funnelbarn=${SERVICE_IMAGE}:${{ github.sha }}
             kubectl -n ${NAMESPACE} set image deployment/funnelbarn-web \
               funnelbarn-web=${WEB_IMAGE}:${{ github.sha }}
-            kubectl -n ${NAMESPACE} rollout status deployment/funnelbarn --timeout=180s
-            kubectl -n ${NAMESPACE} rollout status deployment/funnelbarn-web --timeout=180s
+            kubectl -n ${NAMESPACE} rollout status deployment/funnelbarn --timeout=360s
+            kubectl -n ${NAMESPACE} rollout status deployment/funnelbarn-web --timeout=360s
           "
 
       - name: Post release marker to BugBarn


### PR DESCRIPTION
Image pull from GHCR took 2m32s, exceeding the 180s rollout timeout. Doubled to 360s.