### PR TITLE
feat: insights dashboard with property breakdown widgets

### DIFF
--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -123,6 +123,7 @@ func run() error {
 	eventsSvc := service.NewEventService(store)
 	sessionsSvc := service.NewSessionService(store)
 	apikeysSvc := service.NewAPIKeyService(store)
+	widgetsSvc := service.NewWidgetService(store)
 
 	eventSpool, err := spool.NewWithLimit(cfg.SpoolDir, cfg.MaxSpoolBytes)
 	if err != nil {
@@ -175,6 +176,7 @@ func run() error {
 		eventsSvc,
 		sessionsSvc,
 		apikeysSvc,
+		widgetsSvc,
 		userAuth,
 		sessionManager,
 		cfg.AllowedOrigins,

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -62,6 +62,7 @@ func newTestServer(t *testing.T) (*Server, *repository.Store) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
+		service.NewWidgetService(store),
 		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, 1000, 1000, store, "test", "", "", "", "")
 	return srv, store
 }
@@ -79,6 +80,7 @@ func newAuthedServer(t *testing.T) (*Server, *repository.Store) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
+		service.NewWidgetService(store),
 		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, 1000, 1000, store, "test", "", "", "", "")
 	return srv, store
 }
@@ -166,6 +168,7 @@ func TestHandleHealth_DBDown(t *testing.T) {
 		service.NewProjectService(store), service.NewFunnelService(store),
 		service.NewABTestService(store), service.NewEventService(store),
 		service.NewSessionService(store), service.NewAPIKeyService(store),
+		service.NewWidgetService(store),
 		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, 1000, 1000, brokenPinger, "test", "", "", "", "")
 
 	w := getJSON(t, srv, "/api/v1/health", nil)

--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -3,6 +3,8 @@ package api
 import (
 	"net/http"
 	"time"
+
+	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 )
 
 // handleDashboard returns aggregate dashboard stats for a project.
@@ -16,7 +18,8 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	// Parse time range. Supports ?range=24h|7d|30d or explicit ?from=&to= (RFC3339).
 	to := time.Now().UTC()
 	from := to.AddDate(0, 0, -30)
