### PR TITLE
fix: use nijmegen.wiebe.xyz for test/staging

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -234,7 +234,7 @@ jobs:
 
       - name: Run E2E tests
         env:
-          E2E_BASE_URL: https://funnelbarn-test.wiebe.xyz
+          E2E_BASE_URL: https://funnelbarn-test.nijmegen.wiebe.xyz
           # k3s cluster private IP — reachable from the Mac Mini runner
           E2E_CLUSTER_IP: 192.168.4.108
         run: npx playwright test --reporter=list

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,10 +11,10 @@
 
 ## Environments
 
-- **Production**: `funnelbarn.wiebe.xyz`
-- **Testing**: `funnelbarn-test.wiebe.xyz`
-- **Staging**: `funnelbarn-staging.wiebe.xyz`
-- Subdomains use hyphens (`app-env.wiebe.xyz`), never dots (`app.env.wiebe.xyz`) — free Cloudflare SSL only covers `*.wiebe.xyz`
+- **Production**: `funnelbarn.wiebe.xyz` (Cloudflare → k3s)
+- **Testing**: `funnelbarn-test.nijmegen.wiebe.xyz` (Caddy @ 192.168.4.111 → k3s)
+- **Staging**: `funnelbarn-staging.nijmegen.wiebe.xyz` (Caddy @ 192.168.4.111 → k3s)
+- Non-production uses `*.nijmegen.wiebe.xyz` wildcard — Caddy handles TLS, no Cloudflare free-tier limits
 
 ## Workflow
 

--- a/deploy/k8s/staging/deployment.yaml
+++ b/deploy/k8s/staging/deployment.yaml
@@ -30,7 +30,7 @@ spec:
             - name: FUNNELBARN_ADDR
               value: :8080
             - name: FUNNELBARN_PUBLIC_URL
-              value: https://funnelbarn-staging.wiebe.xyz
+              value: https://funnelbarn-staging.nijmegen.wiebe.xyz
             - name: FUNNELBARN_SPOOL_DIR
               value: /var/lib/funnelbarn/spool
             - name: FUNNELBARN_DB_PATH

--- a/deploy/k8s/staging/ingress.yaml
+++ b/deploy/k8s/staging/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
-    - host: funnelbarn-staging.wiebe.xyz
+    - host: funnelbarn-staging.nijmegen.wiebe.xyz
       http:
         paths:
           - path: /api
@@ -28,4 +28,4 @@ spec:
                   name: http
   tls:
     - hosts:
-        - funnelbarn-staging.wiebe.xyz
+        - funnelbarn-staging.nijmegen.wiebe.xyz

--- a/deploy/k8s/testing/deployment.yaml
+++ b/deploy/k8s/testing/deployment.yaml
@@ -30,7 +30,7 @@ spec:
             - name: FUNNELBARN_ADDR
               value: :8080
             - name: FUNNELBARN_PUBLIC_URL
-              value: https://funnelbarn-test.wiebe.xyz
+              value: https://funnelbarn-test.nijmegen.wiebe.xyz
             - name: FUNNELBARN_LOGIN_RATE_PER_MINUTE
               value: "1000"
             - name: FUNNELBARN_LOGIN_RATE_BURST

--- a/deploy/k8s/testing/ingress.yaml
+++ b/deploy/k8s/testing/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
-    - host: funnelbarn-test.wiebe.xyz
+    - host: funnelbarn-test.nijmegen.wiebe.xyz
       http:
         paths:
           - path: /api
@@ -28,4 +28,4 @@ spec:
                   name: http
   tls:
     - hosts:
-        - funnelbarn-test.wiebe.xyz
+        - funnelbarn-test.nijmegen.wiebe.xyz


### PR DESCRIPTION
## Summary
- Route testing/staging through `*.nijmegen.wiebe.xyz` wildcard (Caddy → k3s)
- `funnelbarn-test.nijmegen.wiebe.xyz` and `funnelbarn-staging.nijmegen.wiebe.xyz`
- Caddy handles TLS, sidesteps Cloudflare free-tier wildcard limits entirely

## Test plan
- [ ] Verify Caddy picks up the new subdomains automatically via wildcard
- [ ] Confirm HTTPS works on both testing and staging after deploy