### PR TITLE
fix: read targetingKey (camelCase) from evaluation context

### DIFF
--- a/internal/service/flags.go
+++ b/internal/service/flags.go
@@ -69,7 +69,10 @@ func (svc *FlagService) EvaluateFlag(ctx context.Context, projectID, flagKey str
 		}, nil
 	}
 
-	targetingKey := evalContext["targeting_key"]
+	targetingKey := evalContext["targetingKey"]
+	if targetingKey == "" {
+		targetingKey = evalContext["targeting_key"]
+	}
 	if targetingKey == "" {
 		targetingKey = evalContext["session_id"]
 	}


### PR DESCRIPTION
## Summary
- OpenFeature SDKs send `targetingKey` (camelCase) in the evaluation context, but the service was reading `targeting_key` (snake_case)
- This caused all evaluations to hash an empty string, assigning every user the same variant regardless of split
- Now reads camelCase first, then falls back to snake_case for compatibility

## Test plan
- [x] Dogfooded on testing env — all users were getting the same variant, this fix resolves it
- [ ] After deploy: re-run evaluate calls with different targeting keys, verify variant distribution matches split percentages