### PR TITLE
chore: add SpanBarn secrets to staging and production

### DIFF
--- a/deploy/k8s/production/secret.yaml
+++ b/deploy/k8s/production/secret.yaml
@@ -1,32 +1,34 @@
-apiVersion: ENC[AES256_GCM,data:mxg=,iv:Dtr/kx4yKlkewKJYQrt3PVAsmF/tqO6CgCLrhEHgYCM=,tag:erGAWx6Ch478wJhypH6XFQ==,type:str]
-kind: ENC[AES256_GCM,data:xxK0QRS3,iv:NPQh80ocrGu8EMETtpK9JhDtQROOyLVZSas3+FfAops=,tag:kiEk7Ha815nuSNCYVLSDgw==,type:str]
+apiVersion: ENC[AES256_GCM,data:4tw=,iv:IGs8GeIUlJ1dGxuYnD+P9vvqPy21u7wFr99nkxfu/X8=,tag:M5LdL5ayzTXW/l4iH3OTwQ==,type:str]
+kind: ENC[AES256_GCM,data:QO5MeL6t,iv:UmSC4DeJlhA9QaYIGttO0oBJI6AnkOQsod7NbJ9aBx4=,tag:C3RHZjgoHUOoIRdUUg8V2A==,type:str]
 metadata:
-    name: ENC[AES256_GCM,data:7yeKvgviOZj5GXATnUtXwjtA,iv:23BsbHwUCFM2j604lk4eUTzp6YFzgE1gQAU/+LeDckw=,tag:1eRyL4L+xkYUAkSiD4P5Rw==,type:str]
-    namespace: ENC[AES256_GCM,data:XXucUl0MqAf4omNC+tpxQI8sMfNz,iv:ZnIrA+RiM+tBxS6JVBq6n921dIfziV/8alp9hUdEhUs=,tag:IqzYbxRTqN44i2iyKX+QLw==,type:str]
+    name: ENC[AES256_GCM,data:sv2v4cX9YwrAhUMX153pV5G3,iv:R/Q1XeTR5DhpNDcQDmXSweyL094NNtbhKpaFqTkk+0Y=,tag:o5Br5cbigNYUTziTRcU0nQ==,type:str]
+    namespace: ENC[AES256_GCM,data:u+TlUku0MJLv8R+zMlE0LZdLIBMc,iv:1MTNlZ1+dO2gi7wRI4YOSkDSmjIc7Pf1NW6HwnrWOY0=,tag:LqqMf1JKXERkubjTZprABw==,type:str]
 stringData:
-    FUNNELBARN_ADMIN_PASSWORD_BCRYPT: ENC[AES256_GCM,data:p9WWepN9OQoKsqqK6JUHlKgx8GchXgigeYjxjB5IkPAc5eoWGm4OI99AEKIuW/Lpoccjxf+sDOHhz8aa,iv:AzQRjk+9zWFt6EmoxU6jfTJOHlUyR33zFe3zEEcrEOQ=,tag:nQl3aGjvyRfYCP3TOY075Q==,type:str]
-    FUNNELBARN_ADMIN_USERNAME: ENC[AES256_GCM,data:U23Kdu8=,iv:nLIykOtrDiqyvytEYs3xY8HhEjkyEeO5vYT/xT373fs=,tag:HHfaadcR9DmGWceJ/AUwqg==,type:str]
-    FUNNELBARN_API_KEY: ENC[AES256_GCM,data:qZvZakkmE7mEbnaTl+bxF3M/eEYIMtV2Y5M+vAon0v2OIv0pZoz7Tymr25NXtF1szgLeyNIJbpIsvVZcdY6Cwg==,iv:h70g3/1HRdyCLabyZc530p7W4lK+48/MUpzaAWPrCCE=,tag:pCsnJUajfk5amF4ZuUlrZA==,type:str]
-    FUNNELBARN_ENVIRONMENT: ENC[AES256_GCM,data:LeJgiGeyafnKLw==,iv:E3bPXWsg/PMHGjQQtYJ1PGYzIHRmrQrhW8jk+8Fdyjo=,tag:vo6NrkDPDQdi4RWphDcBcg==,type:str]
-    FUNNELBARN_SELF_API_KEY: ENC[AES256_GCM,data:i2vxhFmC/7kicj0cbJeiJN+FBptqu7352MmhsrJA8vdgGpoxhrHJXg==,iv:zeZavwy88P/mtC8qy8/cmCILUSKV8OclGBL3aKMUlyY=,tag:dPVQEWADmeK87izVsnZV4w==,type:str]
-    FUNNELBARN_SELF_ENDPOINT: ENC[AES256_GCM,data:pts9/E1+xd9cws/MnQBzRwyLcgwB61Qhlw==,iv:0/o1ZD4ziOBxd/sj04VyLvw/Wng6od+nKUPTc2q74vs=,tag:Tq1G9NrSJcy8DoBtm5Rslg==,type:str]
-    FUNNELBARN_SESSION_SECRET: ENC[AES256_GCM,data:mVhPeqHGSHfRjkfrQJ+9A5s87gzUvq0TdBpkf0s0DjIHdzsVb58jyny49TrAr//nKHzmtjitIUXHcSOAQXdoqg==,iv:X0fENGCyT1v54BTApZE2Gos3Or7xeU4MaqHdRItPA/M=,tag:kUOnhZDmyF83ZISIbvohnQ==,type:str]
-    LITESTREAM_ACCESS_KEY_ID: ENC[AES256_GCM,data:4IjXjyu/jIyk2uWV8YW3JCgE/F1l,iv:RMnuZWDBoJ4+11mIzGuljQ1a5H8OICZKTUtxgsyAt28=,tag:8zbbRzZvo4E3lxsvMThmFA==,type:str]
-    LITESTREAM_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:/d0Ps12gFV+DlPqpicvaF9tL85WFFI03,iv:t6OofhPWKWwc19vouc1HB92CUEdEQXcX4USLKqPOmm0=,tag:q3if6yumbgxhKKCOdDx1RA==,type:str]
-    FUNNELBARN_DOGFOOD_API_KEY: ENC[AES256_GCM,data:4bnfPbfX07PLipBDgK2KIqEyLc32aynF0OkskGiRkvwRTjVi5MDn7XeOT0KSClgN5U1Is/+PVnsaAjaLhgloPA==,iv:d9LwFaI1hVOqbj/L0Hw7Xj4aJ2Md9a1HGXbDIC7vWs4=,tag:xrre9pm63fpnDQHKpSIEXg==,type:str]
-type: ENC[AES256_GCM,data:C5ut2SGe,iv:z/uXG0+eQbK+enMqBv1IjsFEoTJ5t4OBNbpUPpNAxOU=,tag:cEm9II9Hbu94I28Jz/tFKQ==,type:str]
+    FUNNELBARN_ADMIN_PASSWORD_BCRYPT: ENC[AES256_GCM,data:TBWC+bwc0mbJvyzHdiaslTlYNRCnFUKF2n1bTeXAkKPQI3ioYE8H04Kc8fHAbFJFc70hPOzh3ZiKseL5,iv:ZbJhyWS6cRsSC498Mu5+cp6WvlhukxDDAgrY+36aTC4=,tag:B5VreS2UdY9GVs+X5kD20w==,type:str]
+    FUNNELBARN_ADMIN_USERNAME: ENC[AES256_GCM,data:32tnwJw=,iv:eK9p9UzRLZu+68G7yO5y6Ck83AD8zGP8C/mEkoMFS4E=,tag:P9rqTMO/CmNBfgtCBzY9QA==,type:str]
+    FUNNELBARN_API_KEY: ENC[AES256_GCM,data:1n+NVhyBbzwn6jE0tAlVoes/vacRoUyaZsHbCDLC6fIJv4MxbA+GxqI6rc01Op2gjURoWzbBMngzcTWvPlYfWw==,iv:Z1OXSI9c9mciPL6xvwH1y6Tk9YbFlZguE+6k8C8Z5/M=,tag:UCN7swQUNTEBKpxsfU7QSw==,type:str]
+    FUNNELBARN_ENVIRONMENT: ENC[AES256_GCM,data:c49giv+VNbknOw==,iv:Fu1q6qDFzfhFKbRqNKxcbw+d5NPUUt4utDhrJ+eYS9U=,tag:ZfHi3vu7WAwKJukfsdkgKA==,type:str]
+    FUNNELBARN_SELF_API_KEY: ENC[AES256_GCM,data:kLXaGKjEZ8AjSjI78/W1UrDFuSd9I9UWBWTEJRvbglAcPODg73hVTg==,iv:iyfbruw1fJs2jUf0WQvLw61h2WPBhRLsU/Ax1DpaaEs=,tag:LeLyGPe5769wTHwu+dJh2g==,type:str]
+    FUNNELBARN_SELF_ENDPOINT: ENC[AES256_GCM,data:DBU0lNMEkEhlpJvb8i+ixIUD4LEw3Zjh5Q==,iv:dRMtMR6M4QTDoiUCmNO1v/bO0Wl5S6j9N/J3X2maB64=,tag:N+xlPGrmzlaLWcdDs1S+8A==,type:str]
+    FUNNELBARN_SESSION_SECRET: ENC[AES256_GCM,data:uxGZjT09mb+Y2R66itBt4kcdu9bXFmN+RCkv9qKjvcQeY5AlD5JDH3h0QQtfiusZQX1bGpf2Nc5adhqUj9Izdw==,iv:G19TEHANGzgNNYYNs8XhRI5CSkCI6Fe78RpVJTQfVfI=,tag:a6xFlZkQ80GFsQ3UkuZ5yA==,type:str]
+    LITESTREAM_ACCESS_KEY_ID: ENC[AES256_GCM,data:+eBMw77Jn3U3pW/YiFMS2MF+3LzA,iv:7kHxHlC1jDVmb6L5XQZ54IqKwQ0cJH1tOi4ZGNa4YVs=,tag:igJCMfQZiX658kYmfahoOg==,type:str]
+    LITESTREAM_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:0at6G1RV11Q9dlPeIKx/m+553MfuL8i/,iv:vZHqCIlElS9tzBbBL2EMaqgZugbxxYQeBrD27yP2t/Y=,tag:82UBaRomjYxG+rhrlnaj5Q==,type:str]
+    FUNNELBARN_DOGFOOD_API_KEY: ENC[AES256_GCM,data:ggN27JkTPCqOOKHGR7Y4/0LW6NF+vTx5ZF58QewpxZb4M/wgwk7nzUL4wM7IAD4ru+F4Elzatp2brZUB3gP+NQ==,iv:OhrKRNDYnJpIkR+DV648VqsSQJZYKMatXaTXUYsp9mg=,tag:nZ2jVUHuCqsXg5o46F4qEQ==,type:str]
+    FUNNELBARN_SPANBARN_ENDPOINT: ENC[AES256_GCM,data:+kf9ID0qOtv+r7VDyVbtRMCX1/YyGv9MU1Pxeq4KzyU+Q2aE,iv:K3uesHcee4Hy4EWzRr2S/kWRzJH1Rf9X/Te3yKO6QsE=,tag:GOIzkJgXfxYJzLqxrkjrMg==,type:str]
+    FUNNELBARN_SPANBARN_API_KEY: ENC[AES256_GCM,data:SymdW5bvhFyvOLJw0OZLVsgVeEjzl+UqnH/tKa/2wRXJERfe/ArljQ==,iv:KH1I8y4W/YBRDdJHIaLkz+lLeXWhYqRWWAZK+PWpWls=,tag:w272ZPjvTrdWLppjrKMMKw==,type:str]
+type: ENC[AES256_GCM,data:F2dhX/7h,iv:+TR+FJeT3eT15f6U4M90H1HDaE4yXLZwJhGR5xWNgvs=,tag:YOm3cnRAsgL4iCm4PS59DA==,type:str]
 sops:
     age:
         - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOcnpFYkRxaEJnM2cyeklW
