### PR TITLE
feat(api): runtime client-config endpoint for BugBarn frontend reporting

### DIFF
--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -185,6 +185,8 @@ func run() error {
 		cfg.IngestRateBurst,
 		store,
 		Version,
+		cfg.SelfEndpoint,
+		cfg.SelfAPIKey,
 	)
 	if cfg.MetricsToken != "" {
 		apiServer.SetMetricsToken(cfg.MetricsToken)

--- a/internal/api/client_config.go
+++ b/internal/api/client_config.go
@@ -1,0 +1,16 @@
+package api
+
+import "net/http"
+
+// handleClientConfig returns public client-side configuration for the frontend.
+// No auth required — values are safe to expose (ingest keys are public by design).
+func (s *Server) handleClientConfig(w http.ResponseWriter, r *http.Request) {
+	type response struct {
+		BugbarnEndpoint  string `json:"bugbarn_endpoint"`
+		BugbarnIngestKey string `json:"bugbarn_ingest_key"`
+	}
+	s.writeJSON(w, http.StatusOK, response{
+		BugbarnEndpoint:  s.bugbarnEndpoint,
+		BugbarnIngestKey: s.bugbarnIngestKey,
+	})
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -33,11 +33,13 @@ type Server struct {
 	ingest         *ingest.Handler
 	userAuth       *auth.UserAuthenticator
 	sessionManager *auth.SessionManager
-	allowedOrigins []string
-	sessionSecret  string
-	publicURL      string
-	metricsToken   string
-	version        string
+	allowedOrigins     []string
+	sessionSecret      string
+	publicURL          string
+	metricsToken       string
+	version            string
+	bugbarnEndpoint    string
+	bugbarnIngestKey   string
 
 	loginLimiter  *rateLimiter
 	eventsLimiter *rateLimiter
@@ -66,26 +68,30 @@ func NewServer(
 	ingestRateBurst float64,
 	db Pinger,
 	version string,
+	bugbarnEndpoint string,
+	bugbarnIngestKey string,
 ) *Server {
 	s := &Server{
-		mux:            http.NewServeMux(),
-		db:             db,
-		version:        version,
-		projects:       projects,
-		funnels:        funnels,
-		abtests:        abtests,
-		events:         events,
-		sessions:       sessions,
-		apikeys:        apikeys,
-		ingest:         ingestHandler,
-		userAuth:       userAuth,
-		sessionManager: sessionManager,
-		allowedOrigins: allowedOrigins,
-		sessionSecret:  sessionSecret,
-		publicURL:      publicURL,
-		loginLimiter:   newRateLimiter(loginRatePerMinute, loginRateBurst),
-		eventsLimiter:  newRateLimiter(ingestRatePerMinute, ingestRateBurst),
-		apiLimiter:     newRateLimiter(apiRatePerMinute, apiRateBurst),
+		mux:              http.NewServeMux(),
+		db:               db,
+		version:          version,
+		projects:         projects,
+		funnels:          funnels,
+		abtests:          abtests,
+		events:           events,
+		sessions:         sessions,
+		apikeys:          apikeys,
+		ingest:           ingestHandler,
+		userAuth:         userAuth,
+		sessionManager:   sessionManager,
+		allowedOrigins:   allowedOrigins,
+		sessionSecret:    sessionSecret,
+		publicURL:        publicURL,
+		bugbarnEndpoint:  bugbarnEndpoint,
+		bugbarnIngestKey: bugbarnIngestKey,
+		loginLimiter:     newRateLimiter(loginRatePerMinute, loginRateBurst),
+		eventsLimiter:    newRateLimiter(ingestRatePerMinute, ingestRateBurst),
+		apiLimiter:       newRateLimiter(apiRatePerMinute, apiRateBurst),
 	}
 	s.registerRoutes()
 	return s
@@ -98,6 +104,7 @@ func (s *Server) registerRoutes() {
 	// Public
 	s.mux.HandleFunc("GET /api/v1/health", s.handleHealth)
 	s.mux.HandleFunc("GET /api/v1/setup/{slug}", s.handleSetup)
+	s.mux.HandleFunc("GET /api/v1/client-config", s.handleClientConfig)
 
 	// Ingest (API key required)
 	s.mux.Handle("POST /api/v1/events", s.eventsLimiter.middleware(s.ingest))

--- a/web/src/lib/bugbarn.ts
+++ b/web/src/lib/bugbarn.ts
@@ -1,50 +1,58 @@
 // BugBarn error reporting utility.
-// Reads VITE_BUGBARN_ENDPOINT and VITE_BUGBARN_INGEST_KEY at build time.
-// Falls back to console.error only when env vars are not configured.
+// Config is fetched from /api/v1/client-config at runtime so the Docker image
+// is environment-agnostic. Falls back to console.error only when unconfigured.
 
-const endpoint = import.meta.env.VITE_BUGBARN_ENDPOINT as string | undefined
-const ingestKey = import.meta.env.VITE_BUGBARN_INGEST_KEY as string | undefined
+interface ClientConfig {
+  bugbarn_endpoint: string
+  bugbarn_ingest_key: string
+}
 
-const configured = Boolean(endpoint && ingestKey)
+let endpoint = ''
+let ingestKey = ''
+let initialized = false
+
+async function loadConfig(): Promise<void> {
+  if (initialized) return
+  initialized = true
+  try {
+    const res = await fetch('/api/v1/client-config')
+    if (!res.ok) return
+    const cfg: ClientConfig = await res.json()
+    endpoint = cfg.bugbarn_endpoint ?? ''
+    ingestKey = cfg.bugbarn_ingest_key ?? ''
+  } catch {
+    // Config fetch failed — reporting falls back to console.error.
+  }
+}
+
+// Kick off config fetch immediately so it's ready before the first error.
+loadConfig()
 
 export interface BugBarnPayload {
   name: string
   properties: Record<string, unknown>
 }
 
-/**
- * Report an error to BugBarn. If the env vars are not set, falls back to
- * console.error so local development is unaffected.
- */
 export function reportToBugBarn(payload: BugBarnPayload): void {
-  if (!configured) {
+  if (!endpoint || !ingestKey) {
     console.error('[BugBarn not configured]', payload.name, payload.properties)
     return
   }
-
-  // Fire-and-forget: never let reporting itself throw.
   try {
     fetch(`${endpoint}/api/v1/ingest`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'X-BugBarn-Api-Key': ingestKey!,
+        'X-BugBarn-Api-Key': ingestKey,
       },
       body: JSON.stringify(payload),
-      // keepalive so the request survives page unload (e.g. for onerror)
       keepalive: true,
-    }).catch(() => {
-      // Silently swallow — we must never throw from error reporting.
-    })
+    }).catch(() => {})
   } catch {
-    // Defensive: JSON.stringify can theoretically throw for circular refs.
+    // Never throw from error reporting.
   }
 }
 
-/**
- * Convenience wrapper that extracts message and stack from an Error (or any
- * thrown value) and sends it to BugBarn.
- */
 export function reportError(
   error: unknown,
   context: Record<string, unknown> = {},
@@ -56,7 +64,7 @@ export function reportError(
     properties: {
       message,
       stack,
-      url: window.location.href,
+      url: typeof window !== 'undefined' ? window.location.href : '',
       ...context,
     },
   })


### PR DESCRIPTION
Instead of baking VITE_ env vars into the JS bundle, the frontend fetches `/api/v1/client-config` at startup and initialises BugBarn error reporting from the response. The backend reuses `FUNNELBARN_SELF_ENDPOINT` and `FUNNELBARN_SELF_API_KEY` that are already in the production secret.