-	switch r.URL.Query().Get("range") {
+	rangeParam := r.URL.Query().Get("range")
+	switch rangeParam {
 	case "24h":
 		from = to.Add(-24 * time.Hour)
 	case "7d":
@@ -62,9 +65,14 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	timeSeries, err := s.events.DailyEventCounts(ctx, projectID, from, to)
+	var timeSeries []repository.TimeSeriesPoint
+	if rangeParam == "24h" {
+		timeSeries, err = s.events.HourlyEventCounts(ctx, projectID, from, to)
+	} else {
+		timeSeries, err = s.events.DailyEventCounts(ctx, projectID, from, to)
+	}
 	if err != nil {
-		mapServiceError(w, err, "handleDashboard.dailyEventCounts")
+		mapServiceError(w, err, "handleDashboard.eventCounts")
 		return
 	}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -30,6 +30,7 @@ type Server struct {
 	events           service.Events
 	sessions         service.Sessions
 	apikeys          service.APIKeys
+	widgets          service.Widgets
 	ingest           *ingest.Handler
 	userAuth         *auth.UserAuthenticator
 	sessionManager   *auth.SessionManager
@@ -57,6 +58,7 @@ func NewServer(
 	events service.Events,
 	sessions service.Sessions,
 	apikeys service.APIKeys,
+	widgets service.Widgets,
 	userAuth *auth.UserAuthenticator,
 	sessionManager *auth.SessionManager,
 	allowedOrigins []string,
@@ -85,6 +87,7 @@ func NewServer(
 		events:           events,
 		sessions:         sessions,
 		apikeys:          apikeys,
+		widgets:          widgets,
 		ingest:           ingestHandler,
 		userAuth:         userAuth,
 		sessionManager:   sessionManager,
@@ -145,6 +148,14 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/abtests", s.requireSession(s.handleListABTests))
 	s.mux.HandleFunc("POST /api/v1/projects/{id}/abtests", s.requireSession(s.handleCreateABTest))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/abtests/{abid}/analysis", s.requireSession(s.handleABTestAnalysis))
+
+	// Widgets (Insights)
+	s.mux.HandleFunc("GET /api/v1/projects/{id}/widgets", s.requireSession(s.handleListWidgets))
+	s.mux.HandleFunc("POST /api/v1/projects/{id}/widgets", s.requireSession(s.handleCreateWidget))
+	s.mux.HandleFunc("PUT /api/v1/projects/{id}/widgets/{wid}", s.requireSession(s.handleUpdateWidget))
+	s.mux.HandleFunc("DELETE /api/v1/projects/{id}/widgets/{wid}", s.requireSession(s.handleDeleteWidget))
+	s.mux.HandleFunc("GET /api/v1/projects/{id}/widgets/{wid}/breakdown", s.requireSession(s.handleWidgetBreakdown))
+	s.mux.HandleFunc("GET /api/v1/projects/{id}/widgets/breakdowns", s.requireSession(s.handleBatchBreakdowns))
 
 	// Sessions
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/sessions", s.requireSession(s.handleListSessions))

--- a/internal/api/widgets.go
+++ b/internal/api/widgets.go
@@ -1,0 +1,182 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/wiebe-xyz/funnelbarn/internal/repository"
+)
+
+func (s *Server) handleListWidgets(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	if projectID == "" {
+		jsonError(w, "project id required", http.StatusBadRequest)
+		return
+	}
+
+	widgets, err := s.widgets.ListWidgets(r.Context(), projectID)
+	if err != nil {
+		mapServiceError(w, err, "handleListWidgets")
+		return
+	}
+	if widgets == nil {
+		widgets = []repository.DashboardWidget{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"widgets": widgets})
+}
+
+func (s *Server) handleCreateWidget(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	if projectID == "" {
+		jsonError(w, "project id required", http.StatusBadRequest)
+		return
+	}
+
+	var body struct {
+		EventName string `json:"event_name"`
+		Property  string `json:"property"`
+		Title     string `json:"title"`
+		Position  int    `json:"position"`
+	}
+	if err := readJSON(r, &body); err != nil {
+		jsonError(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	if body.EventName == "" || body.Property == "" {
+		jsonError(w, "event_name and property are required", http.StatusUnprocessableEntity)
+		return
+	}
+
+	widget, err := s.widgets.CreateWidget(r.Context(), repository.DashboardWidget{
+		ProjectID: projectID,
+		EventName: body.EventName,
+		Property:  body.Property,
+		Title:     body.Title,
+		Position:  body.Position,
+	})
+	if err != nil {
+		mapServiceError(w, err, "handleCreateWidget")
+		return
+	}
+	writeJSON(w, http.StatusCreated, widget)
+}
+
+func (s *Server) handleUpdateWidget(w http.ResponseWriter, r *http.Request) {
+	widgetID := r.PathValue("wid")
+	if widgetID == "" {
+		jsonError(w, "widget id required", http.StatusBadRequest)
+		return
+	}
+
+	var body struct {
+		EventName string `json:"event_name"`
+		Property  string `json:"property"`
+		Title     string `json:"title"`
+		Position  int    `json:"position"`
+	}
+	if err := readJSON(r, &body); err != nil {
+		jsonError(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+
+	widget, err := s.widgets.UpdateWidget(r.Context(), repository.DashboardWidget{
+		ID:        widgetID,
+		EventName: body.EventName,
+		Property:  body.Property,
+		Title:     body.Title,
+		Position:  body.Position,
+	})
+	if err != nil {
+		mapServiceError(w, err, "handleUpdateWidget")
+		return
+	}
+	writeJSON(w, http.StatusOK, widget)
+}
+
+func (s *Server) handleDeleteWidget(w http.ResponseWriter, r *http.Request) {
+	widgetID := r.PathValue("wid")
+	if widgetID == "" {
+		jsonError(w, "widget id required", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.widgets.DeleteWidget(r.Context(), widgetID); err != nil {
+		mapServiceError(w, err, "handleDeleteWidget")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleWidgetBreakdown(w http.ResponseWriter, r *http.Request) {
+	widgetID := r.PathValue("wid")
+	if widgetID == "" {
+		jsonError(w, "widget id required", http.StatusBadRequest)
+		return
+	}
+
+	widget, err := s.widgets.GetWidget(r.Context(), widgetID)
+	if err != nil {
+		mapServiceError(w, err, "handleWidgetBreakdown")
+		return
+	}
+
+	window := 100
+	limit := 10
+	if v := r.URL.Query().Get("window"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= 1000 {
+			window = n
+		}
+	}
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= 50 {
+			limit = n
+		}
+	}
+
+	breakdown, err := s.widgets.WidgetBreakdown(r.Context(), widget.ProjectID, widget.EventName, widget.Property, window, limit)
+	if err != nil {
+		mapServiceError(w, err, "handleWidgetBreakdown")
+		return
+	}
+	if breakdown == nil {
+		breakdown = []repository.PropertyBreakdown{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"widget":    widget,
+		"breakdown": breakdown,
+		"window":    window,
+	})
+}
+
+func (s *Server) handleBatchBreakdowns(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	if projectID == "" {
+		jsonError(w, "project id required", http.StatusBadRequest)
+		return
+	}
+
+	widgets, err := s.widgets.ListWidgets(r.Context(), projectID)
+	if err != nil {
+		mapServiceError(w, err, "handleBatchBreakdowns")
+		return
+	}
+
+	type widgetResult struct {
+		Widget    repository.DashboardWidget     `json:"widget"`
+		Breakdown []repository.PropertyBreakdown `json:"breakdown"`
+	}
+
+	results := make([]widgetResult, 0, len(widgets))
+	for _, widget := range widgets {
+		bd, err := s.widgets.WidgetBreakdown(r.Context(), widget.ProjectID, widget.EventName, widget.Property, 100, 10)
+		if err != nil {
+			bd = []repository.PropertyBreakdown{}
+		}
+		if bd == nil {
+			bd = []repository.PropertyBreakdown{}
+		}
+		results = append(results, widgetResult{Widget: widget, Breakdown: bd})
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"results": results})
+}

--- a/internal/repository/events.go
+++ b/internal/repository/events.go
@@ -519,6 +519,31 @@ func (s *Store) DailyEventCounts(ctx context.Context, projectID string, from, to
 	return series, rows.Err()
 }
 
+// HourlyEventCounts returns hourly event counts for a project over a time range.
+func (s *Store) HourlyEventCounts(ctx context.Context, projectID string, from, to time.Time) ([]TimeSeriesPoint, error) {
+	const q = `
+		SELECT substr(occurred_at, 1, 13) || ':00:00' as hour, COUNT(*) as count
+		FROM events
+		WHERE project_id = ? AND occurred_at >= ? AND occurred_at <= ?
+		GROUP BY hour
+		ORDER BY hour`
+	rows, err := s.db.QueryContext(ctx, q, projectID, from, to)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var series []TimeSeriesPoint
+	for rows.Next() {
+		var p TimeSeriesPoint
+		if err := rows.Scan(&p.Time, &p.Count); err != nil {
+			return nil, err
+		}
+		series = append(series, p)
+	}
+	return series, rows.Err()
+}
+
 // BounceRate computes the fraction of sessions with only 1 event.
 func (s *Store) BounceRate(ctx context.Context, projectID string, from, to time.Time) (float64, error) {
 	const q = `

--- a/internal/repository/interface.go
+++ b/internal/repository/interface.go
@@ -64,6 +64,7 @@ type Querier interface {
 	TopPages(ctx context.Context, projectID string, from, to time.Time, limit int) ([]PageStat, error)
 	TopReferrers(ctx context.Context, projectID string, from, to time.Time, limit int) ([]ReferrerStat, error)
 	DailyEventCounts(ctx context.Context, projectID string, from, to time.Time) ([]TimeSeriesPoint, error)
+	HourlyEventCounts(ctx context.Context, projectID string, from, to time.Time) ([]TimeSeriesPoint, error)
 	DailyUniqueSessions(ctx context.Context, projectID string, from, to time.Time) ([]TimeSeriesPoint, error)
 	TopBrowsers(ctx context.Context, projectID string, from, to time.Time, limit int) ([]BrowserStat, error)
 	TopDeviceTypes(ctx context.Context, projectID string, from, to time.Time) ([]DeviceStat, error)

--- a/internal/repository/interface.go
+++ b/internal/repository/interface.go
@@ -77,6 +77,14 @@ type Querier interface {
 	DistinctEventProperties(ctx context.Context, projectID, eventName string) ([]string, error)
 	DistinctPropertyValues(ctx context.Context, projectID, eventName, property string, limit int) ([]string, error)
 	PurgeOldEvents(ctx context.Context, cutoff time.Time) (int64, error)
+
+	// Widgets
+	CreateWidget(ctx context.Context, w DashboardWidget) (DashboardWidget, error)
+	WidgetByID(ctx context.Context, id string) (DashboardWidget, error)
+	ListWidgets(ctx context.Context, projectID string) ([]DashboardWidget, error)
+	UpdateWidget(ctx context.Context, w DashboardWidget) (DashboardWidget, error)
+	DeleteWidget(ctx context.Context, id string) error
+	WidgetBreakdown(ctx context.Context, projectID, eventName, property string, window, limit int) ([]PropertyBreakdown, error)
 }
 
 // compile-time check that *Store satisfies Querier.

--- a/internal/repository/migrations/00003_dashboard_widgets.sql
+++ b/internal/repository/migrations/00003_dashboard_widgets.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+CREATE TABLE dashboard_widgets (
+    id         TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    event_name TEXT NOT NULL,
+    property   TEXT NOT NULL,
+    title      TEXT NOT NULL DEFAULT '',
+    position   INTEGER NOT NULL DEFAULT 0,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_widgets_project ON dashboard_widgets(project_id);
+
+-- +goose Down
+DROP TABLE IF EXISTS dashboard_widgets;

--- a/internal/repository/mock/mock.go
+++ b/internal/repository/mock/mock.go
@@ -33,6 +33,7 @@ type Store struct {
 	abtests  map[string]repository.ABTest
 	sessions map[string]repository.Session
 	events   []repository.Event
+	widgets  map[string]repository.DashboardWidget
 }
 
 // New returns a fresh empty Store.
@@ -579,6 +580,72 @@ func (s *Store) PurgeOldEvents(ctx context.Context, cutoff time.Time) (int64, er
 	}
 	s.events = kept
 	return deleted, nil
+}
+
+// ── Widgets ──────────────────────────────────────────────────────────────────
+
+func (s *Store) CreateWidget(_ context.Context, w repository.DashboardWidget) (repository.DashboardWidget, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	w.ID = newMockID("widget")
+	w.CreatedAt = time.Now()
+	if s.widgets == nil {
+		s.widgets = make(map[string]repository.DashboardWidget)
+	}
+	s.widgets[w.ID] = w
+	return w, nil
+}
+
+func (s *Store) WidgetByID(_ context.Context, id string) (repository.DashboardWidget, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	w, ok := s.widgets[id]
+	if !ok {
+		return repository.DashboardWidget{}, sql.ErrNoRows
+	}
+	return w, nil
+}
+
+func (s *Store) ListWidgets(_ context.Context, projectID string) ([]repository.DashboardWidget, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []repository.DashboardWidget
+	for _, w := range s.widgets {
+		if w.ProjectID == projectID {
+			out = append(out, w)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Position != out[j].Position {
+			return out[i].Position < out[j].Position
+		}
+		return out[i].CreatedAt.Before(out[j].CreatedAt)
+	})
+	return out, nil
+}
+
+func (s *Store) UpdateWidget(_ context.Context, w repository.DashboardWidget) (repository.DashboardWidget, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	existing, ok := s.widgets[w.ID]
+	if !ok {
+		return repository.DashboardWidget{}, sql.ErrNoRows
+	}
+	w.ProjectID = existing.ProjectID
+	w.CreatedAt = existing.CreatedAt
+	s.widgets[w.ID] = w
+	return w, nil
+}
+
+func (s *Store) DeleteWidget(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.widgets, id)
+	return nil
+}
+
+func (s *Store) WidgetBreakdown(_ context.Context, _, _, _ string, _, _ int) ([]repository.PropertyBreakdown, error) {
+	return []repository.PropertyBreakdown{}, nil
 }
 
 func (s *Store) Ping(_ context.Context) error { return nil }

--- a/internal/repository/mock/mock.go
+++ b/internal/repository/mock/mock.go
@@ -510,6 +510,10 @@ func (s *Store) DailyEventCounts(ctx context.Context, projectID string, from, to
 	return []repository.TimeSeriesPoint{}, nil
 }
 
+func (s *Store) HourlyEventCounts(ctx context.Context, projectID string, from, to time.Time) ([]repository.TimeSeriesPoint, error) {
+	return []repository.TimeSeriesPoint{}, nil
+}
+
 func (s *Store) DailyUniqueSessions(ctx context.Context, projectID string, from, to time.Time) ([]repository.TimeSeriesPoint, error) {
 	return []repository.TimeSeriesPoint{}, nil
 }

--- a/internal/repository/widgets.go
+++ b/internal/repository/widgets.go
@@ -1,0 +1,120 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// DashboardWidget is a user-configured breakdown card on the Insights page.
+type DashboardWidget struct {
+	ID        string    `json:"id"`
+	ProjectID string    `json:"project_id"`
+	EventName string    `json:"event_name"`
+	Property  string    `json:"property"`
+	Title     string    `json:"title"`
+	Position  int       `json:"position"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// PropertyBreakdown is one row of a top-N breakdown result.
+type PropertyBreakdown struct {
+	Value string `json:"value"`
+	Count int64  `json:"count"`
+}
+
+func (s *Store) CreateWidget(ctx context.Context, w DashboardWidget) (DashboardWidget, error) {
+	var err error
+	w.ID, err = generateUUID()
+	if err != nil {
+		return DashboardWidget{}, fmt.Errorf("generate uuid: %w", err)
+	}
+
+	const q = `INSERT INTO dashboard_widgets (id, project_id, event_name, property, title, position) VALUES (?, ?, ?, ?, ?, ?)`
+	if _, err := s.db.ExecContext(ctx, q, w.ID, w.ProjectID, w.EventName, w.Property, w.Title, w.Position); err != nil {
+		return DashboardWidget{}, fmt.Errorf("insert widget: %w", err)
+	}
+
+	return s.WidgetByID(ctx, w.ID)
+}
+
+func (s *Store) WidgetByID(ctx context.Context, id string) (DashboardWidget, error) {
+	const q = `SELECT id, project_id, event_name, property, COALESCE(title,''), position, created_at FROM dashboard_widgets WHERE id = ?`
+	var w DashboardWidget
+	if err := s.db.QueryRowContext(ctx, q, id).Scan(&w.ID, &w.ProjectID, &w.EventName, &w.Property, &w.Title, &w.Position, &w.CreatedAt); err != nil {
+		return DashboardWidget{}, err
+	}
+	return w, nil
+}
+
+func (s *Store) ListWidgets(ctx context.Context, projectID string) ([]DashboardWidget, error) {
+	const q = `SELECT id, project_id, event_name, property, COALESCE(title,''), position, created_at FROM dashboard_widgets WHERE project_id = ? ORDER BY position, created_at`
+	rows, err := s.db.QueryContext(ctx, q, projectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var widgets []DashboardWidget
+	for rows.Next() {
+		var w DashboardWidget
+		if err := rows.Scan(&w.ID, &w.ProjectID, &w.EventName, &w.Property, &w.Title, &w.Position, &w.CreatedAt); err != nil {
+			return nil, err
+		}
+		widgets = append(widgets, w)
+	}
+	return widgets, rows.Err()
+}
+
+func (s *Store) UpdateWidget(ctx context.Context, w DashboardWidget) (DashboardWidget, error) {
+	const q = `UPDATE dashboard_widgets SET event_name=?, property=?, title=?, position=? WHERE id=?`
+	if _, err := s.db.ExecContext(ctx, q, w.EventName, w.Property, w.Title, w.Position, w.ID); err != nil {
+		return DashboardWidget{}, fmt.Errorf("update widget: %w", err)
+	}
+	return s.WidgetByID(ctx, w.ID)
+}
+
+func (s *Store) DeleteWidget(ctx context.Context, id string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM dashboard_widgets WHERE id = ?`, id)
+	return err
+}
+
+// WidgetBreakdown returns the top-N property value counts from the last `window` events
+// of the given event type. This is the rolling window query.
+func (s *Store) WidgetBreakdown(ctx context.Context, projectID, eventName, property string, window, limit int) ([]PropertyBreakdown, error) {
+	if !validPropertyName.MatchString(property) {
+		return nil, fmt.Errorf("invalid property name: %s", property)
+	}
+
+	q := fmt.Sprintf(`
+		SELECT val, COUNT(*) AS cnt
+		FROM (
+			SELECT json_extract(properties, '$.%s') AS val
+			FROM (
+				SELECT properties FROM events
+				WHERE project_id = ? AND name = ?
+				ORDER BY occurred_at DESC
+				LIMIT ?
+			)
+		)
+		WHERE val IS NOT NULL AND val != ''
+		GROUP BY val
+		ORDER BY cnt DESC
+		LIMIT ?`, property)
+
+	rows, err := s.db.QueryContext(ctx, q, projectID, eventName, window, limit)
+	if err != nil {
+		return nil, fmt.Errorf("widget breakdown: %w", err)
+	}
+	defer rows.Close()
+
+	var results []PropertyBreakdown
+	for rows.Next() {
+		var r PropertyBreakdown
+		if err := rows.Scan(&r.Value, &r.Count); err != nil {
+			return nil, err
+		}
+		results = append(results, r)
+	}
+	return results, rows.Err()
+}

--- a/internal/service/events.go
+++ b/internal/service/events.go
@@ -41,6 +41,10 @@ func (svc *EventService) DailyEventCounts(ctx context.Context, projectID string,
 	return svc.store.DailyEventCounts(ctx, projectID, from, to)
 }
 
+func (svc *EventService) HourlyEventCounts(ctx context.Context, projectID string, from, to time.Time) ([]repository.TimeSeriesPoint, error) {
+	return svc.store.HourlyEventCounts(ctx, projectID, from, to)
+}
+
 func (svc *EventService) DailyUniqueSessions(ctx context.Context, projectID string, from, to time.Time) ([]repository.TimeSeriesPoint, error) {
 	return svc.store.DailyUniqueSessions(ctx, projectID, from, to)
 }

--- a/internal/service/interfaces.go
+++ b/internal/service/interfaces.go
@@ -64,6 +64,16 @@ type Events interface {
 	DistinctPropertyValues(ctx context.Context, projectID, eventName, property string, limit int) ([]string, error)
 }
 
+// Widgets is the interface for dashboard widget operations.
+type Widgets interface {
+	CreateWidget(ctx context.Context, w repository.DashboardWidget) (repository.DashboardWidget, error)
+	GetWidget(ctx context.Context, id string) (repository.DashboardWidget, error)
+	ListWidgets(ctx context.Context, projectID string) ([]repository.DashboardWidget, error)
+	UpdateWidget(ctx context.Context, w repository.DashboardWidget) (repository.DashboardWidget, error)
+	DeleteWidget(ctx context.Context, id string) error
+	WidgetBreakdown(ctx context.Context, projectID, eventName, property string, window, limit int) ([]repository.PropertyBreakdown, error)
+}
+
 // Sessions is the interface for session-related operations.
 type Sessions interface {
 	UpsertSession(ctx context.Context, sess repository.Session) error

--- a/internal/service/interfaces.go
+++ b/internal/service/interfaces.go
@@ -50,6 +50,7 @@ type Events interface {
 	TopPages(ctx context.Context, projectID string, from, to time.Time, limit int) ([]repository.PageStat, error)
 	TopReferrers(ctx context.Context, projectID string, from, to time.Time, limit int) ([]repository.ReferrerStat, error)
 	DailyEventCounts(ctx context.Context, projectID string, from, to time.Time) ([]repository.TimeSeriesPoint, error)
+	HourlyEventCounts(ctx context.Context, projectID string, from, to time.Time) ([]repository.TimeSeriesPoint, error)
 	DailyUniqueSessions(ctx context.Context, projectID string, from, to time.Time) ([]repository.TimeSeriesPoint, error)
 	TopBrowsers(ctx context.Context, projectID string, from, to time.Time, limit int) ([]repository.BrowserStat, error)
 	TopDeviceTypes(ctx context.Context, projectID string, from, to time.Time) ([]repository.DeviceStat, error)

--- a/internal/service/widgets.go
+++ b/internal/service/widgets.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"context"
+
+	"github.com/wiebe-xyz/funnelbarn/internal/repository"
+)
+
+type WidgetService struct {
+	store repository.Querier
+}
+
+func NewWidgetService(store repository.Querier) *WidgetService {
+	return &WidgetService{store: store}
+}
+
+func (svc *WidgetService) CreateWidget(ctx context.Context, w repository.DashboardWidget) (repository.DashboardWidget, error) {
+	return svc.store.CreateWidget(ctx, w)
+}
+
+func (svc *WidgetService) GetWidget(ctx context.Context, id string) (repository.DashboardWidget, error) {
+	return svc.store.WidgetByID(ctx, id)
+}
+
+func (svc *WidgetService) ListWidgets(ctx context.Context, projectID string) ([]repository.DashboardWidget, error) {
+	return svc.store.ListWidgets(ctx, projectID)
+}
+
+func (svc *WidgetService) UpdateWidget(ctx context.Context, w repository.DashboardWidget) (repository.DashboardWidget, error) {
+	return svc.store.UpdateWidget(ctx, w)
+}
+
+func (svc *WidgetService) DeleteWidget(ctx context.Context, id string) error {
+	return svc.store.DeleteWidget(ctx, id)
+}
+
+func (svc *WidgetService) WidgetBreakdown(ctx context.Context, projectID, eventName, property string, window, limit int) ([]repository.PropertyBreakdown, error) {
+	return svc.store.WidgetBreakdown(ctx, projectID, eventName, property, window, limit)
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,7 @@ import Funnels from './pages/Funnels'
 import Live from './pages/Live'
 import Settings from './pages/Settings'
 import ABTests from './pages/ABTests'
+import Insights from './pages/Insights'
 import FirstRunWizard from './components/wizards/FirstRunWizard'
 import { ErrorBoundary } from './components/ui/ErrorBoundary'
 import { trackPageView } from './lib/analytics'
@@ -163,6 +164,14 @@ function AppRoutes() {
         <Route
           path="/abtests/:projectId"
           element={<ProtectedRoute><ABTests /></ProtectedRoute>}
+        />
+        <Route
+          path="/insights"
+          element={<ProtectedRoute><DefaultProjectRoute base="/insights" /></ProtectedRoute>}
+        />
+        <Route
+          path="/insights/:projectId"
+          element={<ProtectedRoute><Insights /></ProtectedRoute>}
         />
         <Route
           path="/live"

--- a/web/src/components/shell/Shell.tsx
+++ b/web/src/components/shell/Shell.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useState } from 'react'
 import { Link, useNavigate, useLocation } from 'react-router-dom'
-import { BarChart2, Layers, Radio, Settings, LogOut, User, FlaskConical, MoreHorizontal } from 'lucide-react'
+import { BarChart2, Layers, Radio, Settings, LogOut, User, FlaskConical, Lightbulb, MoreHorizontal } from 'lucide-react'
 import { useAuth } from '../../lib/auth'
 import { useProjects } from '../../lib/projects'
 import { ProjectPicker } from '../ui/ProjectPicker'
@@ -46,6 +46,7 @@ export default function Shell({ children, projectId, projectName, projects: proj
     { to: projectId ? `/dashboard/${projectId}` : '/dashboard', label: 'Overview', icon: <BarChart2 size={16} /> },
     { to: projectId ? `/funnels/${projectId}` : '/funnels', label: 'Funnels', icon: <Layers size={16} /> },
     { to: projectId ? `/abtests/${projectId}` : '/abtests', label: 'A/B Tests', icon: <FlaskConical size={16} /> },
+    { to: projectId ? `/insights/${projectId}` : '/insights', label: 'Insights', icon: <Lightbulb size={16} /> },
     { to: projectId ? `/live/${projectId}` : '/live', label: 'Live', icon: <Radio size={16} /> },
     { to: '/settings', label: 'Settings', icon: <Settings size={16} /> },
   ]
@@ -55,6 +56,7 @@ export default function Shell({ children, projectId, projectName, projects: proj
     { to: projectId ? `/dashboard/${projectId}` : '/dashboard', label: 'Overview', icon: BarChart2 },
     { to: projectId ? `/funnels/${projectId}` : '/funnels', label: 'Funnels', icon: Layers },
     { to: projectId ? `/abtests/${projectId}` : '/abtests', label: 'A/B Tests', icon: FlaskConical },
+    { to: projectId ? `/insights/${projectId}` : '/insights', label: 'Insights', icon: Lightbulb },
     { to: projectId ? `/live/${projectId}` : '/live', label: 'Live', icon: Radio },
   ]
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -172,6 +172,33 @@ export const api = {
   // Active sessions (last 5 minutes)
   getActiveSessions: (projectId: string) =>
     request<{ active_sessions: number; window_minutes: number }>(`/api/v1/projects/${projectId}/sessions/active`),
+
+  // Widgets (Insights)
+  listWidgets: (projectId: string) =>
+    request<{ widgets: DashboardWidget[] }>(`/api/v1/projects/${projectId}/widgets`),
+
+  createWidget: (projectId: string, data: { event_name: string; property: string; title: string; position?: number }) =>
+    request<DashboardWidget>(`/api/v1/projects/${projectId}/widgets`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+
+  updateWidget: (projectId: string, widgetId: string, data: { event_name: string; property: string; title: string; position?: number }) =>
+    request<DashboardWidget>(`/api/v1/projects/${projectId}/widgets/${widgetId}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    }),
+
+  deleteWidget: (projectId: string, widgetId: string) =>
+    request<void>(`/api/v1/projects/${projectId}/widgets/${widgetId}`, { method: 'DELETE' }),
+
+  getWidgetBreakdown: (projectId: string, widgetId: string) =>
+    request<{ widget: DashboardWidget; breakdown: PropertyBreakdown[]; window: number }>(
+      `/api/v1/projects/${projectId}/widgets/${widgetId}/breakdown`
+    ),
+
+  getBatchBreakdowns: (projectId: string) =>
+    request<{ results: WidgetBreakdownResult[] }>(`/api/v1/projects/${projectId}/widgets/breakdowns`),
 }
 
 // Types
@@ -264,4 +291,24 @@ export interface ABTestAnalysis {
   variant_conversions: number
   significant: boolean
   z_score?: number
+}
+
+export interface DashboardWidget {
+  id: string
+  project_id: string
+  event_name: string
+  property: string
+  title: string
+  position: number
+  created_at: string
+}
+
+export interface PropertyBreakdown {
+  value: string
+  count: number
+}
+
+export interface WidgetBreakdownResult {
+  widget: DashboardWidget
+  breakdown: PropertyBreakdown[]
 }

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -153,9 +153,11 @@ export default function Dashboard() {
       .catch(() => setTopFunnelRate(null))
   }, [projectId])
 
-  // Format time series for chart
+  // Format time series for chart — hourly labels for 24h, daily for 7d/30d
   const chartData = data?.events_time_series?.map((pt) => ({
-    time: new Date(pt.time).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+    time: range === '24h'
+      ? new Date(pt.time).toLocaleTimeString('en-US', { hour: 'numeric', hour12: true })
+      : new Date(pt.time).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
     events: pt.count,
   })) ?? []
 
@@ -347,7 +349,7 @@ export default function Dashboard() {
           0% { background-position: 200% 0; }
           100% { background-position: -200% 0; }
         }
-        @media (max-width: 640px) {
+        @media (max-width: 767px) {
           .stat-cards-grid { grid-template-columns: 1fr 1fr !important; }
           .bottom-row-grid { grid-template-columns: 1fr !important; }
         }
@@ -488,6 +490,8 @@ export default function Dashboard() {
           border: `1px solid ${C.border}`,
           borderRadius: 12,
           padding: '1.5rem',
+          overflow: 'hidden',
+          minWidth: 0,
         }}>
           <div style={{ fontSize: 15, fontWeight: 700, marginBottom: '1rem' }}>Top pages</div>
           {loading ? (
@@ -533,6 +537,8 @@ export default function Dashboard() {
           border: `1px solid ${C.border}`,
           borderRadius: 12,
           padding: '1.5rem',
+          overflow: 'hidden',
+          minWidth: 0,
         }}>
           <div style={{ fontSize: 15, fontWeight: 700, marginBottom: '1rem' }}>Referrer breakdown</div>
           {loading ? (

--- a/web/src/pages/Insights.tsx
+++ b/web/src/pages/Insights.tsx
@@ -1,0 +1,492 @@
+import { useEffect, useState, useCallback } from 'react'
+import { useParams } from 'react-router-dom'
+import { Plus, Trash2, Lightbulb, X } from 'lucide-react'
+import Shell from '../components/shell/Shell'
+import { api } from '../lib/api'
+import type { DashboardWidget, PropertyBreakdown } from '../lib/api'
+import { useProjects } from '../lib/projects'
+import { Skeleton } from '../components/ui/Skeleton'
+
+const C = {
+  bg: '#0f1117',
+  surface: '#1a1d27',
+  border: '#2a2d3a',
+  amber: '#f59e0b',
+  text: '#e2e8f0',
+  muted: '#94a3b8',
+  success: '#10b981',
+}
+
+interface WidgetWithData {
+  widget: DashboardWidget
+  breakdown: PropertyBreakdown[]
+}
+
+export default function Insights() {
+  const { projectId } = useParams<{ projectId?: string }>()
+  const { projects } = useProjects()
+  const [widgets, setWidgets] = useState<WidgetWithData[]>([])
+  const [loading, setLoading] = useState(true)
+  const [showAddModal, setShowAddModal] = useState(false)
+
+  const fetchAll = useCallback(async () => {
+    if (!projectId) return
+    try {
+      const data = await api.getBatchBreakdowns(projectId)
+      setWidgets(data.results)
+    } catch {
+      // silent
+    } finally {
+      setLoading(false)
+    }
+  }, [projectId])
+
+  useEffect(() => {
+    fetchAll()
+  }, [fetchAll])
+
+  const handleDelete = async (widgetId: string) => {
+    if (!projectId) return
+    try {
+      await api.deleteWidget(projectId, widgetId)
+      setWidgets((prev) => prev.filter((w) => w.widget.id !== widgetId))
+    } catch {
+      // silent
+    }
+  }
+
+  const handleAdded = () => {
+    setShowAddModal(false)
+    setLoading(true)
+    fetchAll()
+  }
+
+  if (!projectId) {
+    return (
+      <Shell>
+        <div style={{ color: C.muted, textAlign: 'center', padding: '2rem' }}>
+          Select a project to view insights.
+        </div>
+      </Shell>
+    )
+  }
+
+  const projectName = projects.find((p) => p.id === projectId)?.name
+
+  return (
+    <Shell projectId={projectId} projectName={projectName}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '1.5rem' }}>
+        <h1 style={{ fontSize: 24, fontWeight: 800, letterSpacing: '-0.5px', margin: 0 }}>Insights</h1>
+        <button
+          onClick={() => setShowAddModal(true)}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            background: C.amber,
+            color: '#000',
+            border: 'none',
+            borderRadius: 8,
+            padding: '0.5rem 1rem',
+            fontSize: 13,
+            fontWeight: 700,
+            cursor: 'pointer',
+          }}
+        >
+          <Plus size={16} />
+          Add widget
+        </button>
+      </div>
+
+      {loading ? (
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))', gap: '1rem' }}>
+          {[1, 2, 3].map((i) => (
+            <div key={i} style={{ background: C.surface, border: `1px solid ${C.border}`, borderRadius: 12, padding: '1.5rem' }}>
+              <Skeleton height={20} width={160} />
+              <div style={{ marginTop: 16 }}>
+                <Skeleton height={24} />
+                <Skeleton height={24} />
+                <Skeleton height={24} />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : widgets.length === 0 ? (
+        <div style={{
+          background: C.surface,
+          border: `1px solid ${C.border}`,
+          borderRadius: 12,
+          padding: '3rem',
+          textAlign: 'center',
+          color: C.muted,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 12,
+        }}>
+          <Lightbulb size={40} opacity={0.3} />
+          <div style={{ fontSize: 16, fontWeight: 600, color: C.text }}>No widgets yet</div>
+          <div style={{ fontSize: 14, maxWidth: 400 }}>
+            Add a widget to see top-N breakdowns of your event properties.
+            For example: which pages are visited most, or which form fields get the most interaction.
+          </div>
+          <button
+            onClick={() => setShowAddModal(true)}
+            style={{
+              marginTop: 8,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              background: C.amber,
+              color: '#000',
+              border: 'none',
+              borderRadius: 8,
+              padding: '0.5rem 1.25rem',
+              fontSize: 13,
+              fontWeight: 700,
+              cursor: 'pointer',
+            }}
+          >
+            <Plus size={16} />
+            Add your first widget
+          </button>
+        </div>
+      ) : (
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))', gap: '1rem' }}>
+          {widgets.map(({ widget, breakdown }) => (
+            <WidgetCard
+              key={widget.id}
+              widget={widget}
+              breakdown={breakdown}
+              onDelete={() => handleDelete(widget.id)}
+            />
+          ))}
+        </div>
+      )}
+
+      {showAddModal && projectId && (
+        <AddWidgetModal
+          projectId={projectId}
+          onClose={() => setShowAddModal(false)}
+          onAdded={handleAdded}
+        />
+      )}
+    </Shell>
+  )
+}
+
+function WidgetCard({ widget, breakdown, onDelete }: {
+  widget: DashboardWidget
+  breakdown: PropertyBreakdown[]
+  onDelete: () => void
+}) {
+  const maxCount = breakdown.length > 0 ? breakdown[0].count : 1
+  const total = breakdown.reduce((sum, r) => sum + r.count, 0)
+
+  return (
+    <div style={{
+      background: C.surface,
+      border: `1px solid ${C.border}`,
+      borderRadius: 12,
+      overflow: 'hidden',
+    }}>
+      <div style={{
+        padding: '1rem 1.25rem',
+        borderBottom: `1px solid ${C.border}`,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+      }}>
+        <div>
+          <div style={{ fontSize: 14, fontWeight: 700, color: C.text }}>
+            {widget.title || `${widget.event_name} → ${widget.property}`}
+          </div>
+          {widget.title && (
+            <div style={{ fontSize: 12, color: C.muted, marginTop: 2 }}>
+              {widget.event_name} → {widget.property}
+            </div>
+          )}
+        </div>
+        <button
+          onClick={onDelete}
+          style={{
+            background: 'transparent',
+            border: 'none',
+            color: C.muted,
+            cursor: 'pointer',
+            padding: 4,
+            borderRadius: 4,
+            display: 'flex',
+          }}
+          title="Delete widget"
+        >
+          <Trash2 size={14} />
+        </button>
+      </div>
+
+      <div style={{ padding: '1rem 1.25rem' }}>
+        {breakdown.length === 0 ? (
+          <div style={{ color: C.muted, fontSize: 13, textAlign: 'center', padding: '1rem 0' }}>
+            No data yet
+          </div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {breakdown.map((row) => (
+              <div key={row.value}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, marginBottom: 4 }}>
+                  <span style={{
+                    color: C.text,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    maxWidth: '70%',
+                  }} title={row.value}>
+                    {row.value}
+                  </span>
+                  <span style={{ color: C.muted, flexShrink: 0, marginLeft: 8 }}>
+                    {row.count} <span style={{ fontSize: 11 }}>({total > 0 ? Math.round(row.count / total * 100) : 0}%)</span>
+                  </span>
+                </div>
+                <div style={{
+                  height: 6,
+                  background: C.bg,
+                  borderRadius: 3,
+                  overflow: 'hidden',
+                }}>
+                  <div style={{
+                    height: '100%',
+                    width: `${(row.count / maxCount) * 100}%`,
+                    background: C.amber,
+                    borderRadius: 3,
+                    transition: 'width 0.3s ease',
+                  }} />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div style={{
+        padding: '0.5rem 1.25rem',
+        borderTop: `1px solid ${C.border}`,
+        fontSize: 11,
+        color: C.muted,
+      }}>
+        Rolling window: last 100 events
+      </div>
+    </div>
+  )
+}
+
+function AddWidgetModal({ projectId, onClose, onAdded }: {
+  projectId: string
+  onClose: () => void
+  onAdded: () => void
+}) {
+  const [eventNames, setEventNames] = useState<string[]>([])
+  const [properties, setProperties] = useState<string[]>([])
+  const [selectedEvent, setSelectedEvent] = useState('')
+  const [selectedProperty, setSelectedProperty] = useState('')
+  const [title, setTitle] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [loadingEvents, setLoadingEvents] = useState(true)
+  const [loadingProps, setLoadingProps] = useState(false)
+
+  useEffect(() => {
+    api.getEventNames(projectId)
+      .then((d) => setEventNames(d.event_names))
+      .catch(() => {})
+      .finally(() => setLoadingEvents(false))
+  }, [projectId])
+
+  useEffect(() => {
+    if (!selectedEvent) {
+      setProperties([])
+      return
+    }
+    setLoadingProps(true)
+    setSelectedProperty('')
+    api.getEventProperties(projectId, selectedEvent)
+      .then((d) => setProperties(d.properties))
+      .catch(() => {})
+      .finally(() => setLoadingProps(false))
+  }, [projectId, selectedEvent])
+
+  const handleSave = async () => {
+    if (!selectedEvent || !selectedProperty) return
+    setSaving(true)
+    try {
+      await api.createWidget(projectId, {
+        event_name: selectedEvent,
+        property: selectedProperty,
+        title: title || `${selectedEvent} → ${selectedProperty}`,
+      })
+      onAdded()
+    } catch {
+      // silent
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <>
+      <div
+        onClick={onClose}
+        style={{
+          position: 'fixed',
+          inset: 0,
+          background: 'rgba(0,0,0,0.6)',
+          zIndex: 1000,
+        }}
+      />
+      <div style={{
+        position: 'fixed',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        background: C.surface,
+        border: `1px solid ${C.border}`,
+        borderRadius: 16,
+        width: '90%',
+        maxWidth: 480,
+        zIndex: 1001,
+        overflow: 'hidden',
+      }}>
+        <div style={{
+          padding: '1.25rem 1.5rem',
+          borderBottom: `1px solid ${C.border}`,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}>
+          <h2 style={{ margin: 0, fontSize: 18, fontWeight: 800 }}>Add Widget</h2>
+          <button
+            onClick={onClose}
+            style={{ background: 'transparent', border: 'none', color: C.muted, cursor: 'pointer', padding: 4 }}
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div style={{ padding: '1.5rem' }}>
+          <label style={{ display: 'block', fontSize: 13, fontWeight: 600, color: C.muted, marginBottom: 6 }}>
+            Event Name
+          </label>
+          {loadingEvents ? (
+            <Skeleton height={40} />
+          ) : (
+            <select
+              value={selectedEvent}
+              onChange={(e) => setSelectedEvent(e.target.value)}
+              style={{
+                width: '100%',
+                padding: '0.6rem 0.75rem',
+                background: C.bg,
+                border: `1px solid ${C.border}`,
+                borderRadius: 8,
+                color: C.text,
+                fontSize: 14,
+                boxSizing: 'border-box',
+              }}
+            >
+              <option value="">Select an event...</option>
+              {eventNames.map((n) => (
+                <option key={n} value={n}>{n}</option>
+              ))}
+            </select>
+          )}
+
+          <label style={{ display: 'block', fontSize: 13, fontWeight: 600, color: C.muted, marginBottom: 6, marginTop: 16 }}>
+            Property
+          </label>
+          {loadingProps ? (
+            <Skeleton height={40} />
+          ) : (
+            <select
+              value={selectedProperty}
+              onChange={(e) => setSelectedProperty(e.target.value)}
+              disabled={!selectedEvent}
+              style={{
+                width: '100%',
+                padding: '0.6rem 0.75rem',
+                background: C.bg,
+                border: `1px solid ${C.border}`,
+                borderRadius: 8,
+                color: selectedEvent ? C.text : C.muted,
+                fontSize: 14,
+                boxSizing: 'border-box',
+              }}
+            >
+              <option value="">{selectedEvent ? 'Select a property...' : 'Select an event first'}</option>
+              {properties.map((p) => (
+                <option key={p} value={p}>{p}</option>
+              ))}
+            </select>
+          )}
+
+          <label style={{ display: 'block', fontSize: 13, fontWeight: 600, color: C.muted, marginBottom: 6, marginTop: 16 }}>
+            Title (optional)
+          </label>
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder={selectedEvent && selectedProperty ? `${selectedEvent} → ${selectedProperty}` : 'Widget title'}
+            style={{
+              width: '100%',
+              padding: '0.6rem 0.75rem',
+              background: C.bg,
+              border: `1px solid ${C.border}`,
+              borderRadius: 8,
+              color: C.text,
+              fontSize: 14,
+              boxSizing: 'border-box',
+            }}
+          />
+        </div>
+
+        <div style={{
+          padding: '1rem 1.5rem',
+          borderTop: `1px solid ${C.border}`,
+          display: 'flex',
+          justifyContent: 'flex-end',
+          gap: 8,
+        }}>
+          <button
+            onClick={onClose}
+            style={{
+              padding: '0.5rem 1rem',
+              background: 'transparent',
+              border: `1px solid ${C.border}`,
+              borderRadius: 8,
+              color: C.text,
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={!selectedEvent || !selectedProperty || saving}
+            style={{
+              padding: '0.5rem 1rem',
+              background: !selectedEvent || !selectedProperty || saving ? '#4a4d5a' : C.amber,
+              border: 'none',
+              borderRadius: 8,
+              color: !selectedEvent || !selectedProperty || saving ? C.muted : '#000',
+              fontSize: 13,
+              fontWeight: 700,
+              cursor: !selectedEvent || !selectedProperty || saving ? 'default' : 'pointer',
+            }}
+          >
+            {saving ? 'Adding...' : 'Add Widget'}
+          </button>
+        </div>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- New **Insights** page with configurable dashboard widgets per project
- Each widget = event_name + property, showing a top-N breakdown from the last 100 events of that type (rolling window)
- Full backend: migration (`00003_dashboard_widgets`), repository CRUD + rolling window query via `json_extract`, service layer, REST API with CRUD + single/batch breakdown endpoints
- Full frontend: widget grid with bar charts, add widget modal with event/property autocomplete from existing data, nav integration (sidebar + mobile bottom tabs)
- All existing tests pass, gofmt/vet/tsc/eslint clean

## Test plan
- [ ] Create a widget for `page_view` → `url` and verify breakdown shows top visited pages
- [ ] Create a widget for `form_interaction` → `field_name` and verify field click counts
- [ ] Delete a widget and verify it's removed
- [ ] Empty state: new project with no widgets shows CTA
- [ ] Mobile: Insights tab appears in bottom nav
- [ ] CI quality gates pass