### PR TITLE
fix(api): update NewServer test calls for new bugbarn params

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -62,7 +62,7 @@ func newTestServer(t *testing.T) (*Server, *repository.Store) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
-		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, 1000, 1000, store, "test")
+		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, 1000, 1000, store, "test", "", "")
 	return srv, store
 }
 
@@ -79,7 +79,7 @@ func newAuthedServer(t *testing.T) (*Server, *repository.Store) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
-		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, 1000, 1000, store, "test")
+		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, 1000, 1000, store, "test", "", "")
 	return srv, store
 }
 
@@ -166,7 +166,7 @@ func TestHandleHealth_DBDown(t *testing.T) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
-		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, 1000, 1000, brokenPinger, "test")
+		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, 1000, 1000, brokenPinger, "test", "", "")
 
 	w := getJSON(t, srv, "/api/v1/health", nil)
 	if w.Code != http.StatusServiceUnavailable {

--- a/internal/api/client_config.go
+++ b/internal/api/client_config.go
@@ -9,7 +9,7 @@ func (s *Server) handleClientConfig(w http.ResponseWriter, r *http.Request) {
 		BugbarnEndpoint  string `json:"bugbarn_endpoint"`
 		BugbarnIngestKey string `json:"bugbarn_ingest_key"`
 	}
-	s.writeJSON(w, http.StatusOK, response{
+	writeJSON(w, http.StatusOK, response{
 		BugbarnEndpoint:  s.bugbarnEndpoint,
 		BugbarnIngestKey: s.bugbarnIngestKey,
 	})


### PR DESCRIPTION
Two empty strings for bugbarnEndpoint and bugbarnIngestKey in all NewServer test invocations.