### PR TITLE
feat: dogfood FunnelBarn analytics and improve observability

### DIFF
--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -149,6 +149,9 @@ func run() error {
 	if selfReporting {
 		slog.Info("self-reporting enabled", "endpoint", cfg.SelfEndpoint)
 	}
+	if cfg.DogfoodAPIKey != "" {
+		slog.Info("dogfood analytics enabled", "project", cfg.DogfoodProject)
+	}
 
 	go runBackgroundWorker(ctx, cfg, store)
 
@@ -187,6 +190,8 @@ func run() error {
 		Version,
 		cfg.SelfEndpoint,
 		cfg.SelfAPIKey,
+		cfg.DogfoodAPIKey,
+		cfg.DogfoodProject,
 	)
 	if cfg.MetricsToken != "" {
 		apiServer.SetMetricsToken(cfg.MetricsToken)

--- a/deploy/k8s/production/deployment.yaml
+++ b/deploy/k8s/production/deployment.yaml
@@ -84,6 +84,14 @@ spec:
                   name: funnelbarn-secrets
                   key: FUNNELBARN_ENVIRONMENT
                   optional: true
+            - name: FUNNELBARN_DOGFOOD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_DOGFOOD_API_KEY
+                  optional: true
+            - name: FUNNELBARN_DOGFOOD_PROJECT
+              value: funnelbarn
             - name: LITESTREAM_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/deploy/k8s/staging/deployment.yaml
+++ b/deploy/k8s/staging/deployment.yaml
@@ -78,6 +78,14 @@ spec:
                   name: funnelbarn-secrets
                   key: FUNNELBARN_ENVIRONMENT
                   optional: true
+            - name: FUNNELBARN_DOGFOOD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_DOGFOOD_API_KEY
+                  optional: true
+            - name: FUNNELBARN_DOGFOOD_PROJECT
+              value: funnelbarn
           resources:
             requests:
               cpu: 100m

--- a/internal/api/abtests.go
+++ b/internal/api/abtests.go
@@ -80,7 +80,7 @@ func (s *Server) handleCreateABTest(w http.ResponseWriter, r *http.Request) {
 		mapServiceError(w, err, "handleCreateABTest")
 		return
 	}
-	slog.DebugContext(r.Context(), "ab test created", "test_id", test.ID, "project_id", projectID, "request_id", RequestIDFromContext(r.Context()))
+	slog.InfoContext(r.Context(), "ab test created", "test_id", test.ID, "project_id", projectID, "request_id", RequestIDFromContext(r.Context()))
 	writeJSON(w, http.StatusCreated, test)
 }
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -62,7 +62,7 @@ func newTestServer(t *testing.T) (*Server, *repository.Store) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
-		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, 1000, 1000, store, "test", "", "")
+		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, 1000, 1000, store, "test", "", "", "", "")
 	return srv, store
 }
 
@@ -79,7 +79,7 @@ func newAuthedServer(t *testing.T) (*Server, *repository.Store) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
-		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, 1000, 1000, store, "test", "", "")
+		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, 1000, 1000, store, "test", "", "", "", "")
 	return srv, store
 }
 
