### PR TITLE
feat: event discovery and filter autocomplete for funnel builder

### DIFF
--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -39,6 +39,59 @@ func (s *Server) handleEventNames(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"event_names": names})
 }
 
+// handleEventProperties returns distinct JSON property keys for a given event name.
+func (s *Server) handleEventProperties(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	if projectID == "" {
+		jsonError(w, "project id required", http.StatusBadRequest)
+		return
+	}
+	eventName := r.URL.Query().Get("event_name")
+	if eventName == "" {
+		jsonError(w, "event_name query parameter required", http.StatusBadRequest)
+		return
+	}
+
+	props, err := s.events.DistinctEventProperties(r.Context(), projectID, eventName)
+	if err != nil {
+		mapServiceError(w, err, "handleEventProperties")
+		return
+	}
+	if props == nil {
+		props = []string{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"properties": props})
+}
+
+// handleEventPropertyValues returns distinct values for a property key on a given event name.
+func (s *Server) handleEventPropertyValues(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	if projectID == "" {
+		jsonError(w, "project id required", http.StatusBadRequest)
+		return
+	}
+	eventName := r.URL.Query().Get("event_name")
+	if eventName == "" {
+		jsonError(w, "event_name query parameter required", http.StatusBadRequest)
+		return
+	}
+	property := r.URL.Query().Get("property")
+	if property == "" {
+		jsonError(w, "property query parameter required", http.StatusBadRequest)
+		return
+	}
+
+	vals, err := s.events.DistinctPropertyValues(r.Context(), projectID, eventName, property, 50)
+	if err != nil {
+		mapServiceError(w, err, "handleEventPropertyValues")
+		return
+	}
+	if vals == nil {
+		vals = []string{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"values": vals})
+}
+
 // handleListEvents returns a paginated list of events for a project.
 func (s *Server) handleListEvents(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -6,12 +6,18 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 )
+
+func now() time.Time { return time.Now().UTC().Truncate(time.Second) }
+
+func randomID() string { return fmt.Sprintf("%x", time.Now().UnixNano()) }
 
 // ---------------------------------------------------------------------------
 // A/B test handlers
