### PR TITLE
fix: dashboard 500 error and Litestream S3 replication

### DIFF
--- a/deploy/k8s/production/secret.yaml
+++ b/deploy/k8s/production/secret.yaml
@@ -11,8 +11,9 @@ stringData:
     FUNNELBARN_SELF_API_KEY: ENC[AES256_GCM,data:i2vxhFmC/7kicj0cbJeiJN+FBptqu7352MmhsrJA8vdgGpoxhrHJXg==,iv:zeZavwy88P/mtC8qy8/cmCILUSKV8OclGBL3aKMUlyY=,tag:dPVQEWADmeK87izVsnZV4w==,type:str]
     FUNNELBARN_SELF_ENDPOINT: ENC[AES256_GCM,data:pts9/E1+xd9cws/MnQBzRwyLcgwB61Qhlw==,iv:0/o1ZD4ziOBxd/sj04VyLvw/Wng6od+nKUPTc2q74vs=,tag:Tq1G9NrSJcy8DoBtm5Rslg==,type:str]
     FUNNELBARN_SESSION_SECRET: ENC[AES256_GCM,data:mVhPeqHGSHfRjkfrQJ+9A5s87gzUvq0TdBpkf0s0DjIHdzsVb58jyny49TrAr//nKHzmtjitIUXHcSOAQXdoqg==,iv:X0fENGCyT1v54BTApZE2Gos3Or7xeU4MaqHdRItPA/M=,tag:kUOnhZDmyF83ZISIbvohnQ==,type:str]
-    LITESTREAM_ACCESS_KEY_ID: ENC[AES256_GCM,data:+Egu1CI=,iv:yPZ56I2a8PDgUCYs5qJ9E4TXpzmBPGtpxd4kVc293HA=,tag:7OJQNoDwOH4o5lqfM6Hr1A==,type:str]
-    LITESTREAM_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:CikNyQj6cos=,iv:lZwmehI/+RE6X5nPIv/H+3feTPeJe9JnS1NAYh50zNo=,tag:yxrZtfIKfYuURpWP41qNfg==,type:str]
+    LITESTREAM_ACCESS_KEY_ID: ENC[AES256_GCM,data:4IjXjyu/jIyk2uWV8YW3JCgE/F1l,iv:RMnuZWDBoJ4+11mIzGuljQ1a5H8OICZKTUtxgsyAt28=,tag:8zbbRzZvo4E3lxsvMThmFA==,type:str]
+    LITESTREAM_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:/d0Ps12gFV+DlPqpicvaF9tL85WFFI03,iv:t6OofhPWKWwc19vouc1HB92CUEdEQXcX4USLKqPOmm0=,tag:q3if6yumbgxhKKCOdDx1RA==,type:str]
+    FUNNELBARN_DOGFOOD_API_KEY: ENC[AES256_GCM,data:4bnfPbfX07PLipBDgK2KIqEyLc32aynF0OkskGiRkvwRTjVi5MDn7XeOT0KSClgN5U1Is/+PVnsaAjaLhgloPA==,iv:d9LwFaI1hVOqbj/L0Hw7Xj4aJ2Md9a1HGXbDIC7vWs4=,tag:xrre9pm63fpnDQHKpSIEXg==,type:str]
 type: ENC[AES256_GCM,data:C5ut2SGe,iv:z/uXG0+eQbK+enMqBv1IjsFEoTJ5t4OBNbpUPpNAxOU=,tag:cEm9II9Hbu94I28Jz/tFKQ==,type:str]
 sops:
     age:
@@ -25,7 +26,7 @@ sops:
             V0FicWJ1OTQ2RU5aRUtIQURsWnJnbDAKPtakhM76h/AOWbIDmzAljDEfjCWq5IdL
             j7RaHQMD3nXtPIQ1b1VVi9VoMM4reRZ8h88HRX8bxXX5J6TWGxKLrg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-30T17:11:36Z"