@@ -166,7 +166,7 @@ func TestHandleHealth_DBDown(t *testing.T) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
-		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, 1000, 1000, brokenPinger, "test", "", "")
+		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, 1000, 1000, brokenPinger, "test", "", "", "", "")
 
 	w := getJSON(t, srv, "/api/v1/health", nil)
 	if w.Code != http.StatusServiceUnavailable {

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -30,6 +30,7 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 	// Try env-var user auth.
 	if s.userAuth.Enabled() {
 		if !s.userAuth.Valid(body.Username, body.Password) {
+			slog.WarnContext(r.Context(), "login failed", "username", body.Username, "reason", "invalid_credentials", "request_id", RequestIDFromContext(r.Context()))
 			jsonError(w, "invalid credentials", http.StatusUnauthorized)
 			return
 		}
@@ -37,10 +38,12 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 		// Fall back to DB user.
 		user, err := s.projects.UserByUsername(r.Context(), body.Username)
 		if err != nil {
+			slog.WarnContext(r.Context(), "login failed", "username", body.Username, "reason", "user_not_found", "request_id", RequestIDFromContext(r.Context()))
 			jsonError(w, "invalid credentials", http.StatusUnauthorized)
 			return
 		}
 		if bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(body.Password)) != nil {
+			slog.WarnContext(r.Context(), "login failed", "username", body.Username, "reason", "wrong_password", "request_id", RequestIDFromContext(r.Context()))
 			jsonError(w, "invalid credentials", http.StatusUnauthorized)
 			return
 		}
@@ -58,7 +61,7 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 	http.SetCookie(w, auth.SessionCookie(token, expires, secure))
 	http.SetCookie(w, auth.CSRFCookie(token, expires, secure))
 
-	slog.DebugContext(r.Context(), "user login", "username", body.Username, "request_id", RequestIDFromContext(r.Context()))
+	slog.InfoContext(r.Context(), "user login", "username", body.Username, "request_id", RequestIDFromContext(r.Context()))
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"username": body.Username,
@@ -133,7 +136,7 @@ func (s *Server) handleCreateProject(w http.ResponseWriter, r *http.Request) {
 		mapServiceError(w, err, "handleCreateProject")
 		return
 	}
-	slog.DebugContext(r.Context(), "project created", "project_id", project.ID, "request_id", RequestIDFromContext(r.Context()))
+	slog.InfoContext(r.Context(), "project created", "project_id", project.ID, "name", body.Name, "request_id", RequestIDFromContext(r.Context()))
 	writeJSON(w, http.StatusCreated, project)
 }
 
@@ -240,6 +243,7 @@ func (s *Server) handleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 		Scope     string `json:"scope"`
 		CreatedAt string `json:"created_at"`
 	}