@@ -354,5 +360,88 @@ func TestHandleListEvents_PaginationClamped(t *testing.T) {
 	// limit in response should be clamped to ≤ 500
 	if lim, ok := resp["limit"].(float64); ok && lim > 500 {
 		t.Errorf("limit clamped: want ≤ 500, got %.0f", lim)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Event properties / property values handlers
+// ---------------------------------------------------------------------------
+
+func TestHandleEventProperties_Success(t *testing.T) {
+	srv, store := newTestServer(t)
+	ctx := context.Background()
+	p, _ := store.CreateProject(ctx, "PropsSite", "propssite")
+
+	_ = store.InsertEvent(ctx, repository.Event{
+		ID: "ep1", ProjectID: p.ID, SessionID: "s1", Name: "signup",
+		Properties: `{"plan":"pro","source":"ads"}`,
+		IngestID: "i-ep1", OccurredAt: now(),
+	})
+
+	w := getJSON(t, srv, "/api/v1/projects/"+p.ID+"/event-properties?event_name=signup", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Properties []string `json:"properties"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Properties) != 2 {
+		t.Fatalf("want 2 properties, got %d: %v", len(resp.Properties), resp.Properties)
+	}
+}
+
+func TestHandleEventProperties_MissingEventName(t *testing.T) {
+	srv, store := newTestServer(t)
+	ctx := context.Background()
+	p, _ := store.CreateProject(ctx, "PropsNoName", "propsnoname")
+
+	w := getJSON(t, srv, "/api/v1/projects/"+p.ID+"/event-properties", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", w.Code)
+	}
+}
+
+func TestHandleEventPropertyValues_Success(t *testing.T) {
+	srv, store := newTestServer(t)
+	ctx := context.Background()
+	p, _ := store.CreateProject(ctx, "ValsSite", "valssite")
+
+	for _, plan := range []string{"pro", "free", "pro"} {
+		_ = store.InsertEvent(ctx, repository.Event{
+			ID: randomID(), ProjectID: p.ID, SessionID: "s1", Name: "signup",
+			Properties: `{"plan":"` + plan + `"}`,
+			IngestID: randomID(), OccurredAt: now(),
+		})
+	}
+
+	w := getJSON(t, srv, "/api/v1/projects/"+p.ID+"/event-property-values?event_name=signup&property=plan", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Values []string `json:"values"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Values) != 2 {
+		t.Fatalf("want 2 distinct values, got %d: %v", len(resp.Values), resp.Values)
+	}
+}
+
+func TestHandleEventPropertyValues_MissingParams(t *testing.T) {
+	srv, store := newTestServer(t)
+	ctx := context.Background()
+	p, _ := store.CreateProject(ctx, "ValsNoParam", "valsnoparam")
+
+	// Missing event_name
+	w1 := getJSON(t, srv, "/api/v1/projects/"+p.ID+"/event-property-values?property=plan", nil)
+	if w1.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 for missing event_name, got %d", w1.Code)
+	}
+
+	// Missing property
+	w2 := getJSON(t, srv, "/api/v1/projects/"+p.ID+"/event-property-values?event_name=signup", nil)
+	if w2.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 for missing property, got %d", w2.Code)
 	}
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -375,7 +375,7 @@ func TestHandleEventProperties_Success(t *testing.T) {
 	_ = store.InsertEvent(ctx, repository.Event{
 		ID: "ep1", ProjectID: p.ID, SessionID: "s1", Name: "signup",
 		Properties: `{"plan":"pro","source":"ads"}`,
-		IngestID: "i-ep1", OccurredAt: now(),
+		IngestID:   "i-ep1", OccurredAt: now(),
 	})
 
 	w := getJSON(t, srv, "/api/v1/projects/"+p.ID+"/event-properties?event_name=signup", nil)
@@ -411,7 +411,7 @@ func TestHandleEventPropertyValues_Success(t *testing.T) {
 		_ = store.InsertEvent(ctx, repository.Event{
 			ID: randomID(), ProjectID: p.ID, SessionID: "s1", Name: "signup",
 			Properties: `{"plan":"` + plan + `"}`,
-			IngestID: randomID(), OccurredAt: now(),
+			IngestID:   randomID(), OccurredAt: now(),
 		})
 	}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -130,6 +130,8 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/dashboard", s.requireSession(s.handleDashboard))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/events", s.requireSession(s.handleListEvents))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/event-names", s.requireSession(s.handleEventNames))
+	s.mux.HandleFunc("GET /api/v1/projects/{id}/event-properties", s.requireSession(s.handleEventProperties))
+	s.mux.HandleFunc("GET /api/v1/projects/{id}/event-property-values", s.requireSession(s.handleEventPropertyValues))
 
 	// Funnels
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/funnels", s.requireSession(s.handleListFunnels))

--- a/internal/repository/events.go
+++ b/internal/repository/events.go
@@ -609,6 +609,62 @@ func (s *Store) DistinctEventNames(ctx context.Context, projectID string) ([]str
 	return names, rows.Err()
 }
 
+// DistinctEventProperties returns all unique JSON property keys used by events
+// with the given name for a project.
+func (s *Store) DistinctEventProperties(ctx context.Context, projectID, eventName string) ([]string, error) {
+	const q = `
+		SELECT DISTINCT j.key
+		FROM events e, json_each(e.properties) j
+		WHERE e.project_id = ? AND e.name = ? AND e.properties != '' AND e.properties IS NOT NULL
+		ORDER BY j.key`
+	rows, err := s.db.QueryContext(ctx, q, projectID, eventName)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var keys []string
+	for rows.Next() {
+		var k string
+		if err := rows.Scan(&k); err != nil {
+			return nil, err
+		}
+		keys = append(keys, k)
+	}
+	return keys, rows.Err()
+}
+
+// DistinctPropertyValues returns up to `limit` unique values for a JSON
+// property key on events with the given name for a project.
+func (s *Store) DistinctPropertyValues(ctx context.Context, projectID, eventName, property string, limit int) ([]string, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	const q = `
+		SELECT DISTINCT json_extract(e.properties, '$.' || ?) AS val
+		FROM events e
+		WHERE e.project_id = ? AND e.name = ?
+		  AND e.properties != '' AND e.properties IS NOT NULL
+		  AND val IS NOT NULL AND val != ''
+		ORDER BY val
+		LIMIT ?`
+	rows, err := s.db.QueryContext(ctx, q, property, projectID, eventName, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var vals []string
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			return nil, err
+		}
+		vals = append(vals, v)
+	}
+	return vals, rows.Err()
+}
+
 // TopOS is an alias for TopOSSystems kept for backward compatibility in tests.
 func (s *Store) TopOS(ctx context.Context, projectID string, from, to time.Time, limit int) ([]OSStat, error) {
 	return s.TopOSSystems(ctx, projectID, from, to, limit)

--- a/internal/repository/events_test.go
+++ b/internal/repository/events_test.go
@@ -581,6 +581,84 @@ func TestFunnelSegmentData(t *testing.T) {
 	require.Empty(t, segs.DeviceTypes) // no events
 }
 
+func TestDistinctEventProperties(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	p, _ := s.CreateProject(ctx, "EvtProps", "evtprops")
+
+	// Insert events with JSON properties.
+	e1 := repository.Event{
+		ID:         randomHex(t),
+		ProjectID:  p.ID,
+		SessionID:  "s1",
+		Name:       "signup",
+		Properties: `{"plan":"pro","source":"google"}`,
+		IngestID:   "ingest-" + randomHex(t),
+		OccurredAt: time.Now().UTC().Truncate(time.Second),
+	}
+	e2 := repository.Event{
+		ID:         randomHex(t),
+		ProjectID:  p.ID,
+		SessionID:  "s2",
+		Name:       "signup",
+		Properties: `{"plan":"free","region":"eu"}`,
+		IngestID:   "ingest-" + randomHex(t),
+		OccurredAt: time.Now().UTC().Truncate(time.Second),
+	}
+	require.NoError(t, s.InsertEvent(ctx, e1))
+	require.NoError(t, s.InsertEvent(ctx, e2))
+
+	props, err := s.DistinctEventProperties(ctx, p.ID, "signup")
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"plan", "region", "source"}, props)
+
+	// Different event name returns nothing.
+	empty, err := s.DistinctEventProperties(ctx, p.ID, "page_view")
+	require.NoError(t, err)
+	require.Empty(t, empty)
+}
+
+func TestDistinctPropertyValues(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	p, _ := s.CreateProject(ctx, "PropVals", "propvals")
+
+	for _, plan := range []string{"pro", "free", "enterprise", "pro"} {
+		e := repository.Event{
+			ID:         randomHex(t),
+			ProjectID:  p.ID,
+			SessionID:  "s1",
+			Name:       "signup",
+			Properties: fmt.Sprintf(`{"plan":"%s"}`, plan),
+			IngestID:   "ingest-" + randomHex(t),
+			OccurredAt: time.Now().UTC().Truncate(time.Second),
+		}
+		require.NoError(t, s.InsertEvent(ctx, e))
+	}
+
+	vals, err := s.DistinctPropertyValues(ctx, p.ID, "signup", "plan", 50)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"enterprise", "free", "pro"}, vals)
+
+	// Non-existent property returns empty.
+	empty, err := s.DistinctPropertyValues(ctx, p.ID, "signup", "nonexistent", 50)
+	require.NoError(t, err)
+	require.Empty(t, empty)
+}
+
+func TestDistinctEventProperties_EmptyProperties(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	p, _ := s.CreateProject(ctx, "EmptyProps", "emptyprops")
+
+	// Event with no properties.
+	insertEvent(t, s, p.ID, "s1", "click", "https://example.com/")
+
+	props, err := s.DistinctEventProperties(ctx, p.ID, "click")
+	require.NoError(t, err)
+	require.Empty(t, props)
+}
+
 func TestAnalyzeFunnel_WithEqSegment(t *testing.T) {
 	ctx := context.Background()
 	s := newTestStore(t)

--- a/internal/repository/interface.go
+++ b/internal/repository/interface.go
@@ -74,6 +74,8 @@ type Querier interface {
 	UniqueSessionCount(ctx context.Context, projectID string, from, to time.Time) (int64, error)
 	GetEventByIngestID(ctx context.Context, ingestID string) (*Event, error)
 	DistinctEventNames(ctx context.Context, projectID string) ([]string, error)
+	DistinctEventProperties(ctx context.Context, projectID, eventName string) ([]string, error)
+	DistinctPropertyValues(ctx context.Context, projectID, eventName, property string, limit int) ([]string, error)
 	PurgeOldEvents(ctx context.Context, cutoff time.Time) (int64, error)
 }
 

--- a/internal/repository/mock/mock.go
+++ b/internal/repository/mock/mock.go
@@ -557,6 +557,14 @@ func (s *Store) DistinctEventNames(_ context.Context, _ string) ([]string, error
 	return nil, nil
 }
 
+func (s *Store) DistinctEventProperties(_ context.Context, _, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func (s *Store) DistinctPropertyValues(_ context.Context, _, _, _ string, _ int) ([]string, error) {
+	return nil, nil
+}
+
 func (s *Store) PurgeOldEvents(ctx context.Context, cutoff time.Time) (int64, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/service/events.go
+++ b/internal/service/events.go
@@ -80,3 +80,11 @@ func (svc *EventService) GetEventByIngestID(ctx context.Context, ingestID string
 func (svc *EventService) DistinctEventNames(ctx context.Context, projectID string) ([]string, error) {
 	return svc.store.DistinctEventNames(ctx, projectID)
 }
+
+func (svc *EventService) DistinctEventProperties(ctx context.Context, projectID, eventName string) ([]string, error) {
+	return svc.store.DistinctEventProperties(ctx, projectID, eventName)
+}
+
+func (svc *EventService) DistinctPropertyValues(ctx context.Context, projectID, eventName, property string, limit int) ([]string, error) {
+	return svc.store.DistinctPropertyValues(ctx, projectID, eventName, property, limit)
+}

--- a/internal/service/interfaces.go
+++ b/internal/service/interfaces.go
@@ -60,6 +60,8 @@ type Events interface {
 	UniqueSessionCount(ctx context.Context, projectID string, from, to time.Time) (int64, error)
 	GetEventByIngestID(ctx context.Context, ingestID string) (*repository.Event, error)
 	DistinctEventNames(ctx context.Context, projectID string) ([]string, error)
+	DistinctEventProperties(ctx context.Context, projectID, eventName string) ([]string, error)
+	DistinctPropertyValues(ctx context.Context, projectID, eventName, property string, limit int) ([]string, error)
 }
 
 // Sessions is the interface for session-related operations.

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -216,3 +216,36 @@ describe('api.createFunnel', () => {
     expect(body.steps).toEqual(steps)
   })
 })
+
+describe('api.getEventProperties', () => {
+  it('calls the correct URL with encoded event_name', async () => {
+    mockFetch(200, { properties: ['plan', 'source'] })
+    const result = await api.getEventProperties('proj1', 'page view')
+    expect(result.properties).toEqual(['plan', 'source'])
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string]
+    expect(url).toContain('/event-properties?event_name=page%20view')
+  })
+
+  it('returns empty array from server', async () => {
+    mockFetch(200, { properties: [] })
+    const result = await api.getEventProperties('proj1', 'signup')
+    expect(result.properties).toEqual([])
+  })
+})
+
+describe('api.getEventPropertyValues', () => {
+  it('calls the correct URL with encoded params', async () => {
+    mockFetch(200, { values: ['pro', 'free'] })
+    const result = await api.getEventPropertyValues('proj1', 'signup', 'plan')
+    expect(result.values).toEqual(['pro', 'free'])
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string]
+    expect(url).toContain('/event-property-values?event_name=signup&property=plan')
+  })
+
+  it('encodes special characters in property name', async () => {
+    mockFetch(200, { values: [] })
+    await api.getEventPropertyValues('proj1', 'click', 'button name')
+    const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string]
+    expect(url).toContain('property=button%20name')
+  })
+})

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -162,6 +162,13 @@ export const api = {
   getEventNames: (projectId: string) =>
     request<{ event_names: string[] }>(`/api/v1/projects/${projectId}/event-names`),
 
+  // Event properties (autocomplete for filters)
+  getEventProperties: (projectId: string, eventName: string) =>
+    request<{ properties: string[] }>(`/api/v1/projects/${projectId}/event-properties?event_name=${encodeURIComponent(eventName)}`),
+
+  getEventPropertyValues: (projectId: string, eventName: string, property: string) =>
+    request<{ values: string[] }>(`/api/v1/projects/${projectId}/event-property-values?event_name=${encodeURIComponent(eventName)}&property=${encodeURIComponent(property)}`),
+
   // Active sessions (last 5 minutes)
   getActiveSessions: (projectId: string) =>
     request<{ active_sessions: number; window_minutes: number }>(`/api/v1/projects/${projectId}/sessions/active`),

--- a/web/src/pages/Funnels.tsx
+++ b/web/src/pages/Funnels.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef } from 'react'
 import { useParams } from 'react-router-dom'
