### PR TITLE
fix: hyphenated subdomains for Cloudflare SSL

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -234,7 +234,7 @@ jobs:
 
       - name: Run E2E tests
         env:
-          E2E_BASE_URL: https://funnelbarn.test.wiebe.xyz
+          E2E_BASE_URL: https://funnelbarn-test.wiebe.xyz
           # k3s cluster private IP — reachable from the Mac Mini runner
           E2E_CLUSTER_IP: 192.168.4.108
         run: npx playwright test --reporter=list

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+# FunnelBarn
+
+## CI/CD Pipeline
+
+- **PR quality gates** (`ci.yml`): go fmt, go vet, staticcheck, tsc, eslint, vitest — runs on all PRs
+- **Testing** (`build-and-test.yml`): auto-deploys every push to `main` → `funnelbarn-testing` namespace
+- **Staging** (`build-and-test.yml`): auto-deploys every push to `main` → `funnelbarn-staging` namespace (runs after testing succeeds)
+- **Production** (`deploy-production.yml`): manual workflow_dispatch — provide a git tag (e.g. `v0.1.0`), it resolves the tag to a commit SHA, verifies images exist in GHCR, then deploys to `funnelbarn` namespace
+- Images are tagged by commit SHA in GHCR (`ghcr.io/webwiebe/funnelbarn/service` and `ghcr.io/webwiebe/funnelbarn/web`)
+- All deploy jobs run on self-hosted runners; CI quality checks run on ubuntu
+
+## Environments
+
+- **Production**: `funnelbarn.wiebe.xyz`
+- **Testing**: `funnelbarn-test.wiebe.xyz`
+- **Staging**: `funnelbarn-staging.wiebe.xyz`
+- Subdomains use hyphens (`app-env.wiebe.xyz`), never dots (`app.env.wiebe.xyz`) — free Cloudflare SSL only covers `*.wiebe.xyz`
+
+## Workflow
+
+- Always use PRs — never push directly to main

--- a/deploy/k8s/staging/deployment.yaml
+++ b/deploy/k8s/staging/deployment.yaml
@@ -30,7 +30,7 @@ spec:
             - name: FUNNELBARN_ADDR
               value: :8080
             - name: FUNNELBARN_PUBLIC_URL
-              value: https://funnelbarn.staging.wiebe.xyz
+              value: https://funnelbarn-staging.wiebe.xyz
             - name: FUNNELBARN_SPOOL_DIR
               value: /var/lib/funnelbarn/spool
             - name: FUNNELBARN_DB_PATH

--- a/deploy/k8s/staging/ingress.yaml
+++ b/deploy/k8s/staging/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
-    - host: funnelbarn.staging.wiebe.xyz
+    - host: funnelbarn-staging.wiebe.xyz
       http:
         paths:
           - path: /api
@@ -28,4 +28,4 @@ spec:
                   name: http
   tls:
     - hosts:
-        - funnelbarn.staging.wiebe.xyz
+        - funnelbarn-staging.wiebe.xyz

--- a/deploy/k8s/testing/deployment.yaml
+++ b/deploy/k8s/testing/deployment.yaml
@@ -30,7 +30,7 @@ spec:
             - name: FUNNELBARN_ADDR
               value: :8080
             - name: FUNNELBARN_PUBLIC_URL
-              value: https://funnelbarn.test.wiebe.xyz
+              value: https://funnelbarn-test.wiebe.xyz
             - name: FUNNELBARN_LOGIN_RATE_PER_MINUTE
               value: "1000"
             - name: FUNNELBARN_LOGIN_RATE_BURST

--- a/deploy/k8s/testing/ingress.yaml
+++ b/deploy/k8s/testing/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
-    - host: funnelbarn.test.wiebe.xyz
+    - host: funnelbarn-test.wiebe.xyz
       http:
         paths:
           - path: /api
@@ -28,4 +28,4 @@ spec:
                   name: http
   tls:
     - hosts:
-        - funnelbarn.test.wiebe.xyz
+        - funnelbarn-test.wiebe.xyz


### PR DESCRIPTION
## Summary
- Rename `funnelbarn.test.wiebe.xyz` → `funnelbarn-test.wiebe.xyz`
- Rename `funnelbarn.staging.wiebe.xyz` → `funnelbarn-staging.wiebe.xyz`
- Update e2e base URL in CI workflow
- Add CLAUDE.md with CI/CD docs and environment info

Free Cloudflare SSL only covers `*.wiebe.xyz`, not `*.*.wiebe.xyz`. Double subdomains cause SSL cert errors (BugBarn DEF-1).

## Test plan
- [ ] Verify DNS records exist for `funnelbarn-test.wiebe.xyz` and `funnelbarn-staging.wiebe.xyz`
- [ ] Confirm testing/staging environments load over HTTPS after deploy