+	slog.InfoContext(r.Context(), "api key created", "key_id", key.ID, "name", body.Name, "scope", body.Scope, "project_id", body.ProjectID, "request_id", RequestIDFromContext(r.Context()))
 	writeJSON(w, http.StatusCreated, map[string]any{
 		"api_key": safeKey{
 			ID:        key.ID,
@@ -262,6 +266,7 @@ func (s *Server) handleDeleteAPIKey(w http.ResponseWriter, r *http.Request) {
 		mapServiceError(w, err, "handleDeleteAPIKey")
 		return
 	}
+	slog.InfoContext(r.Context(), "api key deleted", "key_id", keyID, "request_id", RequestIDFromContext(r.Context()))
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/api/client_config.go
+++ b/internal/api/client_config.go
@@ -6,11 +6,17 @@ import "net/http"
 // No auth required — values are safe to expose (ingest keys are public by design).
 func (s *Server) handleClientConfig(w http.ResponseWriter, r *http.Request) {
 	type response struct {
-		BugbarnEndpoint  string `json:"bugbarn_endpoint"`
-		BugbarnIngestKey string `json:"bugbarn_ingest_key"`
+		BugbarnEndpoint    string `json:"bugbarn_endpoint"`
+		BugbarnIngestKey   string `json:"bugbarn_ingest_key"`
+		FunnelbarnEndpoint string `json:"funnelbarn_endpoint,omitempty"`
+		FunnelbarnAPIKey   string `json:"funnelbarn_api_key,omitempty"`
+		FunnelbarnProject  string `json:"funnelbarn_project,omitempty"`
 	}
 	writeJSON(w, http.StatusOK, response{
-		BugbarnEndpoint:  s.bugbarnEndpoint,
-		BugbarnIngestKey: s.bugbarnIngestKey,
+		BugbarnEndpoint:    s.bugbarnEndpoint,
+		BugbarnIngestKey:   s.bugbarnIngestKey,
+		FunnelbarnEndpoint: s.publicURL,
+		FunnelbarnAPIKey:   s.dogfoodAPIKey,
+		FunnelbarnProject:  s.dogfoodProject,
 	})
 }

--- a/internal/api/funnels.go
+++ b/internal/api/funnels.go
@@ -88,6 +88,7 @@ func (s *Server) handleDeleteFunnel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	slog.InfoContext(r.Context(), "funnel deleted", "funnel_id", funnelID, "project_id", projectID, "request_id", RequestIDFromContext(r.Context()))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -142,7 +143,7 @@ func (s *Server) handleCreateFunnel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.DebugContext(r.Context(), "funnel created", "funnel_id", created.ID, "project_id", projectID, "request_id", RequestIDFromContext(r.Context()))
+	slog.InfoContext(r.Context(), "funnel created", "funnel_id", created.ID, "project_id", projectID, "request_id", RequestIDFromContext(r.Context()))
 	writeJSON(w, http.StatusCreated, created)
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -40,6 +40,8 @@ type Server struct {
 	version            string
 	bugbarnEndpoint    string
 	bugbarnIngestKey   string
+	dogfoodAPIKey      string
+	dogfoodProject     string
 
 	loginLimiter  *rateLimiter
 	eventsLimiter *rateLimiter
@@ -70,6 +72,8 @@ func NewServer(
 	version string,
 	bugbarnEndpoint string,
 	bugbarnIngestKey string,
+	dogfoodAPIKey string,
+	dogfoodProject string,
 ) *Server {
 	s := &Server{
 		mux:              http.NewServeMux(),
@@ -89,6 +93,8 @@ func NewServer(
 		publicURL:        publicURL,
 		bugbarnEndpoint:  bugbarnEndpoint,
 		bugbarnIngestKey: bugbarnIngestKey,
+		dogfoodAPIKey:    dogfoodAPIKey,
+		dogfoodProject:   dogfoodProject,
 		loginLimiter:     newRateLimiter(loginRatePerMinute, loginRateBurst),
 		eventsLimiter:    newRateLimiter(ingestRatePerMinute, ingestRateBurst),
 		apiLimiter:       newRateLimiter(apiRatePerMinute, apiRateBurst),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,8 @@ type Config struct {
 	SelfEndpoint        string
 	SelfAPIKey          string
 	SelfEnvironment     string
+	DogfoodAPIKey       string
+	DogfoodProject      string
 	EventRetentionDays  int // 0 = disabled; default 90
 	LoginRatePerMinute  float64
 	LoginRateBurst      float64
@@ -61,6 +63,8 @@ func Load() Config {
 		SelfEndpoint:        os.Getenv("FUNNELBARN_SELF_ENDPOINT"),
 		SelfAPIKey:          os.Getenv("FUNNELBARN_SELF_API_KEY"),
 		SelfEnvironment:     getenv("FUNNELBARN_ENVIRONMENT", "production"),
+		DogfoodAPIKey:       os.Getenv("FUNNELBARN_DOGFOOD_API_KEY"),
+		DogfoodProject:      getenv("FUNNELBARN_DOGFOOD_PROJECT", "funnelbarn"),
 	}
 
 	if raw := os.Getenv("FUNNELBARN_ALLOWED_ORIGINS"); raw != "" {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
-import { ReactNode, useState } from 'react'
+import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom'
+import { ReactNode, useEffect, useState } from 'react'
 import { AuthProvider, useAuth } from './lib/auth'
 import { ProjectProvider, useProjects } from './lib/projects'
 import Landing from './pages/Landing'
@@ -11,6 +11,7 @@ import Settings from './pages/Settings'
 import ABTests from './pages/ABTests'
 import FirstRunWizard from './components/wizards/FirstRunWizard'
 import { ErrorBoundary } from './components/ui/ErrorBoundary'
+import { trackPageView } from './lib/analytics'
 
 function ProtectedRoute({ children }: { children: ReactNode }) {
   const { user, isLoading } = useAuth()
@@ -114,6 +115,14 @@ function DefaultProjectRoute({ base }: { base: string }) {
   return <Navigate to={`${base}/${target}`} replace />
 }
 
+function PageTracker() {
+  const location = useLocation()
+  useEffect(() => {
+    trackPageView()
+  }, [location.pathname])
+  return null
+}
+
 function AppRoutes() {
   const { user } = useAuth()
   const { refetch } = useProjects()
@@ -124,6 +133,7 @@ function AppRoutes() {
 
   return (
     <>
+      <PageTracker />
       {showWizard && (
         <FirstRunWizard onComplete={() => { refetch(); setWizardDismissed(true) }} />
       )}

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -1,0 +1,104 @@
+// Self-tracking analytics for dogfooding FunnelBarn.
+// Config is fetched from /api/v1/client-config at runtime.
+// Falls back to no-op when unconfigured.
+
+let endpoint = ''
+let apiKey = ''
+let projectName = ''
+let initialized = false
+
+const SESSION_KEY = 'funnelbarn_dogfood_sid'
+const SESSION_EXPIRY_KEY = 'funnelbarn_dogfood_sid_exp'
+const SESSION_TIMEOUT = 30 * 60 * 1000
+
+async function loadConfig(): Promise<void> {
+  if (initialized) return
+  initialized = true
+  try {
+    const res = await fetch('/api/v1/client-config')
+    if (!res.ok) return
+    const cfg = await res.json()
+    endpoint = cfg.funnelbarn_endpoint ?? ''
+    apiKey = cfg.funnelbarn_api_key ?? ''
+    projectName = cfg.funnelbarn_project ?? ''
+  } catch {
+    // Config fetch failed — tracking disabled.
+  }
+}
+
+loadConfig()
+
+function getSessionId(): string {
+  try {
+    const now = Date.now()
+    const expiry = parseInt(localStorage.getItem(SESSION_EXPIRY_KEY) ?? '0', 10)
+    if (now < expiry) {
+      localStorage.setItem(SESSION_EXPIRY_KEY, String(now + SESSION_TIMEOUT))
+      return localStorage.getItem(SESSION_KEY) ?? newSessionId()
+    }
+    const id = newSessionId()
+    localStorage.setItem(SESSION_KEY, id)
+    localStorage.setItem(SESSION_EXPIRY_KEY, String(now + SESSION_TIMEOUT))
+    return id
+  } catch {
+    return ''
+  }
+}
+
+function newSessionId(): string {
+  const bytes = new Uint8Array(16)
+  crypto.getRandomValues(bytes)
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+function extractUTMs(): Record<string, string> {
+  const params = new URLSearchParams(window.location.search)
+  const utms: Record<string, string> = {}
+  for (const key of ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content']) {
+    const val = params.get(key)
+    if (val) utms[key] = val
+  }
+  return utms
+}
+
+function send(name: string, properties?: Record<string, unknown>): void {
+  if (!endpoint || !apiKey) return
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'x-funnelbarn-api-key': apiKey,
+  }
+  if (projectName) {
+    headers['x-funnelbarn-project'] = projectName
+  }
+  const payload: Record<string, unknown> = {
+    name,
+    url: window.location.href,
+    referrer: document.referrer || undefined,
+    session_id: getSessionId(),
+    timestamp: new Date().toISOString(),
+    ...extractUTMs(),
+  }
+  if (properties && Object.keys(properties).length > 0) {
+    payload.properties = properties
+  }
+  try {
+    fetch(`${endpoint}/api/v1/events`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload),
+      keepalive: true,
+    }).catch(() => {})
+  } catch {
+    // Never throw from analytics.
+  }
+}
+
+export function trackPageView(): void {
+  send('page_view')
+}
+
+export function trackEvent(name: string, properties?: Record<string, unknown>): void {
+  send(name, properties)
+}

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
 import { api, User, ApiError } from './api'
+import { trackEvent } from './analytics'
 
 interface AuthContextValue {
   user: User | null
@@ -20,6 +21,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       .catch((e: unknown) => {
         if (e instanceof ApiError && e.status === 401) {
           setUser(null)
+        } else {
+          console.error('auth check failed', e)
+          setUser(null)
         }
       })
       .finally(() => setIsLoading(false))
@@ -31,6 +35,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }
 
   const logout = async () => {
+    trackEvent('logout')
     await api.logout()
     setUser(null)
   }

--- a/web/src/lib/projects.tsx
+++ b/web/src/lib/projects.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect, useState, ReactNode, useCallback } from 'react'
 import { api, Project } from './api'
+import { reportError } from './bugbarn'
 
 const STORAGE_KEY = 'funnelbarn_default_project'
 
@@ -29,7 +30,7 @@ export function ProjectProvider({ children }: { children: ReactNode }) {
     setIsLoading(true)
     api.listProjects()
       .then((d) => setProjects(d.projects || []))
-      .catch(() => setProjects([]))
+      .catch((e) => { reportError(e, { source: 'ProjectProvider.listProjects' }); setProjects([]) })
       .finally(() => setIsLoading(false))
   }, [])
 

--- a/web/src/pages/ABTests.tsx
+++ b/web/src/pages/ABTests.tsx
@@ -4,6 +4,8 @@ import { FlaskConical, Plus, X } from 'lucide-react'
 import Shell from '../components/shell/Shell'
 import { api, ABTest, ABTestAnalysis } from '../lib/api'
 import { useProjects } from '../lib/projects'
+import { trackEvent } from '../lib/analytics'
+import { reportError } from '../lib/bugbarn'
 
 const C = {
   bg: '#0f1117',
@@ -71,6 +73,7 @@ function CreateTestModal({
         control_filter: { property: controlProp, value: controlVal },
         variant_filter: { property: variantProp, value: variantVal },
       })
+      trackEvent('abtest_created', { test_name: name })
       onCreated(t)
     } catch (e) {
       setError(String(e))
@@ -311,7 +314,7 @@ function TestDetail({ test, projectId }: { test: ABTest; projectId: string }) {
   useEffect(() => {
     api.getABTestAnalysis(projectId, test.id)
       .then(setAnalysis)
-      .catch(console.error)
+      .catch((e) => { console.error(e); reportError(e, { source: 'ABTests' }) })
       .finally(() => setLoading(false))
   }, [projectId, test.id])
 
@@ -376,7 +379,7 @@ export default function ABTests() {
     if (!projectId) return
     api.getABTests(projectId)
       .then((d) => setTests(d.tests || []))
-      .catch(console.error)
+      .catch((e) => { console.error(e); reportError(e, { source: 'ABTests' }) })
   }, [projectId])
 
   if (!projectId) {

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -9,6 +9,8 @@ import Shell from '../components/shell/Shell'
 import { api, DashboardData } from '../lib/api'
 import { useProjects } from '../lib/projects'
 import { ProjectPicker } from '../components/ui/ProjectPicker'
+import { trackEvent } from '../lib/analytics'
+import { reportError } from '../lib/bugbarn'
 
 const C = {
   bg: '#0f1117',
@@ -111,6 +113,7 @@ export default function Dashboard() {
     setCreateError(null)
     try {
       const p = await api.createProject(newProjectName, '')
+      trackEvent('project_created', { project_id: p.id, project_name: p.name })
       refetchProjects()
       setShowCreateProject(false)
       setNewProjectName('')
@@ -128,7 +131,7 @@ export default function Dashboard() {
     setError(null)
     api.getDashboard(projectId, range)
       .then(setData)
-      .catch((e: unknown) => setError(String(e)))
+      .catch((e: unknown) => { reportError(e, { source: 'Dashboard.getDashboard' }); setError(String(e)) })
       .finally(() => setLoading(false))
   }, [projectId, range])
 

--- a/web/src/pages/Funnels.tsx
+++ b/web/src/pages/Funnels.tsx
@@ -4,6 +4,8 @@ import { Plus, X, Layers, Pencil, Trash2 } from 'lucide-react'
 import Shell from '../components/shell/Shell'
 import { api, Funnel, FunnelAnalysis, FunnelStepInput } from '../lib/api'
 import { useProjects } from '../lib/projects'
+import { trackEvent } from '../lib/analytics'
+import { reportError } from '../lib/bugbarn'
 
 const LANGS = ['JS', 'React', 'Go', 'Python', 'Swift', 'Kotlin'] as const
 type Lang = typeof LANGS[number]
@@ -330,6 +332,7 @@ function CreateFunnelModal({
     setError(null)
     try {
       const f = await api.createFunnel(projectId, name, steps)
+      trackEvent('funnel_created', { funnel_name: name, step_count: steps.length })
       onCreated(f)
     } catch (e) {
       setError(String(e))
@@ -853,7 +856,7 @@ export default function Funnels() {
     if (!projectId) return
     api.listFunnels(projectId)
       .then((d) => setFunnels(d.funnels || []))
-      .catch(console.error)
+      .catch((e) => { console.error(e); reportError(e, { source: 'Funnels.listFunnels' }) })
   }, [projectId])
 
   // Re-fetch analysis whenever selected funnel or active segment changes.
@@ -866,6 +869,7 @@ export default function Funnels() {
       .then(setAnalysis)
       .catch((e) => {
         console.error(e)
+        reportError(e, { source: 'Funnels.getFunnelAnalysis' })
         setAnalysisError(String(e))
       })
       .finally(() => setAnalysisLoading(false))
@@ -873,6 +877,7 @@ export default function Funnels() {
 
   const loadAnalysis = (funnel: Funnel) => {
     if (!projectId) return
+    trackEvent('funnel_viewed', { funnel_name: funnel.name })
     setSelected(funnel)
     setShowDetail(true)
     // Analysis will be fetched by the effect above.
@@ -890,6 +895,7 @@ export default function Funnels() {
       setShowDetail(false)
     } catch (e) {
       console.error(e)
+      reportError(e, { source: 'Funnels.deleteFunnel' })
       alert('Failed to delete funnel: ' + String(e))
     } finally {
       setDeleting(false)

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -2,6 +2,7 @@ import { useState, FormEvent } from 'react'
 import { useNavigate, Navigate } from 'react-router-dom'
 import { useAuth } from '../lib/auth'
 import { ApiError } from '../lib/api'
+import { trackEvent } from '../lib/analytics'
 
 const C = {
   bg: '#0f1117',
@@ -31,11 +32,14 @@ export default function Login() {
     setSubmitting(true)
     try {
       await login(username, password)
+      trackEvent('login', { method: 'password' })
       navigate('/dashboard', { replace: true })
     } catch (err) {
       if (err instanceof ApiError && err.status === 401) {
+        trackEvent('login_failed', { reason: 'invalid_credentials' })
         setError('Invalid username or password')
       } else {
+        trackEvent('login_failed', { reason: 'error' })
         setError('Something went wrong. Please try again.')
       }
     } finally {

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -4,6 +4,8 @@ import Shell from '../components/shell/Shell'
 import { api, ApiKey } from '../lib/api'
 import { useProjects } from '../lib/projects'
 import { CopyButton } from '../components/ui/CopyButton'
+import { trackEvent } from '../lib/analytics'
+import { reportError } from '../lib/bugbarn'
 
 const C = {
   bg: '#0f1117',
@@ -69,7 +71,7 @@ export default function Settings() {
   useEffect(() => {
     api.listApiKeys()
       .then((d) => setApiKeys(d.api_keys || []))
-      .catch(() => setApiKeys([]))
+      .catch((e) => { reportError(e, { source: 'Settings.listApiKeys' }); setApiKeys([]) })
       .finally(() => setLoading(false))
   }, [])
 
@@ -81,6 +83,7 @@ export default function Settings() {
       // Pass the first project ID so the backend doesn't have to guess.
       const projectId = projects[0]?.id
       const res = await api.createApiKey(newKeyName, newKeyScope, projectId)
+      trackEvent('api_key_created', { scope: newKeyScope })
       setApiKeys((prev) => [...prev, res.api_key])
       setNewKeyValue(res.key)
       setNewKeyName('')


### PR DESCRIPTION
## Summary
- Add self-tracking analytics so FunnelBarn tracks its own usage (page views, login, funnel/project/abtest creation, API key management)
- Define 3 conversion funnels for the `funnelbarn` dogfood project (User Onboarding, Login to Dashboard, Funnel Analysis Engagement)
- Report all silently swallowed frontend errors to BugBarn with source context
- Upgrade business event logs (login, create/delete operations) from Debug to Info; add Warn-level failed login logging

## Test plan
- [x] Go tests pass (`go test ./...`)
- [x] TypeScript compiles (`tsc --noEmit`)
- [x] Deployed to production on layer7 and verified startup logs show `dogfood analytics enabled`
- [x] Sent test events (`page_view`, `login`, `funnel_viewed`) — all accepted, processed, and stored in SQLite
- [x] Verified funnels created in database