-            S3IrcFp3R3ZmdHAwTEwyVFhKOG5jUzZYeTNNCkVYOXBGVTdYRkJNY29tZ0laSEVt
-            VGdMa1REbGdxbmIvZnhVOXhkRVlKV0kKLS0tIHlYMVUxMnJ0OWI0NWFJRHU2akhH
-            V0FicWJ1OTQ2RU5aRUtIQURsWnJnbDAKPtakhM76h/AOWbIDmzAljDEfjCWq5IdL
-            j7RaHQMD3nXtPIQ1b1VVi9VoMM4reRZ8h88HRX8bxXX5J6TWGxKLrg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuNUVyUjlSU2g2UTY4RlhQ
+            RUpvTmxUZzltcWR6ZWNwOFl0UTNTUUszdFg4CkZFRUFOWkJJZkVWU0hNUythRlVa
+            YitNa0Mva2pXRGpoNzZzdE1TZmJTMncKLS0tIFlya1pOWUdmenRXR21Wa0dZOWZO
+            K3VwblNzQWFySkR6K1UzbVp6Yy9JaW8KgZXWEOPfza3zvi0Lb0J3H7K4ah090rJt
+            sVw/YeVeR3nKT+cEQpKjAXXZkZzGqlalRuxl1fB3r2G9LGIyjkUahw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-02T04:55:17Z"
-    mac: ENC[AES256_GCM,data:AJOrxTso+3k/IqBhJGpvPBNYVt+z/eR0koaxwycekbtSIfHxJReAm/mIxzZssLtwRgA70ajaqfuBGarWG/o8Mj0ZXD2hT4rtzOEfHdggkT6lqsKpqIQSDh1KAZ7VHDPCU0jQb8/6UEC1qZku4uHOa/aJMuoMvk95qXwC0yCqLnY=,iv:sDhccpf9SKP6pxprOgEkGciHUETMcr3ZFsxmMtaxoQ4=,tag:6694mVkTR8Z1EXD2/Z/pow==,type:str]
+    lastmodified: "2026-05-07T07:33:14Z"
+    mac: ENC[AES256_GCM,data:OKgfyispaLZoT4LaQaaE0C4dXunV17ZdPOdFHAbRWuf63Okb35wCEInLDYDKUmG2N3XVAUbngwnYvA11eDzHb9Kz+wmOgD6GDxyzgl67pxosZLrNj8Z2CmtPVFbAgGXuhts3pSuC3n7yZalPIiaTXwIU3HkXkH+jZpH/mA08oGs=,iv:TJtKzWmK86l5MEjDTIq/H0RSaYojonjrdNfAuHBZSEE=,tag:fMeMlYVQtNAUbakrkj6fpA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/deploy/k8s/staging/secret.yaml
+++ b/deploy/k8s/staging/secret.yaml
@@ -1,29 +1,31 @@
-apiVersion: ENC[AES256_GCM,data:Q0Y=,iv:Dlhn8ZiC9Qlb0Aw/3w5gHhIVldC3vLp5sQuA23SnDpw=,tag:NRVc9JBiGIbbQvlvxUd5bg==,type:str]
-kind: ENC[AES256_GCM,data:NjlpoDsp,iv:JbNa6FXn0YQWB0WH1YtrE7FRYji/BXSREKlnR197YKE=,tag:trYm4b+6h+Wkn6kqVB90DA==,type:str]
+apiVersion: ENC[AES256_GCM,data:Jko=,iv:CZSKBOvuzwQ3J+9lhgmxZv92WsU/LafAX6ebvKneDIk=,tag:3cdcaseai1gqrpPdIKsI+w==,type:str]
+kind: ENC[AES256_GCM,data:ywVGuv90,iv:BIY7/YEwerMewgk4xiTJj8yNSWw0oI+4pKBbZ13f6qc=,tag:YdH6gDJbjHM+GtYffWzZ8A==,type:str]
 metadata:
-    name: ENC[AES256_GCM,data:p1LqcGcliQPB9slzJbDfA7Bn,iv:LZllqiUDw109Vg7cLMUff1beE/jZs1w0vxWMRDBrIO0=,tag:M/INXxDQPowtdBp5cFMHIw==,type:str]
-    namespace: ENC[AES256_GCM,data:lTulJMsegpeUqdhGzN7TWNph,iv:4kzsiaJQN3RNOergBVmX5yovazlGGaYZTcHqPF6rZVE=,tag:EGnA69Ea/rJxIMZuwK65iw==,type:str]
+    name: ENC[AES256_GCM,data:KeN/5+eiwfFOLOxbLAinb+m+,iv:DhV+StTE2NISkQ/HI/CBZ5yoY9hGV28r2vQJTKZVDsc=,tag:D+4ros/tS7b1HRvvP+zeBg==,type:str]
+    namespace: ENC[AES256_GCM,data:ew0JFI9otFaub0IBh17mtAfa,iv:Fje3Z22/Z3suzX3hi4rNEfm7gUP36FhIVDTP6tO78mM=,tag:ehNAywRHKrKR+vkgt7g3ug==,type:str]
 stringData:
-    FUNNELBARN_ADMIN_PASSWORD_BCRYPT: ENC[AES256_GCM,data:ArqblpAf3umwKH4ygFNIWenh1iSHm9ucWIdxOqTyo44wFOU6lRF0uf+BPq7QtDKOiIFBItM8xO+i4eQF,iv:Wmcc7IJK3+oDnffVJ8k82Joh5GMqGBXnbDQCh2Rdy/Q=,tag:XPj8kpRHU6uBoP/u3xEoVg==,type:str]
-    FUNNELBARN_ADMIN_USERNAME: ENC[AES256_GCM,data:0JVNfn4=,iv:d3T+pXONPU5RIJSH2NU8JnzvRAFjE2x1nsL115ScMC0=,tag:Y2cXcEWp0m8C9pEHgATKfQ==,type:str]
-    FUNNELBARN_API_KEY: ENC[AES256_GCM,data:ef5UyK0mrGXnl3ixZ6mVzoi1h/XdIEz+u+HN9fLDzZ9UVS8oWjy9uIcWKmUF5DSNpD3svVTH2Xtqoew3bn+5ZQ==,iv:0xiQt6ZZj375f2N9lA8F+3PLmTRwg4zNGhXDVrgupJw=,tag:Wmt4J+FlX/ABFNBXBUJFZQ==,type:str]
-    FUNNELBARN_ENVIRONMENT: ENC[AES256_GCM,data:2qMZddTYag==,iv:R0VrT8JmVCSYaV0WJ0rRyOXqpXuWAVURp+guEiAmFj4=,tag:3GxIRnr2ru3+3Pv4EZ1ASQ==,type:str]
-    FUNNELBARN_SELF_API_KEY: ENC[AES256_GCM,data:eGhDe2OJzRMGkAo0z9wnogd0lp1C2fVctaOICEVmtMmiNdsIe0YqIA==,iv:aU3P3eRDLdP/3MJjcAsmqSCpt0AFQDdoQKST5JEGxbk=,tag:k49ofWW7dX9co1ViRllKBQ==,type:str]
-    FUNNELBARN_SELF_ENDPOINT: ENC[AES256_GCM,data:z3bj3X2zayGWBd/HrhKvUpkLuK5kC408nw==,iv:7ASpfZ4v2zItrXJYD5niLcnHeQVWvjZQ9WVwjFDVer0=,tag:JBxZ1KcldI17gfh6zKtIWg==,type:str]
-    FUNNELBARN_SESSION_SECRET: ENC[AES256_GCM,data:0knLHOLBd8b/iQlIq3zbHNCAHRRdds6R2gKZ0WjfWfiOPNpVBAVxxWz6Ph7GKsHdbZwoylMkUqvoVWIGiR6vsw==,iv:mtCGo4kvDoi4qsJtYWh37co9Ippu6AP68TmbYijcDQI=,tag:WUgV2uOK+kwa54zg12MecQ==,type:str]
-type: ENC[AES256_GCM,data:sKH6ryRJ,iv:WOb60TETD4f+tdDJq0p8iTNoKJn0qWkV7bRrhyLJMPQ=,tag:fX8uL6850/MM33rTQW+RIg==,type:str]
+    FUNNELBARN_ADMIN_PASSWORD_BCRYPT: ENC[AES256_GCM,data:w5GfqQN6973Mv4hGWDhTrI7Lvxy6cm8Tu4luIBpsdFH8dV7t9700vYGdP7GOInQznmwuCJRLXSjNdH8b,iv:MBW2S+qX0oO8umgk9p5I6bDaN1Fu1qG/0FG99OqBtp8=,tag:BW15yL2gzGp+IUVfh9QUhw==,type:str]
+    FUNNELBARN_ADMIN_USERNAME: ENC[AES256_GCM,data:HsCBN1o=,iv:5o3H8nRrvbTKp0T/8WENEKLictloli+mkwWuTiPJT8I=,tag:ZuX6y4ey3zvIZ5ORpLOlow==,type:str]
+    FUNNELBARN_API_KEY: ENC[AES256_GCM,data:+qENTFaMDpVmMIFtr3iU6HfPSOuRncg0ilrJUIL1LjV80w79Vxol/Hfmwp/EPOTEwVQ65Y0PZ6rGtSKr/A4Ksw==,iv:AzsWGNWfYwh//fgQwYVXTOPCiJAE7TDPhZ2NHw4MNJE=,tag:Ckm2llFGCIH5RekTdzP6mA==,type:str]
+    FUNNELBARN_ENVIRONMENT: ENC[AES256_GCM,data:YgLcWb7HPQ==,iv:bil8ILGOmkqBW8lWkM32ztBEZid3O9SEqpiwlmtRCuE=,tag:xkjsZZl6I40X1JRGGgqw2Q==,type:str]
+    FUNNELBARN_SELF_API_KEY: ENC[AES256_GCM,data:6SDD45inIY+XyDxgk/hScUsEqVIdgvzEOJCYRLOM416ziRBbO575hw==,iv:6GWUt/qUo+fAHlVuY6EqePi8s3hZ+yJ7QHYU8n5fY1E=,tag:n/ZG++TXkLAho2hxAQ6uVA==,type:str]
+    FUNNELBARN_SELF_ENDPOINT: ENC[AES256_GCM,data:5RKknfDnB89r15Q3ySsQW2fiNjkXNB9X8Q==,iv:nhmYMiwSNULzu3Jzl6sPk6YeYryD1EdCvyGsJBCVIoo=,tag:UKSbnHfXJKAOfK5K8E30ow==,type:str]
+    FUNNELBARN_SESSION_SECRET: ENC[AES256_GCM,data:IkDl0LhwOcWYZTbXM5HuW4JvjskUHBhhg03cLhnf9HFnPDhKyKcEuLePFRT8LDjtGaNGtBUzqBN0MEyJc7wZCA==,iv:wjgWWucSu7Bp1c3GABv34prrs2NwBD+J+GACVA+Jqy0=,tag:kfVEjCaNpyD4VvgX756Owg==,type:str]
+    FUNNELBARN_SPANBARN_ENDPOINT: ENC[AES256_GCM,data:gyAazBuN33p/Y9viLopRzdue5B4NDiu6br+PaCPWDwLt6x4J,iv:vssQzVzpMoXTIMjjbAkRoaTq2ODMqFvjiKvkyo4vqck=,tag:hk1x1SD5b0OOmvKD5FjZNg==,type:str]
+    FUNNELBARN_SPANBARN_API_KEY: ENC[AES256_GCM,data:G/qWkw45IHZhifp9X7Kxg72GL7C7Afn/RRDmAF4jrtDoy0lsCwsMWw==,iv:AKNuOGHlTL7B8DZ+ute5fjhyqaffrQt0Rk2tvvC+jZQ=,tag:s6/GmAUimaIQvMDs5aouPg==,type:str]
+type: ENC[AES256_GCM,data:j3xiz+Or,iv:IZU6E2E7NRmJNESOX3/39faVk97fZEPreoVimwYeHR8=,tag:JM35xtiOm/wxdt30cZHCXQ==,type:str]
 sops:
     age:
         - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIeWd1ODlabUxUZk40bUtP
-            QXliVHJTN0hjUGp3akZtWFpHVDRhT1l2UFMwClZtM0x3U3JFUEdBYVdhUUtMRzJU
-            VVpOSEJUenkyeW1ReG9UbXVaellUWUkKLS0tIGhXb1l2VmhDREVVUWJTbmZuVk5V
-            VzJVSkNvWUhkb3lJeXdRZy8rNWpmOWMKyNmr8/Fc79YeHhKbb8VUy3YG7Cd7LSf9
-            YKebdspGvWgpQJe4ny4TQFlciHLq1VdRZJ2R3kx18NYA8S/NdtuGkg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqMU5oVzlKMjkwU2gwcDZW
+            ZndqNWhwN21LZis5WFdMSjRCeHExNCtXMGlVCnBXMGR5SGRzZGprZVZVcWRBQ3FN
+            SCtJb1YvNWU2VmJ6RzQ5a3NGdkRONUEKLS0tIGlwMitIKzIzNmh3dDNNT2gxb3FO
+            M1pZcUQrWmxCWlQzUldpcWZpTlF5Z2sKxvRXA7kLe7HoC+UJmtfQuzGOZ+1oaKvI
+            anzLivgCzT7bxqYfSbAjDu3HY+wdVU4ezJeAgAnL7EXH5B8YCFNyJg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-29T18:13:14Z"
-    mac: ENC[AES256_GCM,data:7j9G5CWhFDwJVPiQaYtbn1C+/Z9QMuNrgU/sPUMtlxP51fi8SKWtqT6pslGzYbYV2HHf/CSHq7kDSO//W3WlWb0QQgg/vbQLsbodj6yrRUGqoA4cwBQtsfxDJz0VTLXWOag1ScjHiot333AWmhKPGIAxhAMwBsnzihEUXIzwrNw=,iv:/wgVijhfCj+sNP2jGU6qRMnnYJZZR9DdtD5j9XU7ONw=,tag:S1mJnPtIh5ZDFgXtU+ppfA==,type:str]
+    lastmodified: "2026-05-07T07:33:14Z"
+    mac: ENC[AES256_GCM,data:0xrCjGSYWLsetrLO5GsGAOE7QmBwy+OhfzFo4NGi/cFGEJt1faPfT8VZc+/Y6UN0p9OaBHM+T8lwF9JhJURuFO8/HS7gvbqAOW0LULT94cpVOxEbCtwVO28Gq9Qfbgq6qq9sxhjv0lmsK+dIyorXLy98FKsZfsmMKo7cjStMvsU=,iv:8miUa8tVaNxI501JRwQwJo78tmuoq+QleRdztiojc64=,tag:cgBm9h2uHrzbylPWUF84EQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Summary
- Adds `FUNNELBARN_SPANBARN_ENDPOINT` and `FUNNELBARN_SPANBARN_API_KEY` to staging and production encrypted secrets
- Env var references were already added to deployment manifests in #86 (optional), this just provides the values

## Test plan
- [x] Testing already has these secrets and is exporting traces
- [ ] After merge + redeploy: staging and production will begin exporting traces to SpanBarn