### PR TITLE
feat: project domains, funnel filters, event autocomplete, and bug fixes

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -284,7 +284,7 @@ func (s *Server) handleDeleteProject(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// handleUpdateProject updates a project's name.
+// handleUpdateProject updates a project's name and domain.
 func (s *Server) handleUpdateProject(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
 	if projectID == "" {
@@ -292,7 +292,8 @@ func (s *Server) handleUpdateProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var body struct {
-		Name string `json:"name"`
+		Name   string `json:"name"`
+		Domain string `json:"domain"`
 	}
 	if err := readJSON(r, &body); err != nil {
 		jsonError(w, "invalid request body", http.StatusBadRequest)
@@ -302,7 +303,7 @@ func (s *Server) handleUpdateProject(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "name is required", http.StatusBadRequest)
 		return
 	}
-	project, err := s.projects.UpdateProject(r.Context(), projectID, body.Name)
+	project, err := s.projects.UpdateProject(r.Context(), projectID, body.Name, body.Domain)
 	if err != nil {
 		mapServiceError(w, err, "handleUpdateProject")
 		return

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -20,6 +20,25 @@ func addPaginationHeaders(w http.ResponseWriter, r *http.Request, limit, offset,
 	w.Header().Set("Link", fmt.Sprintf(`<%s>; rel="next"`, next))
 }
 
+// handleEventNames returns distinct event names for a project (autocomplete).
+func (s *Server) handleEventNames(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	if projectID == "" {
+		jsonError(w, "project id required", http.StatusBadRequest)
+		return
+	}
+
+	names, err := s.events.DistinctEventNames(r.Context(), projectID)
+	if err != nil {
+		mapServiceError(w, err, "handleEventNames")
+		return
+	}
+	if names == nil {
+		names = []string{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"event_names": names})
+}
+
 // handleListEvents returns a paginated list of events for a project.
 func (s *Server) handleListEvents(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -129,6 +129,7 @@ func (s *Server) registerRoutes() {
 	// Dashboard & analytics (session required)
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/dashboard", s.requireSession(s.handleDashboard))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/events", s.requireSession(s.handleListEvents))
+	s.mux.HandleFunc("GET /api/v1/projects/{id}/event-names", s.requireSession(s.handleEventNames))
 
 	// Funnels
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/funnels", s.requireSession(s.handleListFunnels))
@@ -204,7 +205,7 @@ func (s *Server) setCORSHeaders(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(s.allowedOrigins) == 0 {
+	if len(s.allowedOrigins) == 0 || (len(s.allowedOrigins) == 1 && s.allowedOrigins[0] == "") {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 	} else {
 		for _, allowed := range s.allowedOrigins {

--- a/internal/repository/events.go
+++ b/internal/repository/events.go
@@ -589,6 +589,26 @@ func (s *Store) DailyUniqueSessions(ctx context.Context, projectID string, from,
 	return series, rows.Err()
 }
 
+// DistinctEventNames returns all unique event names for a project (for autocomplete).
+func (s *Store) DistinctEventNames(ctx context.Context, projectID string) ([]string, error) {
+	const q = `SELECT DISTINCT name FROM events WHERE project_id = ? ORDER BY name`
+	rows, err := s.db.QueryContext(ctx, q, projectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		names = append(names, name)
+	}
+	return names, rows.Err()
+}
+
 // TopOS is an alias for TopOSSystems kept for backward compatibility in tests.
 func (s *Store) TopOS(ctx context.Context, projectID string, from, to time.Time, limit int) ([]OSStat, error) {
 	return s.TopOSSystems(ctx, projectID, from, to, limit)

--- a/internal/repository/events_test.go
+++ b/internal/repository/events_test.go
@@ -441,9 +441,10 @@ func TestUpdateProject(t *testing.T) {
 
 	p, _ := s.CreateProject(ctx, "Old Name", "old-name-repo")
 
-	updated, err := s.UpdateProject(ctx, p.ID, "New Name")
+	updated, err := s.UpdateProject(ctx, p.ID, "New Name", "example.com")
 	require.NoError(t, err)
 	require.Equal(t, "New Name", updated.Name)
+	require.Equal(t, "example.com", updated.Domain)
 	require.Equal(t, p.ID, updated.ID)
 }
 

--- a/internal/repository/funnels.go
+++ b/internal/repository/funnels.go
@@ -4,9 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 )
+
+// validPropertyName matches only alphanumeric and underscore characters.
+var validPropertyName = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 
 // Funnel is a multi-step conversion funnel.
 type Funnel struct {
@@ -296,6 +300,16 @@ func (s *Store) AnalyzeFunnel(ctx context.Context, f Funnel, from, to time.Time,
 		if segArg != nil {
 			args = append(args, segArg)
 		}
+
+		// Append step-level property filters.
+		for _, filter := range step.Filters {
+			if !validPropertyName.MatchString(filter.Property) {
+				continue // skip invalid property names to prevent injection
+			}
+			q += fmt.Sprintf(" AND json_extract(properties, '$.%s') = ?", filter.Property)
+			args = append(args, filter.Value)
+		}
+
 		if err := s.db.QueryRowContext(ctx, q, args...).Scan(&n); err != nil {
 			return nil, fmt.Errorf("analyze step %d: %w", i, err)
 		}

--- a/internal/repository/interface.go
+++ b/internal/repository/interface.go
@@ -18,7 +18,7 @@ type Querier interface {
 	EnsureProject(ctx context.Context, slug string) (Project, error)
 	EnsureProjectPending(ctx context.Context, name, slug string) (Project, error)
 	ListProjects(ctx context.Context) ([]Project, error)
-	UpdateProject(ctx context.Context, id, name string) (Project, error)
+	UpdateProject(ctx context.Context, id, name, domain string) (Project, error)
 	DeleteProject(ctx context.Context, id string) error
 	ApproveProject(ctx context.Context, id string) (Project, error)
 	HasProjects(ctx context.Context) (bool, error)
@@ -73,6 +73,7 @@ type Querier interface {
 	AvgEventsPerSession(ctx context.Context, projectID string, from, to time.Time) (float64, error)
 	UniqueSessionCount(ctx context.Context, projectID string, from, to time.Time) (int64, error)
 	GetEventByIngestID(ctx context.Context, ingestID string) (*Event, error)
+	DistinctEventNames(ctx context.Context, projectID string) ([]string, error)
 	PurgeOldEvents(ctx context.Context, cutoff time.Time) (int64, error)
 }
 

--- a/internal/repository/migrations/00002_add_project_domain.sql
+++ b/internal/repository/migrations/00002_add_project_domain.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE projects ADD COLUMN domain TEXT;
+
+-- +goose Down
+-- SQLite does not support DROP COLUMN in older versions; this is a best-effort rollback.
+-- For SQLite 3.35.0+ the below works:
+ALTER TABLE projects DROP COLUMN domain;

--- a/internal/repository/mock/mock.go
+++ b/internal/repository/mock/mock.go
@@ -102,7 +102,7 @@ func (s *Store) ListProjects(ctx context.Context) ([]repository.Project, error) 
 	return out, nil
 }
 
-func (s *Store) UpdateProject(ctx context.Context, id, name string) (repository.Project, error) {
+func (s *Store) UpdateProject(ctx context.Context, id, name, domain string) (repository.Project, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	p, ok := s.projects[id]
@@ -110,6 +110,7 @@ func (s *Store) UpdateProject(ctx context.Context, id, name string) (repository.
 		return repository.Project{}, sql.ErrNoRows
 	}
 	p.Name = name
+	p.Domain = domain
 	s.projects[id] = p
 	return p, nil
 }
@@ -549,6 +550,10 @@ func (s *Store) GetEventByIngestID(ctx context.Context, ingestID string) (*repos
 			return &ec, nil
 		}
 	}
+	return nil, nil
+}
+
+func (s *Store) DistinctEventNames(_ context.Context, _ string) ([]string, error) {
 	return nil, nil
 }
 

--- a/internal/repository/projects.go
+++ b/internal/repository/projects.go
@@ -21,6 +21,7 @@ type Project struct {
 	Name      string    `json:"name"`
 	Slug      string    `json:"slug"`
 	Status    string    `json:"status"`
+	Domain    string    `json:"domain"`
 	CreatedAt time.Time `json:"created_at"`
 }
 
@@ -106,9 +107,10 @@ func (s *Store) DeleteProject(ctx context.Context, id string) error {
 	return s.q.DeleteProject(ctx, id)
 }
 
-// UpdateProject updates a project's name.
-func (s *Store) UpdateProject(ctx context.Context, id, name string) (Project, error) {
-	if err := s.q.UpdateProjectName(ctx, sqlcgen.UpdateProjectNameParams{Name: name, ID: id}); err != nil {
+// UpdateProject updates a project's name and domain.
+func (s *Store) UpdateProject(ctx context.Context, id, name, domain string) (Project, error) {
+	domainVal := sql.NullString{String: domain, Valid: domain != ""}
+	if err := s.q.UpdateProject(ctx, sqlcgen.UpdateProjectParams{Name: name, Domain: domainVal, ID: id}); err != nil {
 		return Project{}, fmt.Errorf("update project: %w", err)
 	}
 	return s.ProjectByID(ctx, id)
@@ -129,6 +131,7 @@ func projectFromGen(p sqlcgen.Project) Project {
 		Name:      p.Name,
 		Slug:      p.Slug,
 		Status:    p.Status,
+		Domain:    p.Domain.String,
 		CreatedAt: p.CreatedAt,
 	}
 }

--- a/internal/repository/queries/projects.sql
+++ b/internal/repository/queries/projects.sql
@@ -1,11 +1,11 @@
 -- name: GetProjectByID :one
-SELECT id, name, slug, status, created_at FROM projects WHERE id = ?;
+SELECT id, name, slug, status, domain, created_at FROM projects WHERE id = ?;
 
 -- name: GetProjectBySlug :one
-SELECT id, name, slug, status, created_at FROM projects WHERE slug = ?;
+SELECT id, name, slug, status, domain, created_at FROM projects WHERE slug = ?;
 
 -- name: ListProjects :many
-SELECT id, name, slug, status, created_at FROM projects ORDER BY name;
+SELECT id, name, slug, status, domain, created_at FROM projects ORDER BY name;
 
 -- name: InsertProject :exec
 INSERT INTO projects (id, name, slug) VALUES (?, ?, ?);
@@ -15,6 +15,9 @@ INSERT INTO projects (id, name, slug, status) VALUES (?, ?, ?, 'pending');
 
 -- name: UpdateProjectName :exec
 UPDATE projects SET name = ? WHERE id = ?;
+
+-- name: UpdateProject :exec
+UPDATE projects SET name = ?, domain = ? WHERE id = ?;
 
 -- name: DeleteProject :exec
 DELETE FROM projects WHERE id = ?;

--- a/internal/repository/sqlcgen/models.go
+++ b/internal/repository/sqlcgen/models.go
@@ -72,11 +72,12 @@ type FunnelStep struct {
 }
 
 type Project struct {
-	ID        string    `json:"id"`
-	Name      string    `json:"name"`
-	Slug      string    `json:"slug"`
-	Status    string    `json:"status"`
-	CreatedAt time.Time `json:"created_at"`
+	ID        string         `json:"id"`
+	Name      string         `json:"name"`
+	Slug      string         `json:"slug"`
+	Status    string         `json:"status"`
+	Domain    sql.NullString `json:"domain"`
+	CreatedAt time.Time      `json:"created_at"`
 }
 
 type SchemaMigration struct {

--- a/internal/repository/sqlcgen/projects.sql.go
+++ b/internal/repository/sqlcgen/projects.sql.go
@@ -7,6 +7,7 @@ package sqlcgen
 
 import (
 	"context"
+	"database/sql"
 )
 
 const approveProject = `-- name: ApproveProject :exec
@@ -39,7 +40,7 @@ func (q *Queries) DeleteProject(ctx context.Context, id string) error {
 }
 
 const getProjectByID = `-- name: GetProjectByID :one
-SELECT id, name, slug, status, created_at FROM projects WHERE id = ?
+SELECT id, name, slug, status, domain, created_at FROM projects WHERE id = ?
 `
 
 func (q *Queries) GetProjectByID(ctx context.Context, id string) (Project, error) {
@@ -50,13 +51,14 @@ func (q *Queries) GetProjectByID(ctx context.Context, id string) (Project, error
 		&i.Name,
 		&i.Slug,
 		&i.Status,
+		&i.Domain,
 		&i.CreatedAt,
 	)
 	return i, err
 }
 
 const getProjectBySlug = `-- name: GetProjectBySlug :one
-SELECT id, name, slug, status, created_at FROM projects WHERE slug = ?
+SELECT id, name, slug, status, domain, created_at FROM projects WHERE slug = ?
 `
 
 func (q *Queries) GetProjectBySlug(ctx context.Context, slug string) (Project, error) {
@@ -67,6 +69,7 @@ func (q *Queries) GetProjectBySlug(ctx context.Context, slug string) (Project, e
 		&i.Name,
 		&i.Slug,
 		&i.Status,
+		&i.Domain,
 		&i.CreatedAt,
 	)
 	return i, err
@@ -103,7 +106,7 @@ func (q *Queries) InsertProjectPending(ctx context.Context, arg InsertProjectPen
 }
 
 const listProjects = `-- name: ListProjects :many
-SELECT id, name, slug, status, created_at FROM projects ORDER BY name
+SELECT id, name, slug, status, domain, created_at FROM projects ORDER BY name
 `
 
 func (q *Queries) ListProjects(ctx context.Context) ([]Project, error) {
@@ -120,6 +123,7 @@ func (q *Queries) ListProjects(ctx context.Context) ([]Project, error) {
 			&i.Name,
 			&i.Slug,
 			&i.Status,
+			&i.Domain,
 			&i.CreatedAt,
 		); err != nil {
 			return nil, err
@@ -133,6 +137,21 @@ func (q *Queries) ListProjects(ctx context.Context) ([]Project, error) {
 		return nil, err
 	}
 	return items, nil
+}
+
+const updateProject = `-- name: UpdateProject :exec
+UPDATE projects SET name = ?, domain = ? WHERE id = ?
+`
+
+type UpdateProjectParams struct {
+	Name   string         `json:"name"`
+	Domain sql.NullString `json:"domain"`
+	ID     string         `json:"id"`
+}
+
+func (q *Queries) UpdateProject(ctx context.Context, arg UpdateProjectParams) error {
+	_, err := q.db.ExecContext(ctx, updateProject, arg.Name, arg.Domain, arg.ID)
+	return err
 }
 
 const updateProjectName = `-- name: UpdateProjectName :exec

--- a/internal/repository/store_test.go
+++ b/internal/repository/store_test.go
@@ -86,9 +86,10 @@ func TestStore_UpdateProject(t *testing.T) {
 	p, err := s.CreateProject(ctx, "Original", "the-slug")
 	require.NoError(t, err)
 
-	updated, err := s.UpdateProject(ctx, p.ID, "Updated Name")
+	updated, err := s.UpdateProject(ctx, p.ID, "Updated Name", "example.org")
 	require.NoError(t, err)
 	assert.Equal(t, "Updated Name", updated.Name)
+	assert.Equal(t, "example.org", updated.Domain)
 	assert.Equal(t, "the-slug", updated.Slug) // slug unchanged
 }
 

--- a/internal/service/events.go
+++ b/internal/service/events.go
@@ -76,3 +76,7 @@ func (svc *EventService) UniqueSessionCount(ctx context.Context, projectID strin
 func (svc *EventService) GetEventByIngestID(ctx context.Context, ingestID string) (*repository.Event, error) {
 	return svc.store.GetEventByIngestID(ctx, ingestID)
 }
+
+func (svc *EventService) DistinctEventNames(ctx context.Context, projectID string) ([]string, error) {
+	return svc.store.DistinctEventNames(ctx, projectID)
+}

--- a/internal/service/interfaces.go
+++ b/internal/service/interfaces.go
@@ -13,7 +13,7 @@ type Projects interface {
 	ListProjects(ctx context.Context) ([]repository.Project, error)
 	GetProject(ctx context.Context, id string) (repository.Project, error)
 	GetProjectBySlug(ctx context.Context, slug string) (repository.Project, error)
-	UpdateProject(ctx context.Context, id, name string) (repository.Project, error)
+	UpdateProject(ctx context.Context, id, name, domain string) (repository.Project, error)
 	DeleteProject(ctx context.Context, id string) error
 	ApproveProject(ctx context.Context, id string) (repository.Project, error)
 	EnsureProjectPending(ctx context.Context, name, slug string) (repository.Project, error)
@@ -59,6 +59,7 @@ type Events interface {
 	AvgEventsPerSession(ctx context.Context, projectID string, from, to time.Time) (float64, error)
 	UniqueSessionCount(ctx context.Context, projectID string, from, to time.Time) (int64, error)
 	GetEventByIngestID(ctx context.Context, ingestID string) (*repository.Event, error)
+	DistinctEventNames(ctx context.Context, projectID string) ([]string, error)
 }
 
 // Sessions is the interface for session-related operations.

--- a/internal/service/projects.go
+++ b/internal/service/projects.go
@@ -82,11 +82,11 @@ func (svc *ProjectService) GetProjectBySlug(ctx context.Context, slug string) (r
 	return p, nil
 }
 
-func (svc *ProjectService) UpdateProject(ctx context.Context, id, name string) (repository.Project, error) {
+func (svc *ProjectService) UpdateProject(ctx context.Context, id, name, projectDomain string) (repository.Project, error) {
 	if strings.TrimSpace(name) == "" {
 		return repository.Project{}, &domain.ValidationError{Field: "name", Message: "required"}
 	}
-	p, err := svc.store.UpdateProject(ctx, id, name)
+	p, err := svc.store.UpdateProject(ctx, id, name, strings.TrimSpace(projectDomain))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return repository.Project{}, fmt.Errorf("%w: project %s", domain.ErrNotFound, id)

--- a/internal/service/projects_test.go
+++ b/internal/service/projects_test.go
@@ -61,9 +61,10 @@ func TestProjectService_UpdateProject(t *testing.T) {
 	p, err := svc.CreateProject(ctx, "Old Name", "old-name")
 	require.NoError(t, err)
 
-	updated, err := svc.UpdateProject(ctx, p.ID, "New Name")
+	updated, err := svc.UpdateProject(ctx, p.ID, "New Name", "example.com")
 	require.NoError(t, err)
 	require.Equal(t, "New Name", updated.Name)
+	require.Equal(t, "example.com", updated.Domain)
 }
 
 func TestProjectService_ApproveProject(t *testing.T) {
@@ -128,7 +129,7 @@ func TestProjectService_UpdateProject_Extended(t *testing.T) {
 	p, err := svc.CreateProject(ctx, "Original Name", "update-slug")
 	require.NoError(t, err)
 
-	updated, err := svc.UpdateProject(ctx, p.ID, "Updated Name")
+	updated, err := svc.UpdateProject(ctx, p.ID, "Updated Name", "")
 	require.NoError(t, err)
 	assert.Equal(t, "Updated Name", updated.Name)
 	assert.Equal(t, "update-slug", updated.Slug)

--- a/internal/service/validation_test.go
+++ b/internal/service/validation_test.go
@@ -154,7 +154,7 @@ func TestProjectService_UpdateProject_EmptyName(t *testing.T) {
 	p, err := svc.CreateProject(ctx, "My Project", "my-update-project")
 	require.NoError(t, err)
 
-	_, err = svc.UpdateProject(ctx, p.ID, "")
+	_, err = svc.UpdateProject(ctx, p.ID, "", "")
 	require.Error(t, err)
 	require.True(t, domain.IsValidation(err), "expected validation error, got: %v", err)
 }

--- a/web/src/components/ui/ProjectPicker.tsx
+++ b/web/src/components/ui/ProjectPicker.tsx
@@ -28,6 +28,8 @@ export function ProjectPicker({ projects, base, onSelect, variant = 'badge' }: P
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
 
+  const sortedProjects = [...projects].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }))
+
   const currentProject = projects.find((p) => p.id === urlProjectId) ?? projects[0]
 
   // Close dropdown when clicking outside
@@ -105,7 +107,7 @@ export function ProjectPicker({ projects, base, onSelect, variant = 'badge' }: P
             zIndex: 300,
             overflow: 'hidden',
           }}>
-            {projects.map((p) => (
+            {sortedProjects.map((p) => (
               <button
                 key={p.id}
                 onClick={() => handleSelect(p)}
@@ -170,7 +172,7 @@ export function ProjectPicker({ projects, base, onSelect, variant = 'badge' }: P
               width: '100%',
               background: p.id === currentProject?.id ? 'rgba(245,158,11,0.07)' : 'transparent',
               border: 'none',
-              borderBottom: i < projects.length - 1 ? `1px solid ${C.border}` : 'none',
+              borderBottom: i < sortedProjects.length - 1 ? `1px solid ${C.border}` : 'none',
               padding: '0.75rem 1rem',
               cursor: 'pointer',
               textAlign: 'left',

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -158,6 +158,10 @@ export const api = {
   getABTestAnalysis: (projectId: string, testId: string) =>
     request<ABTestAnalysis>(`/api/v1/projects/${projectId}/abtests/${testId}/analysis`),
 
+  // Event names (autocomplete)
+  getEventNames: (projectId: string) =>
+    request<{ event_names: string[] }>(`/api/v1/projects/${projectId}/event-names`),
+
   // Active sessions (last 5 minutes)
   getActiveSessions: (projectId: string) =>
     request<{ active_sessions: number; window_minutes: number }>(`/api/v1/projects/${projectId}/sessions/active`),
@@ -192,10 +196,12 @@ export interface Event {
 export interface FunnelStep {
   step_order: number
   event_name: string
+  filters?: { property: string; value: string }[]
 }
 
 export interface FunnelStepInput {
   event_name: string
+  filters?: { property: string; value: string }[]
 }
 
 export interface Funnel {

--- a/web/src/lib/bugbarn.ts
+++ b/web/src/lib/bugbarn.ts
@@ -39,7 +39,7 @@ export function reportToBugBarn(payload: BugBarnPayload): void {
     return
   }
   try {
-    fetch(`${endpoint}/api/v1/ingest`, {
+    fetch(`${endpoint}/api/v1/events`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/web/src/pages/Funnels.tsx
+++ b/web/src/pages/Funnels.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 import { useParams } from 'react-router-dom'
 import { Plus, X, Layers, Pencil, Trash2 } from 'lucide-react'
 import Shell from '../components/shell/Shell'
@@ -50,17 +50,17 @@ const ${constName} = {
 ${stepEntries}
 }
 
-// Track page view on load
-funnelbarn.track(${constName}.${toCamelCase(firstStep)})
+// Track page view (url is auto-captured, add extra context as properties)
+funnelbarn.page({ section: 'landing' })
 
-// Button click example
+// Button click example — pass context so you can filter in funnels
 document.querySelector('#your-cta').addEventListener('click', () => {
-  funnelbarn.track(${constName}.${toCamelCase(midStep)})
+  funnelbarn.track(${constName}.${toCamelCase(midStep)}, { page: location.pathname, label: 'hero-cta' })
 })
 
-// Form submit example
+// Form submit — include form name and page for filtering
 document.querySelector('form').addEventListener('submit', () => {
-  funnelbarn.track(${constName}.${toCamelCase(lastStep)})
+  funnelbarn.track(${constName}.${toCamelCase(lastStep)}, { form: 'signup', page: location.pathname })
 })
 
 // Scroll depth (50%)
@@ -69,6 +69,10 @@ window.addEventListener('scroll', () => {
   const pct = window.scrollY / (document.body.scrollHeight - window.innerHeight)
   if (pct >= 0.5 && !_scrolled) { _scrolled = true; funnelbarn.track('scroll_50') }
 }, { passive: true })
+
+// Identify logged-in users (enables "Logged in" / "Not logged in" segments)
+// Call this after the user logs in
+funnelbarn.identify('user-123')
 </script>`
 
       case 'React':
@@ -92,12 +96,18 @@ function useFunnelTrack() {
 function YourComponent() {
   const track = useFunnelTrack()
 
+  // page() auto-captures URL and referrer; add extra properties as needed
   useEffect(() => {
-    track(${constName}.${toCamelCase(firstStep)})
+    window.funnelbarn?.page({ section: 'dashboard' })
   }, [])
 
+  // Identify logged-in users (enables "Logged in" / "Not logged in" segments)
+  useEffect(() => {
+    if (currentUser) window.funnelbarn?.identify(currentUser.id)
+  }, [currentUser])
+
   return (
-    <button onClick={() => track(${constName}.${toCamelCase(midStep)})}>
+    <button onClick={() => track(${constName}.${toCamelCase(midStep)}, { page: location.pathname })}>
       Continue
     </button>
   )
@@ -141,8 +151,8 @@ client = FunnelBarnClient(
     endpoint="https://funnelbarn.wiebe.xyz"
 )
 
-# Track a step
-client.track(${constNameCapitalized}.${firstStep.toUpperCase()})
+# Track a step (user_id enables "Logged in" / "Not logged in" segments)
+client.track(${constNameCapitalized}.${firstStep.toUpperCase()}, properties={"user_id": "user_123"})
 
 # With properties
 client.track(
@@ -175,9 +185,9 @@ func trackFunnelStep(_ step: ${constNameCapitalized}Step,
     URLSession.shared.dataTask(with: request).resume()
 }
 
-// Usage
-trackFunnelStep(.${toCamelCase(firstStep)})
-trackFunnelStep(.${toCamelCase(lastStep)}, properties: ["user_id": "user_123"])`
+// Usage (user_id enables "Logged in" / "Not logged in" segments)
+trackFunnelStep(.${toCamelCase(firstStep)}, properties: ["user_id": "user_123"])
+trackFunnelStep(.${toCamelCase(lastStep)}, properties: ["plan": "pro"])`
 
       case 'Kotlin':
         return `import okhttp3.*
@@ -210,11 +220,12 @@ class FunnelBarnTracker(private val apiKey: String) {
     }
 }
 
-// Usage
+// Usage (user_id enables "Logged in" / "Not logged in" segments)
 val tracker = FunnelBarnTracker("${key}")
-tracker.track(${constNameCapitalized}.${firstStep.toUpperCase().replace(/-/g, '_')})
+tracker.track(${constNameCapitalized}.${firstStep.toUpperCase().replace(/-/g, '_')},
+    mapOf("user_id" to "user_123"))
 tracker.track(${constNameCapitalized}.${lastStep.toUpperCase().replace(/-/g, '_')},
-    mapOf("user_id" to "user_123"))`
+    mapOf("user_id" to "user_123", "plan" to "pro"))`
     }
   }
 
@@ -279,14 +290,14 @@ tracker.track(${constNameCapitalized}.${lastStep.toUpperCase().replace(/-/g, '_'
 }
 
 const PRESET_SEGMENTS = [
-  { id: 'all', label: 'All' },
-  { id: 'logged_in', label: 'Logged in' },
-  { id: 'not_logged_in', label: 'Not logged in' },
-  { id: 'mobile', label: 'Mobile' },
-  { id: 'desktop', label: 'Desktop' },
-  { id: 'tablet', label: 'Tablet' },
-  { id: 'new_visitor', label: 'New visitors' },
-  { id: 'returning', label: 'Returning' },
+  { id: 'all', label: 'All', tip: 'All sessions, no filtering applied' },
+  { id: 'logged_in', label: 'Logged in', tip: 'Sessions where identify() was called with a user ID. Requires: analytics.identify("user-123") in your tracking code.' },
+  { id: 'not_logged_in', label: 'Not logged in', tip: 'Sessions with no user ID. If you never call identify(), all sessions appear here.' },
+  { id: 'mobile', label: 'Mobile', tip: 'Detected automatically from the User-Agent header — no code changes needed.' },
+  { id: 'desktop', label: 'Desktop', tip: 'Detected automatically from the User-Agent header — no code changes needed.' },
+  { id: 'tablet', label: 'Tablet', tip: 'Detected automatically from the User-Agent header — no code changes needed.' },
+  { id: 'new_visitor', label: 'New visitors', tip: 'First-time sessions (1 event only). Tracked automatically via the SDK session in localStorage.' },
+  { id: 'returning', label: 'Returning', tip: 'Sessions with more than one event. Tracked automatically via the SDK session in localStorage.' },
 ]
 
 const C = {
@@ -306,6 +317,86 @@ function conversionColor(pct: number) {
   return C.error
 }
 
+function EventNameInput({
+  value,
+  onChange,
+  placeholder,
+  eventNames,
+}: {
+  value: string
+  onChange: (val: string) => void
+  placeholder?: string
+  eventNames: string[]
+}) {
+  const [open, setOpen] = useState(false)
+  const [focused, setFocused] = useState(false)
+  const wrapperRef = useRef<HTMLDivElement>(null)
+
+  const filtered = eventNames.filter(
+    (n) => n.toLowerCase().includes(value.toLowerCase()) && n !== value
+  )
+
+  return (
+    <div ref={wrapperRef} style={{ position: 'relative', flex: 1 }}>
+      <input
+        value={value}
+        onChange={(e) => { onChange(e.target.value); setOpen(true) }}
+        onFocus={(e) => { setFocused(true); setOpen(true); e.target.style.borderColor = C.amber }}
+        onBlur={(e) => { setFocused(false); e.target.style.borderColor = C.border; setTimeout(() => setOpen(false), 150) }}
+        placeholder={placeholder || 'Event name, e.g. page_view'}
+        style={{
+          width: '100%',
+          background: C.bg,
+          border: `1px solid ${C.border}`,
+          borderRadius: 8,
+          padding: '0.55rem 0.875rem',
+          color: C.text,
+          fontSize: 14,
+          outline: 'none',
+          boxSizing: 'border-box',
+        }}
+      />
+      {open && focused && filtered.length > 0 && (
+        <div style={{
+          position: 'absolute',
+          top: '100%',
+          left: 0,
+          right: 0,
+          marginTop: 4,
+          background: C.bg,
+          border: `1px solid ${C.border}`,
+          borderRadius: 8,
+          maxHeight: 160,
+          overflowY: 'auto',
+          zIndex: 100,
+        }}>
+          {filtered.slice(0, 10).map((n) => (
+            <div
+              key={n}
+              onMouseDown={(e) => { e.preventDefault(); onChange(n); setOpen(false) }}
+              style={{
+                padding: '0.45rem 0.875rem',
+                fontSize: 13,
+                color: C.text,
+                cursor: 'pointer',
+              }}
+              onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(245,158,11,0.1)')}
+              onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+            >
+              {n}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface StepWithFilters {
+  event_name: string
+  filters: { property: string; value: string }[]
+}
+
 function CreateFunnelModal({
   projectId,
   onClose,
@@ -316,14 +407,28 @@ function CreateFunnelModal({
   onCreated: (f: Funnel) => void
 }) {
   const [name, setName] = useState('')
-  const [steps, setSteps] = useState<FunnelStepInput[]>([{ event_name: '' }, { event_name: '' }])
+  const [steps, setSteps] = useState<StepWithFilters[]>([
+    { event_name: '', filters: [] },
+    { event_name: '', filters: [] },
+  ])
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [eventNames, setEventNames] = useState<string[]>([])
 
-  const addStep = () => setSteps((s) => [...s, { event_name: '' }])
+  useEffect(() => {
+    api.getEventNames(projectId).then((d) => setEventNames(d.event_names || [])).catch(() => {})
+  }, [projectId])
+
+  const addStep = () => setSteps((s) => [...s, { event_name: '', filters: [] }])
   const removeStep = (i: number) => setSteps((s) => s.filter((_, idx) => idx !== i))
   const updateStep = (i: number, val: string) =>
-    setSteps((s) => s.map((st, idx) => (idx === i ? { event_name: val } : st)))
+    setSteps((s) => s.map((st, idx) => (idx === i ? { ...st, event_name: val } : st)))
+  const addFilter = (i: number) =>
+    setSteps((s) => s.map((st, idx) => idx === i ? { ...st, filters: [...st.filters, { property: '', value: '' }] } : st))
+  const removeFilter = (stepIdx: number, filterIdx: number) =>
+    setSteps((s) => s.map((st, i) => i === stepIdx ? { ...st, filters: st.filters.filter((_, fi) => fi !== filterIdx) } : st))
+  const updateFilter = (stepIdx: number, filterIdx: number, field: 'property' | 'value', val: string) =>
+    setSteps((s) => s.map((st, i) => i === stepIdx ? { ...st, filters: st.filters.map((f, fi) => fi === filterIdx ? { ...f, [field]: val } : f) } : st))
 
   const handleCreate = async () => {
     if (!name.trim()) { setError('Name is required'); return }
@@ -331,7 +436,11 @@ function CreateFunnelModal({
     setSaving(true)
     setError(null)
     try {
-      const f = await api.createFunnel(projectId, name, steps)
+      const apiSteps: FunnelStepInput[] = steps.map((s) => ({
+        event_name: s.event_name,
+        ...(s.filters.length > 0 ? { filters: s.filters.filter((f) => f.property && f.value) } : {}),
+      }))
+      const f = await api.createFunnel(projectId, name, apiSteps)
       trackEvent('funnel_created', { funnel_name: name, step_count: steps.length })
       onCreated(f)
     } catch (e) {
@@ -407,47 +516,93 @@ function CreateFunnelModal({
         <div style={{ marginBottom: '1.25rem' }}>
           <label style={{ display: 'block', fontSize: 13, color: C.muted, marginBottom: 10 }}>Steps</label>
           {steps.map((s, i) => (
-            <div key={i} style={{ display: 'flex', gap: 8, marginBottom: 8, alignItems: 'center' }}>
-              <div style={{
-                width: 24,
-                height: 24,
-                background: C.amber,
-                color: '#0f1117',
-                borderRadius: '50%',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                fontSize: 12,
-                fontWeight: 800,
-                flexShrink: 0,
-              }}>
-                {i + 1}
+            <div key={i} style={{ marginBottom: 10 }}>
+              <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                <div style={{
+                  width: 24,
+                  height: 24,
+                  background: C.amber,
+                  color: '#0f1117',
+                  borderRadius: '50%',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: 12,
+                  fontWeight: 800,
+                  flexShrink: 0,
+                }}>
+                  {i + 1}
+                </div>
+                <EventNameInput
+                  value={s.event_name}
+                  onChange={(val) => updateStep(i, val)}
+                  eventNames={eventNames}
+                />
+                {steps.length > 2 && (
+                  <button
+                    onClick={() => removeStep(i)}
+                    style={{ background: 'none', border: 'none', color: C.muted, cursor: 'pointer', padding: 4 }}
+                  >
+                    <X size={14} />
+                  </button>
+                )}
               </div>
-              <input
-                value={s.event_name}
-                onChange={(e) => updateStep(i, e.target.value)}
-                placeholder={`Event name, e.g. page_view`}
-                style={{
-                  flex: 1,
-                  background: C.bg,
-                  border: `1px solid ${C.border}`,
-                  borderRadius: 8,
-                  padding: '0.55rem 0.875rem',
-                  color: C.text,
-                  fontSize: 14,
-                  outline: 'none',
-                }}
-                onFocus={(e) => (e.target.style.borderColor = C.amber)}
-                onBlur={(e) => (e.target.style.borderColor = C.border)}
-              />
-              {steps.length > 2 && (
+              {/* Filters */}
+              <div style={{ marginLeft: 32, marginTop: 4 }}>
+                {s.filters.map((f, fi) => (
+                  <div key={fi} style={{ display: 'flex', gap: 4, alignItems: 'center', marginBottom: 4 }}>
+                    <input
+                      value={f.property}
+                      onChange={(e) => updateFilter(i, fi, 'property', e.target.value)}
+                      placeholder="Property"
+                      style={{
+                        width: 100,
+                        background: C.bg,
+                        border: `1px solid ${C.border}`,
+                        borderRadius: 6,
+                        padding: '0.3rem 0.5rem',
+                        color: C.text,
+                        fontSize: 12,
+                        outline: 'none',
+                      }}
+                    />
+                    <input
+                      value={f.value}
+                      onChange={(e) => updateFilter(i, fi, 'value', e.target.value)}
+                      placeholder="Value"
+                      style={{
+                        width: 100,
+                        background: C.bg,
+                        border: `1px solid ${C.border}`,
+                        borderRadius: 6,
+                        padding: '0.3rem 0.5rem',
+                        color: C.text,
+                        fontSize: 12,
+                        outline: 'none',
+                      }}
+                    />
+                    <button
+                      onClick={() => removeFilter(i, fi)}
+                      style={{ background: 'none', border: 'none', color: C.muted, cursor: 'pointer', padding: 2 }}
+                    >
+                      <X size={12} />
+                    </button>
+                  </div>
+                ))}
                 <button
-                  onClick={() => removeStep(i)}
-                  style={{ background: 'none', border: 'none', color: C.muted, cursor: 'pointer', padding: 4 }}
+                  onClick={() => addFilter(i)}
+                  style={{
+                    background: 'none',
+                    border: 'none',
+                    color: C.muted,
+                    cursor: 'pointer',
+                    fontSize: 12,
+                    padding: '2px 0',
+                  }}
                 >
-                  <X size={14} />
+                  + Add filter
                 </button>
-              )}
+              </div>
             </div>
           ))}
           <button
@@ -521,18 +676,29 @@ function EditFunnelModal({
   onUpdated: (f: Funnel) => void
 }) {
   const [name, setName] = useState(funnel.name)
-  const [steps, setSteps] = useState<FunnelStepInput[]>(
+  const [steps, setSteps] = useState<StepWithFilters[]>(
     funnel.steps?.length > 0
-      ? funnel.steps.map((s) => ({ event_name: s.event_name }))
-      : [{ event_name: '' }, { event_name: '' }]
+      ? funnel.steps.map((s) => ({ event_name: s.event_name, filters: s.filters || [] }))
+      : [{ event_name: '', filters: [] }, { event_name: '', filters: [] }]
   )
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [eventNames, setEventNames] = useState<string[]>([])
 
-  const addStep = () => setSteps((s) => [...s, { event_name: '' }])
+  useEffect(() => {
+    api.getEventNames(projectId).then((d) => setEventNames(d.event_names || [])).catch(() => {})
+  }, [projectId])
+
+  const addStep = () => setSteps((s) => [...s, { event_name: '', filters: [] }])
   const removeStep = (i: number) => setSteps((s) => s.filter((_, idx) => idx !== i))
   const updateStep = (i: number, val: string) =>
-    setSteps((s) => s.map((st, idx) => (idx === i ? { event_name: val } : st)))
+    setSteps((s) => s.map((st, idx) => (idx === i ? { ...st, event_name: val } : st)))
+  const addFilter = (i: number) =>
+    setSteps((s) => s.map((st, idx) => idx === i ? { ...st, filters: [...st.filters, { property: '', value: '' }] } : st))
+  const removeFilter = (stepIdx: number, filterIdx: number) =>
+    setSteps((s) => s.map((st, i) => i === stepIdx ? { ...st, filters: st.filters.filter((_, fi) => fi !== filterIdx) } : st))
+  const updateFilter = (stepIdx: number, filterIdx: number, field: 'property' | 'value', val: string) =>
+    setSteps((s) => s.map((st, i) => i === stepIdx ? { ...st, filters: st.filters.map((f, fi) => fi === filterIdx ? { ...f, [field]: val } : f) } : st))
 
   const handleSave = async () => {
     if (!name.trim()) { setError('Name is required'); return }
@@ -540,7 +706,11 @@ function EditFunnelModal({
     setSaving(true)
     setError(null)
     try {
-      const updated = await api.updateFunnel(projectId, funnel.id, { name, steps })
+      const apiSteps: FunnelStepInput[] = steps.map((s) => ({
+        event_name: s.event_name,
+        ...(s.filters.length > 0 ? { filters: s.filters.filter((f) => f.property && f.value) } : {}),
+      }))
+      const updated = await api.updateFunnel(projectId, funnel.id, { name, steps: apiSteps })
       onUpdated(updated)
     } catch (e) {
       setError(String(e))
@@ -615,47 +785,93 @@ function EditFunnelModal({
         <div style={{ marginBottom: '1.25rem' }}>
           <label style={{ display: 'block', fontSize: 13, color: C.muted, marginBottom: 10 }}>Steps</label>
           {steps.map((s, i) => (
-            <div key={i} style={{ display: 'flex', gap: 8, marginBottom: 8, alignItems: 'center' }}>
-              <div style={{
-                width: 24,
-                height: 24,
-                background: C.amber,
-                color: '#0f1117',
-                borderRadius: '50%',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                fontSize: 12,
-                fontWeight: 800,
-                flexShrink: 0,
-              }}>
-                {i + 1}
+            <div key={i} style={{ marginBottom: 10 }}>
+              <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                <div style={{
+                  width: 24,
+                  height: 24,
+                  background: C.amber,
+                  color: '#0f1117',
+                  borderRadius: '50%',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: 12,
+                  fontWeight: 800,
+                  flexShrink: 0,
+                }}>
+                  {i + 1}
+                </div>
+                <EventNameInput
+                  value={s.event_name}
+                  onChange={(val) => updateStep(i, val)}
+                  eventNames={eventNames}
+                />
+                {steps.length > 1 && (
+                  <button
+                    onClick={() => removeStep(i)}
+                    style={{ background: 'none', border: 'none', color: C.muted, cursor: 'pointer', padding: 4 }}
+                  >
+                    <X size={14} />
+                  </button>
+                )}
               </div>
-              <input
-                value={s.event_name}
-                onChange={(e) => updateStep(i, e.target.value)}
-                placeholder={`Event name, e.g. page_view`}
-                style={{
-                  flex: 1,
-                  background: C.bg,
-                  border: `1px solid ${C.border}`,
-                  borderRadius: 8,
-                  padding: '0.55rem 0.875rem',
-                  color: C.text,
-                  fontSize: 14,
-                  outline: 'none',
-                }}
-                onFocus={(e) => (e.target.style.borderColor = C.amber)}
-                onBlur={(e) => (e.target.style.borderColor = C.border)}
-              />
-              {steps.length > 1 && (
+              {/* Filters */}
+              <div style={{ marginLeft: 32, marginTop: 4 }}>
+                {s.filters.map((f, fi) => (
+                  <div key={fi} style={{ display: 'flex', gap: 4, alignItems: 'center', marginBottom: 4 }}>
+                    <input
+                      value={f.property}
+                      onChange={(e) => updateFilter(i, fi, 'property', e.target.value)}
+                      placeholder="Property"
+                      style={{
+                        width: 100,
+                        background: C.bg,
+                        border: `1px solid ${C.border}`,
+                        borderRadius: 6,
+                        padding: '0.3rem 0.5rem',
+                        color: C.text,
+                        fontSize: 12,
+                        outline: 'none',
+                      }}
+                    />
+                    <input
+                      value={f.value}
+                      onChange={(e) => updateFilter(i, fi, 'value', e.target.value)}
+                      placeholder="Value"
+                      style={{
+                        width: 100,
+                        background: C.bg,
+                        border: `1px solid ${C.border}`,
+                        borderRadius: 6,
+                        padding: '0.3rem 0.5rem',
+                        color: C.text,
+                        fontSize: 12,
+                        outline: 'none',
+                      }}
+                    />
+                    <button
+                      onClick={() => removeFilter(i, fi)}
+                      style={{ background: 'none', border: 'none', color: C.muted, cursor: 'pointer', padding: 2 }}
+                    >
+                      <X size={12} />
+                    </button>
+                  </div>
+                ))}
                 <button
-                  onClick={() => removeStep(i)}
-                  style={{ background: 'none', border: 'none', color: C.muted, cursor: 'pointer', padding: 4 }}
+                  onClick={() => addFilter(i)}
+                  style={{
+                    background: 'none',
+                    border: 'none',
+                    color: C.muted,
+                    cursor: 'pointer',
+                    fontSize: 12,
+                    padding: '2px 0',
+                  }}
                 >
-                  <X size={14} />
+                  + Add filter
                 </button>
-              )}
+              </div>
             </div>
           ))}
           <button
@@ -1137,6 +1353,7 @@ export default function Funnels() {
                 <button
                   key={seg.id}
                   onClick={() => setActiveSegment(seg.id)}
+                  title={seg.tip}
                   style={{
                     padding: '0.35rem 0.875rem',
                     borderRadius: 99,

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -146,7 +146,7 @@ export default function Settings() {
     try {
       await api.updateProject(projectId, { name, domain })
       refetchProjects()
-      setProjectSaveMsg('Saved!')
+      setProjectSaveMsg(projectId)
       setTimeout(() => setProjectSaveMsg(null), 2000)
     } catch (e) {
       setError(String(e))
@@ -387,9 +387,9 @@ export default function Settings() {
                   </button>
                 )}
               </div>
-              {projectSaveMsg && savingProject === null && (
+              {projectSaveMsg === p.id && savingProject === null && (
                 <div style={{ width: '100%', fontSize: 13, color: C.success, paddingTop: 2 }}>
-                  {projectSaveMsg}
+                  Saved!
                 </div>
               )}
               {deleteProjectConfirm === p.id && (
@@ -470,6 +470,28 @@ export default function Settings() {
           </div>
           <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
             <CopyButton value={snippet} />
+          </div>
+
+          {/* Segments reference */}
+          <div style={{ marginTop: '1rem', paddingTop: '0.75rem', borderTop: `1px solid ${C.border}` }}>
+            <div style={{ fontSize: 12, fontWeight: 600, color: C.muted, marginBottom: 6 }}>
+              Segments reference
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <div style={{ fontSize: 12, color: C.muted }}>
+                <span style={{ color: C.text }}>Mobile / Desktop / Tablet</span> — Detected automatically from the browser User-Agent.
+              </div>
+              <div style={{ fontSize: 12, color: C.muted }}>
+                <span style={{ color: C.text }}>Logged in / Not logged in</span> — Call{' '}
+                <code style={{ fontFamily: '"SF Mono", "Fira Code", monospace', color: C.amber, fontSize: 12 }}>
+                  funnelbarn.identify('user-id')
+                </code>{' '}
+                after login.
+              </div>
+              <div style={{ fontSize: 12, color: C.muted }}>
+                <span style={{ color: C.text }}>New visitors / Returning</span> — Tracked automatically via session in localStorage.
+              </div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- **Project domain support**: Add `domain` column to projects table (migration 00002) with full backend persistence — fixes the Settings page save bug where domain edits were silently discarded
- **CORS fix**: Empty `FUNNELBARN_ALLOWED_ORIGINS` now correctly falls back to `*` instead of silently blocking all cross-origin requests
- **Settings "Saved!" fix**: Message now only shows on the specific project that was saved, not all of them
- **Project list sorting**: ProjectPicker dropdown sorts alphabetically (case-insensitive)
- **Funnel step property filters**: Steps can filter on event properties (e.g. `page_view` where `page = /pricing`) using `json_extract` — UI exposed via "+ Add filter" in Create/Edit modals
- **Event name autocomplete**: New `GET /api/v1/projects/{id}/event-names` endpoint powers an autocomplete dropdown in funnel step inputs, making it easy to reuse event names across funnels
- **Segment documentation in-app**: Tooltips on segment buttons explain how each segment is tracked; Settings page includes a segments reference block with `identify()` guidance
- **Implementation snippets**: Now show `page()`, event properties (`{ form, page, label }`), and `identify()` across all 6 language examples

## Test plan
- [ ] Create/edit a project with a domain in Settings — verify it persists on refresh
- [ ] Verify "Saved!" only appears on the project row that was saved
- [ ] Check project dropdown is sorted alphabetically
- [ ] Create a funnel with step filters (e.g. `page_view` with property `page` = `/pricing`)
- [ ] Verify event name autocomplete shows existing events in funnel step inputs
- [ ] Hover segment buttons to see tooltips; check Settings page segments reference
- [ ] Send a cross-origin event from a different domain to verify CORS works
- [ ] Verify GitHub Pages deploys successfully