### PR TITLE
fix: dashboard crash and BugBarn error queue

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -180,10 +180,10 @@ export interface DashboardData {
   total_events: number
   unique_sessions: number
   bounce_rate: number
-  top_pages: { URL: string; Views: number }[]
-  top_referrers: { Domain: string; Visits: number }[]
+  top_pages: { url: string; views: number }[]
+  top_referrers: { domain: string; visits: number }[]
   top_event_names: { name: string; count: number }[]
-  events_time_series: { Time: string; Count: number }[]
+  events_time_series: { time: string; count: number }[]
 }
 
 export interface Event {

--- a/web/src/lib/bugbarn.ts
+++ b/web/src/lib/bugbarn.ts
@@ -1,6 +1,7 @@
 // BugBarn error reporting utility.
 // Config is fetched from /api/v1/client-config at runtime so the Docker image
-// is environment-agnostic. Falls back to console.error only when unconfigured.
+// is environment-agnostic. Errors arriving before config loads are queued and
+// flushed once the endpoint is known.
 
 interface ClientConfig {
   bugbarn_endpoint: string
@@ -9,11 +10,10 @@ interface ClientConfig {
 
 let endpoint = ''
 let ingestKey = ''
-let initialized = false
+let configReady = false
+const pendingQueue: BugBarnPayload[] = []
 
 async function loadConfig(): Promise<void> {
-  if (initialized) return
-  initialized = true
   try {
     const res = await fetch('/api/v1/client-config')
     if (!res.ok) return
@@ -22,10 +22,14 @@ async function loadConfig(): Promise<void> {
     ingestKey = cfg.bugbarn_ingest_key ?? ''
   } catch {
     // Config fetch failed — reporting falls back to console.error.
+  } finally {
+    configReady = true
+    for (const payload of pendingQueue.splice(0)) {
+      sendToBugBarn(payload)
+    }
   }
 }
 
-// Kick off config fetch immediately so it's ready before the first error.
 loadConfig()
 
 export interface BugBarnPayload {
@@ -33,7 +37,7 @@ export interface BugBarnPayload {
   properties: Record<string, unknown>
 }
 
-export function reportToBugBarn(payload: BugBarnPayload): void {
+function sendToBugBarn(payload: BugBarnPayload): void {
   if (!endpoint || !ingestKey) {
     console.error('[BugBarn not configured]', payload.name, payload.properties)
     return
@@ -51,6 +55,14 @@ export function reportToBugBarn(payload: BugBarnPayload): void {
   } catch {
     // Never throw from error reporting.
   }
+}
+
+export function reportToBugBarn(payload: BugBarnPayload): void {
+  if (!configReady) {
+    pendingQueue.push(payload)
+    return
+  }
+  sendToBugBarn(payload)
 }
 
 export function reportError(

--- a/web/src/pages/Dashboard.test.tsx
+++ b/web/src/pages/Dashboard.test.tsx
@@ -43,10 +43,10 @@ const mockDashboard: DashboardData = {
   total_events: 42,
   unique_sessions: 7,
   bounce_rate: 0.42,
-  top_pages: [{ URL: '/home', Views: 30 }],
-  top_referrers: [{ Domain: 'google.com', Visits: 10 }],
+  top_pages: [{ url: '/home', views: 30 }],
+  top_referrers: [{ domain: 'google.com', visits: 10 }],
   top_event_names: [{ name: 'page_view', count: 30 }],
-  events_time_series: [{ Time: '2024-01-01T00:00:00Z', Count: 42 }],
+  events_time_series: [{ time: '2024-01-01T00:00:00Z', count: 42 }],
 }
 
 function renderDashboard(projectId = 'p1') {

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -155,36 +155,36 @@ export default function Dashboard() {
 
   // Format time series for chart
   const chartData = data?.events_time_series?.map((pt) => ({
-    time: new Date(pt.Time).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
-    events: pt.Count,
+    time: new Date(pt.time).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+    events: pt.count,
   })) ?? []
 
   // Referrer data for pie chart
   const referrerData = data?.top_referrers?.slice(0, 6).map((r) => ({
-    name: r.Domain || 'Direct',
-    value: r.Visits,
+    name: r.domain || 'Direct',
+    value: r.visits,
   })) ?? []
 
   // Max views for inline bar
-  const maxViews = data?.top_pages ? Math.max(...data.top_pages.map((p) => p.Views)) : 1
+  const maxViews = data?.top_pages ? Math.max(...data.top_pages.map((p) => p.views)) : 1
 
   // Compute real trends from time-series data (first vs last half of period)
   const eventsTrend = (() => {
     const ts = data?.events_time_series
     if (!ts || ts.length < 2) return undefined
     const mid = Math.floor(ts.length / 2)
-    const prev = ts.slice(0, mid).reduce((s, p) => s + p.Count, 0)
-    const curr = ts.slice(mid).reduce((s, p) => s + p.Count, 0)
+    const prev = ts.slice(0, mid).reduce((s, p) => s + p.count, 0)
+    const curr = ts.slice(mid).reduce((s, p) => s + p.count, 0)
     if (prev === 0) return undefined
     return ((curr - prev) / prev) * 100
   })()
 
   const sessionsTrend = (() => {
-    const ts = (data as (DashboardData & { sessions_time_series?: { Time: string; Count: number }[] }) | null)?.sessions_time_series
+    const ts = (data as (DashboardData & { sessions_time_series?: { time: string; count: number }[] }) | null)?.sessions_time_series
     if (!ts || ts.length < 2) return undefined
     const mid = Math.floor(ts.length / 2)
-    const prev = ts.slice(0, mid).reduce((s, p) => s + p.Count, 0)
-    const curr = ts.slice(mid).reduce((s, p) => s + p.Count, 0)
+    const prev = ts.slice(0, mid).reduce((s, p) => s + p.count, 0)
+    const curr = ts.slice(mid).reduce((s, p) => s + p.count, 0)
     if (prev === 0) return undefined
     return ((curr - prev) / prev) * 100
   })()
@@ -499,7 +499,7 @@ export default function Dashboard() {
           ) : (
             <div>
               {data.top_pages.slice(0, 8).map((p) => (
-                <div key={p.URL} style={{ marginBottom: '0.75rem' }}>
+                <div key={p.url} style={{ marginBottom: '0.75rem' }}>
                   <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4 }}>
                     <div style={{
                       fontSize: 13,
@@ -509,14 +509,14 @@ export default function Dashboard() {
                       textOverflow: 'ellipsis',
                       whiteSpace: 'nowrap',
                     }}>
-                      {p.URL}
+                      {p.url}
                     </div>
-                    <div style={{ fontSize: 13, fontWeight: 700, color: C.amber }}>{p.Views.toLocaleString()}</div>
+                    <div style={{ fontSize: 13, fontWeight: 700, color: C.amber }}>{p.views.toLocaleString()}</div>
                   </div>
                   <div style={{ height: 4, background: '#2a2d3a', borderRadius: 2 }}>
                     <div style={{
                       height: '100%',
-                      width: `${(p.Views / maxViews) * 100}%`,
+                      width: `${(p.views / maxViews) * 100}%`,
                       background: C.amber,
                       borderRadius: 2,
                     }} />


### PR DESCRIPTION
## Summary
- Fix `Cannot read properties of undefined (reading 'toLocaleString')` — API returns lowercase `url`/`views`/`domain`/`visits`/`time`/`count` but types used PascalCase
- Queue BugBarn error reports arriving before client-config loads, flush once ready — prevents early render crashes from being silently dropped to console.error

## Test plan
- [ ] Dashboard loads without crash and shows top pages, referrers, time series
- [ ] Trigger a JS error early in page load — verify it appears in BugBarn