-import { Plus, X, Layers, Pencil, Trash2 } from 'lucide-react'
+import { Plus, X, Layers, Pencil, Trash2, ChevronDown, ChevronRight } from 'lucide-react'
 import Shell from '../components/shell/Shell'
 import { api, Funnel, FunnelAnalysis, FunnelStepInput } from '../lib/api'
 import { useProjects } from '../lib/projects'
@@ -393,6 +393,159 @@ function EventNameInput({
   )
 }
 
+function AutocompleteInput({
+  value,
+  onChange,
+  placeholder,
+  suggestions,
+  width,
+}: {
+  value: string
+  onChange: (val: string) => void
+  placeholder?: string
+  suggestions: string[]
+  width?: number
+}) {
+  const [open, setOpen] = useState(false)
+  const [focused, setFocused] = useState(false)
+
+  const filtered = suggestions.filter(
+    (s) => s.toLowerCase().includes(value.toLowerCase()) && s !== value
+  )
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <input
+        value={value}
+        onChange={(e) => { onChange(e.target.value); setOpen(true) }}
+        onFocus={() => { setFocused(true); setOpen(true) }}
+        onBlur={() => { setFocused(false); setTimeout(() => setOpen(false), 150) }}
+        placeholder={placeholder}
+        style={{
+          width: width ?? 120,
+          background: C.bg,
+          border: `1px solid ${C.border}`,
+          borderRadius: 6,
+          padding: '0.3rem 0.5rem',
+          color: C.text,
+          fontSize: 12,
+          outline: 'none',
+          boxSizing: 'border-box',
+        }}
+      />
+      {open && focused && filtered.length > 0 && (
+        <div style={{
+          position: 'absolute',
+          top: '100%',
+          left: 0,
+          marginTop: 2,
+          background: C.bg,
+          border: `1px solid ${C.border}`,
+          borderRadius: 6,
+          maxHeight: 120,
+          overflowY: 'auto',
+          zIndex: 200,
+          minWidth: width ?? 120,
+        }}>
+          {filtered.slice(0, 10).map((s) => (
+            <div
+              key={s}
+              onMouseDown={(e) => { e.preventDefault(); onChange(s); setOpen(false) }}
+              style={{
+                padding: '0.3rem 0.5rem',
+                fontSize: 12,
+                color: C.text,
+                cursor: 'pointer',
+              }}
+              onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(245,158,11,0.1)')}
+              onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+            >
+              {s}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function AvailableEventsPanel({
+  eventNames,
+  onSelect,
+}: {
+  eventNames: string[]
+  onSelect: (name: string) => void
+}) {
+  const [expanded, setExpanded] = useState(false)
+
+  if (eventNames.length === 0) return null
+
+  return (
+    <div style={{
+      marginBottom: '1.25rem',
+      background: C.bg,
+      border: `1px solid ${C.border}`,
+      borderRadius: 8,
+    }}>
+      <button
+        onClick={() => setExpanded(!expanded)}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+          width: '100%',
+          background: 'none',
+          border: 'none',
+          color: C.muted,
+          cursor: 'pointer',
+          padding: '0.6rem 0.75rem',
+          fontSize: 13,
+          fontWeight: 600,
+          textAlign: 'left',
+        }}
+      >
+        {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+        Available events ({eventNames.length})
+      </button>
+      {expanded && (
+        <div style={{
+          padding: '0 0.75rem 0.6rem',
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 6,
+        }}>
+          {eventNames.map((name) => (
+            <button
+              key={name}
+              onClick={() => onSelect(name)}
+              style={{
+                background: 'rgba(245,158,11,0.08)',
+                border: `1px solid rgba(245,158,11,0.25)`,
+                borderRadius: 6,
+                color: C.amber,
+                padding: '0.3rem 0.6rem',
+                fontSize: 12,
+                cursor: 'pointer',
+                fontWeight: 500,
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = 'rgba(245,158,11,0.18)'
+                e.currentTarget.style.borderColor = 'rgba(245,158,11,0.5)'
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = 'rgba(245,158,11,0.08)'
+                e.currentTarget.style.borderColor = 'rgba(245,158,11,0.25)'
+              }}
+            >
+              {name}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
 interface StepWithFilters {
   event_name: string
   filters: { property: string; value: string }[]
@@ -415,21 +568,51 @@ function CreateFunnelModal({
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [eventNames, setEventNames] = useState<string[]>([])
+  const [stepProperties, setStepProperties] = useState<Record<number, string[]>>({})
+  const [filterValues, setFilterValues] = useState<Record<string, string[]>>({})
 
   useEffect(() => {
     api.getEventNames(projectId).then((d) => setEventNames(d.event_names || [])).catch(() => {})
   }, [projectId])
 
+  const fetchProperties = (stepIdx: number, eventName: string) => {
+    if (!eventName) return
+    api.getEventProperties(projectId, eventName)
+      .then((d) => setStepProperties((prev) => ({ ...prev, [stepIdx]: d.properties || [] })))
+      .catch(() => {})
+  }
+
+  const fetchPropertyValues = (eventName: string, property: string) => {
+    if (!eventName || !property) return
+    const cacheKey = `${eventName}:${property}`
+    if (filterValues[cacheKey]) return
+    api.getEventPropertyValues(projectId, eventName, property)
+      .then((d) => setFilterValues((prev) => ({ ...prev, [cacheKey]: d.values || [] })))
+      .catch(() => {})
+  }
+
   const addStep = () => setSteps((s) => [...s, { event_name: '', filters: [] }])
   const removeStep = (i: number) => setSteps((s) => s.filter((_, idx) => idx !== i))
-  const updateStep = (i: number, val: string) =>
+  const updateStep = (i: number, val: string) => {
     setSteps((s) => s.map((st, idx) => (idx === i ? { ...st, event_name: val } : st)))
+    fetchProperties(i, val)
+  }
   const addFilter = (i: number) =>
     setSteps((s) => s.map((st, idx) => idx === i ? { ...st, filters: [...st.filters, { property: '', value: '' }] } : st))
+  const addFilterWithProperty = (stepIdx: number, property: string) => {
+    setSteps((s) => s.map((st, i) => i === stepIdx ? { ...st, filters: [...st.filters, { property, value: '' }] } : st))
+    const eventName = steps[stepIdx]?.event_name
+    if (eventName) fetchPropertyValues(eventName, property)
+  }
   const removeFilter = (stepIdx: number, filterIdx: number) =>
     setSteps((s) => s.map((st, i) => i === stepIdx ? { ...st, filters: st.filters.filter((_, fi) => fi !== filterIdx) } : st))
-  const updateFilter = (stepIdx: number, filterIdx: number, field: 'property' | 'value', val: string) =>
+  const updateFilter = (stepIdx: number, filterIdx: number, field: 'property' | 'value', val: string) => {
     setSteps((s) => s.map((st, i) => i === stepIdx ? { ...st, filters: st.filters.map((f, fi) => fi === filterIdx ? { ...f, [field]: val } : f) } : st))
+    if (field === 'property') {
+      const eventName = steps[stepIdx]?.event_name
+      if (eventName && val) fetchPropertyValues(eventName, val)
+    }
+  }
 
   const handleCreate = async () => {
     if (!name.trim()) { setError('Name is required'); return }
@@ -514,6 +697,19 @@ function CreateFunnelModal({
           />
         </div>
 
+        <AvailableEventsPanel
+          eventNames={eventNames}
+          onSelect={(eName) => {
+            const emptyIdx = steps.findIndex((s) => !s.event_name)
+            if (emptyIdx >= 0) {
+              updateStep(emptyIdx, eName)
+            } else {
+              setSteps((prev) => [...prev, { event_name: eName, filters: [] }])
+              fetchProperties(steps.length, eName)
+            }
+          }}
+        />
+
         <div style={{ marginBottom: '1.25rem' }}>
           <label style={{ display: 'block', fontSize: 13, color: C.muted, marginBottom: 10 }}>Steps</label>
           {steps.map((s, i) => (
@@ -548,39 +744,53 @@ function CreateFunnelModal({
                   </button>
                 )}
               </div>
-              {/* Filters */}
               <div style={{ marginLeft: 32, marginTop: 4 }}>
+                {(stepProperties[i] || []).length > 0 && (
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: 4 }}>
+                    {(stepProperties[i] || [])
+                      .filter((p) => !s.filters.some((f) => f.property === p))
+                      .map((prop) => (
+                        <button
+                          key={prop}
+                          onClick={() => addFilterWithProperty(i, prop)}
+                          style={{
+                            background: 'rgba(148,163,184,0.08)',
+                            border: `1px solid ${C.border}`,
+                            borderRadius: 4,
+                            color: C.muted,
+                            padding: '0.15rem 0.4rem',
+                            fontSize: 11,
+                            cursor: 'pointer',
+                          }}
+                          onMouseEnter={(e) => {
+                            e.currentTarget.style.borderColor = C.amber
+                            e.currentTarget.style.color = C.amber
+                          }}
+                          onMouseLeave={(e) => {
+                            e.currentTarget.style.borderColor = C.border
+                            e.currentTarget.style.color = C.muted
+                          }}
+                        >
+                          + {prop}
+                        </button>
+                      ))}
+                  </div>
+                )}
                 {s.filters.map((f, fi) => (
                   <div key={fi} style={{ display: 'flex', gap: 4, alignItems: 'center', marginBottom: 4 }}>
-                    <input
+                    <AutocompleteInput
                       value={f.property}
-                      onChange={(e) => updateFilter(i, fi, 'property', e.target.value)}
+                      onChange={(val) => updateFilter(i, fi, 'property', val)}
                       placeholder="Property"
-                      style={{
-                        width: 100,
-                        background: C.bg,
-                        border: `1px solid ${C.border}`,
-                        borderRadius: 6,
-                        padding: '0.3rem 0.5rem',
-                        color: C.text,
-                        fontSize: 12,
-                        outline: 'none',
-                      }}
+                      suggestions={stepProperties[i] || []}
+                      width={120}
                     />
-                    <input
+                    <AutocompleteInput
                       value={f.value}
-                      onChange={(e) => updateFilter(i, fi, 'value', e.target.value)}
+                      onChange={(val) => updateFilter(i, fi, 'value', val)}
                       placeholder="Value"
-                      style={{
-                        width: 100,
-                        background: C.bg,
-                        border: `1px solid ${C.border}`,
-                        borderRadius: 6,
-                        padding: '0.3rem 0.5rem',
-                        color: C.text,
-                        fontSize: 12,
-                        outline: 'none',
-                      }}
+                      suggestions={filterValues[`${s.event_name}:${f.property}`] || []}
+                      width={120}
                     />
                     <button
                       onClick={() => removeFilter(i, fi)}
@@ -685,21 +895,57 @@ function EditFunnelModal({
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [eventNames, setEventNames] = useState<string[]>([])
+  const [stepProperties, setStepProperties] = useState<Record<number, string[]>>({})
+  const [filterValues, setFilterValues] = useState<Record<string, string[]>>({})
+
+  const fetchProperties = (stepIdx: number, eventName: string) => {
+    if (!eventName) return
+    api.getEventProperties(projectId, eventName)
+      .then((d) => setStepProperties((prev) => ({ ...prev, [stepIdx]: d.properties || [] })))
+      .catch(() => {})
+  }
+
+  const fetchPropertyValues = (eventName: string, property: string) => {
+    if (!eventName || !property) return
+    const cacheKey = `${eventName}:${property}`
+    if (filterValues[cacheKey]) return
+    api.getEventPropertyValues(projectId, eventName, property)
+      .then((d) => setFilterValues((prev) => ({ ...prev, [cacheKey]: d.values || [] })))
+      .catch(() => {})
+  }
 
   useEffect(() => {
     api.getEventNames(projectId).then((d) => setEventNames(d.event_names || [])).catch(() => {})
   }, [projectId])
 
+  useEffect(() => {
+    steps.forEach((s, i) => {
+      if (s.event_name) fetchProperties(i, s.event_name)
+    })
+  }, [])
+
   const addStep = () => setSteps((s) => [...s, { event_name: '', filters: [] }])
   const removeStep = (i: number) => setSteps((s) => s.filter((_, idx) => idx !== i))
-  const updateStep = (i: number, val: string) =>
+  const updateStep = (i: number, val: string) => {
     setSteps((s) => s.map((st, idx) => (idx === i ? { ...st, event_name: val } : st)))
+    fetchProperties(i, val)
+  }
   const addFilter = (i: number) =>
     setSteps((s) => s.map((st, idx) => idx === i ? { ...st, filters: [...st.filters, { property: '', value: '' }] } : st))
+  const addFilterWithProperty = (stepIdx: number, property: string) => {
+    setSteps((s) => s.map((st, i) => i === stepIdx ? { ...st, filters: [...st.filters, { property, value: '' }] } : st))
+    const eventName = steps[stepIdx]?.event_name
+    if (eventName) fetchPropertyValues(eventName, property)
+  }
   const removeFilter = (stepIdx: number, filterIdx: number) =>
     setSteps((s) => s.map((st, i) => i === stepIdx ? { ...st, filters: st.filters.filter((_, fi) => fi !== filterIdx) } : st))
-  const updateFilter = (stepIdx: number, filterIdx: number, field: 'property' | 'value', val: string) =>
+  const updateFilter = (stepIdx: number, filterIdx: number, field: 'property' | 'value', val: string) => {
     setSteps((s) => s.map((st, i) => i === stepIdx ? { ...st, filters: st.filters.map((f, fi) => fi === filterIdx ? { ...f, [field]: val } : f) } : st))
+    if (field === 'property') {
+      const eventName = steps[stepIdx]?.event_name
+      if (eventName && val) fetchPropertyValues(eventName, val)
+    }
+  }
 
   const handleSave = async () => {
     if (!name.trim()) { setError('Name is required'); return }
@@ -783,6 +1029,19 @@ function EditFunnelModal({
           />
         </div>
 
+        <AvailableEventsPanel
+          eventNames={eventNames}
+          onSelect={(eName) => {
+            const emptyIdx = steps.findIndex((s) => !s.event_name)
+            if (emptyIdx >= 0) {
+              updateStep(emptyIdx, eName)
+            } else {
+              setSteps((prev) => [...prev, { event_name: eName, filters: [] }])
+              fetchProperties(steps.length, eName)
+            }
+          }}
+        />
+
         <div style={{ marginBottom: '1.25rem' }}>
           <label style={{ display: 'block', fontSize: 13, color: C.muted, marginBottom: 10 }}>Steps</label>
           {steps.map((s, i) => (
@@ -817,39 +1076,53 @@ function EditFunnelModal({
                   </button>
                 )}
               </div>
-              {/* Filters */}
               <div style={{ marginLeft: 32, marginTop: 4 }}>
+                {(stepProperties[i] || []).length > 0 && (
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: 4 }}>
+                    {(stepProperties[i] || [])
+                      .filter((p) => !s.filters.some((f) => f.property === p))
+                      .map((prop) => (
+                        <button
+                          key={prop}
+                          onClick={() => addFilterWithProperty(i, prop)}
+                          style={{
+                            background: 'rgba(148,163,184,0.08)',
+                            border: `1px solid ${C.border}`,
+                            borderRadius: 4,
+                            color: C.muted,
+                            padding: '0.15rem 0.4rem',
+                            fontSize: 11,
+                            cursor: 'pointer',
+                          }}
+                          onMouseEnter={(e) => {
+                            e.currentTarget.style.borderColor = C.amber
+                            e.currentTarget.style.color = C.amber
+                          }}
+                          onMouseLeave={(e) => {
+                            e.currentTarget.style.borderColor = C.border
+                            e.currentTarget.style.color = C.muted
+                          }}
+                        >
+                          + {prop}
+                        </button>
+                      ))}
+                  </div>
+                )}
                 {s.filters.map((f, fi) => (
                   <div key={fi} style={{ display: 'flex', gap: 4, alignItems: 'center', marginBottom: 4 }}>
-                    <input
+                    <AutocompleteInput
                       value={f.property}
-                      onChange={(e) => updateFilter(i, fi, 'property', e.target.value)}
+                      onChange={(val) => updateFilter(i, fi, 'property', val)}
                       placeholder="Property"
-                      style={{
-                        width: 100,
-                        background: C.bg,
-                        border: `1px solid ${C.border}`,
-                        borderRadius: 6,
-                        padding: '0.3rem 0.5rem',
-                        color: C.text,
-                        fontSize: 12,
-                        outline: 'none',
-                      }}
+                      suggestions={stepProperties[i] || []}
+                      width={120}
                     />
-                    <input
+                    <AutocompleteInput
                       value={f.value}
-                      onChange={(e) => updateFilter(i, fi, 'value', e.target.value)}
+                      onChange={(val) => updateFilter(i, fi, 'value', val)}
                       placeholder="Value"
-                      style={{
-                        width: 100,
-                        background: C.bg,
-                        border: `1px solid ${C.border}`,
-                        borderRadius: 6,
-                        padding: '0.3rem 0.5rem',
-                        color: C.text,
-                        fontSize: 12,
-                        outline: 'none',
-                      }}
+                      suggestions={filterValues[`${s.event_name}:${f.property}`] || []}
+                      width={120}
                     />
                     <button
                       onClick={() => removeFilter(i, fi)}

--- a/web/src/pages/Funnels.tsx
+++ b/web/src/pages/Funnels.tsx
@@ -282,7 +282,7 @@ tracker.track(${constNameCapitalized}.${lastStep.toUpperCase().replace(/-/g, '_'
         maxWidth: '100%',
         whiteSpace: 'pre',
         fontFamily: 'ui-monospace, SFMono-Regular, monospace',
-        WebkitOverflowScrolling: 'touch' as any,
+        WebkitOverflowScrolling: 'touch' as React.CSSProperties['WebkitOverflowScrolling'],
       }}>
         {snippet}
       </pre>
@@ -922,6 +922,7 @@ function EditFunnelModal({
     steps.forEach((s, i) => {
       if (s.event_name) fetchProperties(i, s.event_name)
     })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const addStep = () => setSteps((s) => [...s, { event_name: '', filters: [] }])


### PR DESCRIPTION
## Summary
- **Available Events panel**: collapsible section in Create/Edit funnel modals showing all event names for the project as clickable chips — click to fill the next empty step or add a new one
- **Property discovery**: two new API endpoints (`event-properties`, `event-property-values`) that introspect the JSON `properties` column via `json_each`/`json_extract`, surfaced as clickable `+ property` chips below each step
- **Filter autocomplete**: property and value fields in filters now have autocomplete dropdowns populated from the new endpoints; freeform typing still works

## Test plan
- [ ] Create a project with events that have JSON properties (e.g. `page`, `plan`)
- [ ] Open "Create funnel" — verify "Available events" panel lists all event names
- [ ] Click an event chip — verify it fills the next empty step
- [ ] Verify property chips appear below the step once an event name is selected
- [ ] Click a property chip — verify a filter row is added with the property pre-filled
- [ ] Type in a filter value field — verify autocomplete suggestions appear
- [ ] Verify freeform typing still works in all fields (not just autocomplete picks)
- [ ] Open "Edit funnel" — verify property chips load for existing steps on mount
- [ ] Verify no regressions in funnel analysis, segments, or deletion