-    mac: ENC[AES256_GCM,data:/cmPUo6SK9s8eFiGDR7Lqx9dikkZDk/RxNqrJDiTqeWu3mHg1P4e3/UsDgOfzCn4FZ8Y9NjgNkYoharcNvtlChoKjsepr2ZjmLijfTr3LQMesNc+cnU7Jh2F75tZhhm1zkZ1qqzjtVGifEGSxwp+BnBEbEtTD0oDFLI0qb5K3hc=,iv:EyscdNlh7yNt2OJ2tIRrEL8IpjD3/uw0EXfqHYX6Sjg=,tag:rBbDEFKnQG0PngTSPAmhIQ==,type:str]
+    lastmodified: "2026-05-02T04:55:17Z"
+    mac: ENC[AES256_GCM,data:AJOrxTso+3k/IqBhJGpvPBNYVt+z/eR0koaxwycekbtSIfHxJReAm/mIxzZssLtwRgA70ajaqfuBGarWG/o8Mj0ZXD2hT4rtzOEfHdggkT6lqsKpqIQSDh1KAZ7VHDPCU0jQb8/6UEC1qZku4uHOa/aJMuoMvk95qXwC0yCqLnY=,iv:sDhccpf9SKP6pxprOgEkGciHUETMcr3ZFsxmMtaxoQ4=,tag:6694mVkTR8Z1EXD2/Z/pow==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/internal/repository/events.go
+++ b/internal/repository/events.go
@@ -162,7 +162,7 @@ type ReferrerStat struct {
 // EventTimeSeries returns hourly event counts for a project over a time range.
 func (s *Store) EventTimeSeries(ctx context.Context, projectID string, from, to time.Time) ([]TimeSeriesPoint, error) {
 	const q = `
-		SELECT strftime('%Y-%m-%dT%H:00:00Z', occurred_at) as hour, COUNT(*) as count
+		SELECT substr(occurred_at, 1, 13) || ':00:00Z' as hour, COUNT(*) as count
 		FROM events
 		WHERE project_id = ? AND occurred_at >= ? AND occurred_at <= ?
 		GROUP BY hour
@@ -497,7 +497,7 @@ func (s *Store) TopUTMMediums(ctx context.Context, projectID string, from, to ti
 // DailyEventCounts returns daily event counts for a project over a time range.
 func (s *Store) DailyEventCounts(ctx context.Context, projectID string, from, to time.Time) ([]TimeSeriesPoint, error) {
 	const q = `
-		SELECT strftime('%Y-%m-%d', occurred_at) as day, COUNT(*) as count
+		SELECT substr(occurred_at, 1, 10) as day, COUNT(*) as count
 		FROM events
 		WHERE project_id = ? AND occurred_at >= ? AND occurred_at <= ?
 		GROUP BY day
@@ -567,7 +567,7 @@ func (s *Store) AvgEventsPerSession(ctx context.Context, projectID string, from,
 // DailyUniqueSessions returns daily unique session counts.
 func (s *Store) DailyUniqueSessions(ctx context.Context, projectID string, from, to time.Time) ([]TimeSeriesPoint, error) {
 	const q = `
-		SELECT strftime('%Y-%m-%d', occurred_at) as day, COUNT(DISTINCT session_id) as count
+		SELECT substr(occurred_at, 1, 10) as day, COUNT(DISTINCT session_id) as count
 		FROM events
 		WHERE project_id = ? AND occurred_at >= ? AND occurred_at <= ?
 		GROUP BY day


### PR DESCRIPTION
## Summary
- **Dashboard 500 fix**: `strftime()` returns NULL on Go's `time.Time` storage format (`2026-05-02 04:39:04.415 +0000 UTC`), crashing `DailyEventCounts`, `DailyUniqueSessions`, and `EventTimeSeries` queries. Replaced with `substr()` which works with any stored format.
- **Litestream S3 credentials**: Created dedicated `funnelbarn-litestream` MinIO user with scoped policy for the `funnelbarn-sqlite` bucket. Updated SOPS-encrypted production secret.

## Test plan
- [x] All Go tests pass (`go test ./...`)
- [x] Dashboard endpoint no longer returns 500 (verified on production)
- [x] Litestream replication confirmed working — snapshots and WAL segments in MinIO bucket
- [x] Both fixes already deployed and verified on production