### PR TITLE
fix: NaN ago in live event stream timestamps

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -197,7 +197,7 @@ export interface Event {
   id: string
   name: string
   url: string
-  timestamp: string
+  occurred_at: string
 }
 
 export interface FunnelStep {

--- a/web/src/pages/Live.tsx
+++ b/web/src/pages/Live.tsx
@@ -21,7 +21,7 @@ interface LiveEvent {
   id: string
   name: string
   url: string
-  timestamp: string
+  occurred_at: string
 }
 
 interface SparkPoint {
@@ -314,7 +314,7 @@ export default function Live() {
                   {ev.url}
                 </div>
                 <div style={{ fontSize: 12, color: C.muted, flexShrink: 0 }}>
-                  {timeAgo(ev.timestamp)}
+                  {timeAgo(ev.occurred_at)}
                 </div>
               </div>
             ))}


### PR DESCRIPTION
## Summary
- Frontend `Event` and `LiveEvent` interfaces used `timestamp` but the backend serializes as `occurred_at`
- `new Date(undefined)` returns `NaN`, so all timestamps showed "NaN ago"
- Aligned both interfaces to use `occurred_at`

## Test plan
- [ ] Open the Live page with events flowing — timestamps should show "Xs ago", "Xm ago" etc. instead of "NaN ago"