### PR TITLE
fix: remove duplicate project picker and reset funnel on project switch

### DIFF
--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -8,7 +8,6 @@ import { Activity, Users, TrendingDown, MousePointer, ArrowUpRight, ArrowDownRig
 import Shell from '../components/shell/Shell'
 import { api, DashboardData } from '../lib/api'
 import { useProjects } from '../lib/projects'
-import { ProjectPicker } from '../components/ui/ProjectPicker'
 import { trackEvent } from '../lib/analytics'
 import { reportError } from '../lib/bugbarn'
 
@@ -356,19 +355,11 @@ export default function Dashboard() {
         @media (max-width: 400px) {
           .stat-cards-grid { grid-template-columns: 1fr !important; }
         }
-        /* Project picker below heading: always visible (top nav badge shown on desktop too) */
-        .mobile-project-picker { display: block; }
       `}</style>
 
       {/* Header */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '1.5rem' }}>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-          <h1 style={{ fontSize: 24, fontWeight: 800, letterSpacing: '-0.5px', margin: 0 }}>Overview</h1>
-          {/* Project picker — visible on mobile (desktop uses top nav badge) */}
-          <div className="mobile-project-picker">
-            <ProjectPicker projects={projects} base="dashboard" variant="badge" />
-          </div>
-        </div>
+        <h1 style={{ fontSize: 24, fontWeight: 800, letterSpacing: '-0.5px', margin: 0 }}>Overview</h1>
         <div style={{ display: 'flex', gap: 4, background: C.surface, border: `1px solid ${C.border}`, borderRadius: 8, padding: 4 }}>
           {RANGES.map((r) => (
             <button

--- a/web/src/pages/Funnels.tsx
+++ b/web/src/pages/Funnels.tsx
@@ -1345,6 +1345,11 @@ export default function Funnels() {
 
   useEffect(() => {
     if (!projectId) return
+    setSelected(null)
+    setAnalysis(null)
+    setAnalysisError(null)
+    setShowDetail(false)
+    setActiveSegment('all')
     api.listFunnels(projectId)
       .then((d) => setFunnels(d.funnels || []))
       .catch((e) => { console.error(e); reportError(e, { source: 'Funnels.listFunnels' }) })


### PR DESCRIPTION
## Summary
- Remove the redundant project picker from the Dashboard page (below "Overview" heading) — the top nav badge and More sheet pickers are sufficient
- Reset selected funnel state when switching projects on the Funnels page, preventing "funnel not found" errors from stale selection

## Test plan
- [ ] Dashboard: only two project pickers remain (top nav badge + More sheet)
- [ ] Funnels: switch project while viewing a funnel detail — should return to funnel list, no error