### PR TITLE
fix: CSRF validation, security hardening, and ports IoC

### DIFF
--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -171,7 +171,7 @@ func run() error {
 		slog.Info("tracing enabled", "endpoint", cfg.SpanBarnEndpoint)
 	}
 
-	go runBackgroundWorker(ctx, cfg, store)
+	go runBackgroundWorker(ctx, cfg, store, eventSpool)
 
 	apiAuthorizer, err := newAPIAuthorizer(cfg, store)
 	if err != nil {
@@ -185,34 +185,37 @@ func run() error {
 	handler := ingest.NewHandler(apiAuthorizer, eventSpool, cfg.MaxBodyBytes)
 	go handler.Start(ctx)
 
-	apiServer := api.NewServer(
-		handler,
-		projectsSvc,
-		funnelsSvc,
-		abtestsSvc,
-		flagsSvc,
-		eventsSvc,
-		sessionsSvc,
-		apikeysSvc,
-		widgetsSvc,
-		userAuth,
-		sessionManager,
-		cfg.AllowedOrigins,
-		cfg.SessionSecret,
-		cfg.PublicURL,
-		cfg.LoginRatePerMinute,
-		cfg.LoginRateBurst,
-		cfg.APIRatePerMinute,
-		cfg.APIRateBurst,
-		cfg.IngestRatePerMinute,
-		cfg.IngestRateBurst,
-		store,
-		Version,
-		cfg.SelfEndpoint,
-		cfg.SelfAPIKey,
-		cfg.DogfoodAPIKey,
-		cfg.DogfoodProject,
-	)
+	apiServer := api.NewServer(api.ServerConfig{
+		Ingest:              handler,
+		Projects:            projectsSvc,
+		Funnels:             funnelsSvc,
+		ABTests:             abtestsSvc,
+		Flags:               flagsSvc,
+		Events:              eventsSvc,
+		Sessions:            sessionsSvc,
+		APIKeys:             apikeysSvc,
+		Widgets:             widgetsSvc,
+		UserAuth:            userAuth,
+		SessionManager:      sessionManager,
+		AllowedOrigins:      cfg.AllowedOrigins,
+		SessionSecret:       cfg.SessionSecret,
+		PublicURL:           cfg.PublicURL,
+		LoginRatePerMinute:  cfg.LoginRatePerMinute,
+		LoginRateBurst:      cfg.LoginRateBurst,
+		APIRatePerMinute:    cfg.APIRatePerMinute,
+		APIRateBurst:        cfg.APIRateBurst,
+		IngestRatePerMinute: cfg.IngestRatePerMinute,
+		IngestRateBurst:     cfg.IngestRateBurst,
+		SetupRatePerMinute:  cfg.SetupRatePerMinute,
+		SetupRateBurst:      cfg.SetupRateBurst,
+		DB:                  store,
+		Version:             Version,
+		TrustedProxies:      cfg.TrustedProxies,
+		BugbarnEndpoint:     cfg.SelfEndpoint,
+		BugbarnIngestKey:    cfg.SelfAPIKey,
+		DogfoodAPIKey:       cfg.DogfoodAPIKey,
+		DogfoodProject:      cfg.DogfoodProject,
+	})
 	if cfg.MetricsToken != "" {
 		apiServer.SetMetricsToken(cfg.MetricsToken)
 	}
@@ -266,7 +269,7 @@ const (
 	workerRotateThreshold = 64 << 20 // 64 MiB
 )
 
-func runBackgroundWorker(ctx context.Context, cfg config.Config, store *repository.Store) {
+func runBackgroundWorker(ctx context.Context, cfg config.Config, store *repository.Store, eventSpool *spool.Spool) {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 
@@ -294,6 +297,12 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 				} else if n > 0 {
 					slog.Info("purged old events", "count", n, "before", cutoff.Format(time.DateOnly))
 					metrics.EventsPurged.Add(float64(n))
+				}
+				ne, err := store.PurgeOldEvaluations(ctx, cutoff)
+				if err != nil {
+					slog.Error("purge old evaluations", "err", err)
+				} else if ne > 0 {
+					slog.Info("purged old evaluations", "count", ne, "before", cutoff.Format(time.DateOnly))
 				}
 			}
 		case <-ticker.C:
@@ -379,7 +388,7 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 				}
 			}
 
-			if err := spool.RotateIfExceedsPath(cfg.SpoolDir, workerRotateThreshold); err != nil {
+			if err := eventSpool.RotateIfExceeds(workerRotateThreshold); err != nil {
 				slog.Error("worker rotate spool", "err", err)
 			}
 		}

--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -220,6 +220,8 @@ func run() error {
 		apiServer.SetMetricsToken(cfg.MetricsToken)
 	}
 
+	apiServer.StartCleanup(ctx)
+
 	var httpHandler http.Handler = apiServer
 	if selfReporting {
 		httpHandler = bb.RecoverMiddleware(httpHandler)

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -55,15 +55,31 @@ func newTestServer(t *testing.T) (*Server, *repository.Store) {
 	ingestHandler := ingest.NewHandler(auth.New("test-key"), sp, 0)
 	sm := auth.NewSessionManager("test-secret", time.Hour)
 
-	// Use disabled user auth so requireSession lets all requests through.
 	userAuth, _ := auth.NewUserAuthenticator("", "", "")
 
-	srv := NewServer(ingestHandler,
-		service.NewProjectService(store), service.NewFunnelService(store),
-		service.NewABTestService(store), service.NewFlagService(store), service.NewEventService(store),
-		service.NewSessionService(store), service.NewAPIKeyService(store),
-		service.NewWidgetService(store),
-		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, 1000, 1000, store, "test", "", "", "", "")
+	srv := NewServer(ServerConfig{
+		Ingest:              ingestHandler,
+		Projects:            service.NewProjectService(store),
+		Funnels:             service.NewFunnelService(store),
+		ABTests:             service.NewABTestService(store),
+		Flags:               service.NewFlagService(store),
+		Events:              service.NewEventService(store),
+		Sessions:            service.NewSessionService(store),
+		APIKeys:             service.NewAPIKeyService(store),
+		Widgets:             service.NewWidgetService(store),
+		UserAuth:            userAuth,
+		SessionManager:      sm,
+		SessionSecret:       "test-secret",
+		PublicURL:           "http://localhost",
+		LoginRatePerMinute:  1000,
+		LoginRateBurst:      1000,
+		APIRatePerMinute:    1000,
+		APIRateBurst:        1000,
+		IngestRatePerMinute: 1000,
+		IngestRateBurst:     1000,
+		DB:                  store,
+		Version:             "test",
+	})
 	return srv, store
 }
 
@@ -76,12 +92,29 @@ func newAuthedServer(t *testing.T) (*Server, *repository.Store) {
 	sm := auth.NewSessionManager("test-secret", time.Hour)
 	userAuth, _ := auth.NewUserAuthenticator("admin", "password", "")
 
-	srv := NewServer(ingestHandler,
-		service.NewProjectService(store), service.NewFunnelService(store),
-		service.NewABTestService(store), service.NewFlagService(store), service.NewEventService(store),
-		service.NewSessionService(store), service.NewAPIKeyService(store),
-		service.NewWidgetService(store),
-		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, 1000, 1000, store, "test", "", "", "", "")
+	srv := NewServer(ServerConfig{
+		Ingest:              ingestHandler,
+		Projects:            service.NewProjectService(store),
+		Funnels:             service.NewFunnelService(store),
+		ABTests:             service.NewABTestService(store),
+		Flags:               service.NewFlagService(store),
+		Events:              service.NewEventService(store),
+		Sessions:            service.NewSessionService(store),
+		APIKeys:             service.NewAPIKeyService(store),
+		Widgets:             service.NewWidgetService(store),
+		UserAuth:            userAuth,
+		SessionManager:      sm,
+		SessionSecret:       "test-secret",
+		PublicURL:           "http://localhost",
+		LoginRatePerMinute:  1000,
+		LoginRateBurst:      1000,
+		APIRatePerMinute:    1000,
+		APIRateBurst:        1000,
+		IngestRatePerMinute: 1000,
+		IngestRateBurst:     1000,
+		DB:                  store,
+		Version:             "test",
+	})
 	return srv, store
 }
 
@@ -93,6 +126,25 @@ func sessionCookieFor(t *testing.T, srv *Server, username string) *http.Cookie {
 		t.Fatalf("Create session: %v", err)
 	}
 	return auth.SessionCookie(token, expires, false)
+}
+
+func postJSONWithCSRF(t *testing.T, srv *Server, path string, body any, cookie *http.Cookie, csrfToken string) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(body); err != nil {
+		t.Fatalf("encode body: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, path, &buf)
+	req.Header.Set("Content-Type", "application/json")
+	if csrfToken != "" {
+		req.Header.Set("X-FunnelBarn-CSRF", csrfToken)
+	}
+	if cookie != nil {
+		req.AddCookie(cookie)
+	}
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	return w
 }
 
 func postJSON(t *testing.T, srv *Server, path string, body any, cookie *http.Cookie) *httptest.ResponseRecorder {
@@ -164,12 +216,29 @@ func TestHandleHealth_DBDown(t *testing.T) {
 
 	brokenPinger := &failPinger{err: errors.New("connection refused")}
 
-	srv := NewServer(ingestHandler,
-		service.NewProjectService(store), service.NewFunnelService(store),
-		service.NewABTestService(store), service.NewFlagService(store), service.NewEventService(store),
-		service.NewSessionService(store), service.NewAPIKeyService(store),
-		service.NewWidgetService(store),
-		userAuth, sm, nil, "test-secret", "http://localhost", 1000, 1000, 1000, 1000, 1000, 1000, brokenPinger, "test", "", "", "", "")
+	srv := NewServer(ServerConfig{
+		Ingest:              ingestHandler,
+		Projects:            service.NewProjectService(store),
+		Funnels:             service.NewFunnelService(store),
+		ABTests:             service.NewABTestService(store),
+		Flags:               service.NewFlagService(store),
+		Events:              service.NewEventService(store),
+		Sessions:            service.NewSessionService(store),
+		APIKeys:             service.NewAPIKeyService(store),
+		Widgets:             service.NewWidgetService(store),
+		UserAuth:            userAuth,
+		SessionManager:      sm,
+		SessionSecret:       "test-secret",
+		PublicURL:           "http://localhost",
+		LoginRatePerMinute:  1000,
+		LoginRateBurst:      1000,
+		APIRatePerMinute:    1000,
+		APIRateBurst:        1000,
+		IngestRatePerMinute: 1000,
+		IngestRateBurst:     1000,
+		DB:                  brokenPinger,
+		Version:             "test",
+	})
 
 	w := getJSON(t, srv, "/api/v1/health", nil)
 	if w.Code != http.StatusServiceUnavailable {

--- a/internal/api/csrf_test.go
+++ b/internal/api/csrf_test.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/wiebe-xyz/funnelbarn/internal/auth"
+)
+
+func TestCSRF_MutatingRequestWithoutToken_Blocked(t *testing.T) {
+	srv, _ := newAuthedServer(t)
+	cookie := sessionCookieFor(t, srv, "admin")
+
+	w := postJSON(t, srv, "/api/v1/projects", map[string]string{
+		"name": "CSRF Test",
+		"slug": "csrf-test",
+	}, cookie)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("POST without CSRF token: want 403, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestCSRF_MutatingRequestWithValidToken_Allowed(t *testing.T) {
+	srv, _ := newAuthedServer(t)
+	token, expires, err := srv.sessionManager.Create("admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cookie := auth.SessionCookie(token, expires, false)
+	csrfToken := auth.CSRFToken(token)
+
+	w := postJSONWithCSRF(t, srv, "/api/v1/projects", map[string]string{
+		"name": "CSRF OK",
+		"slug": "csrf-ok",
+	}, cookie, csrfToken)
+	if w.Code != http.StatusCreated {
+		t.Errorf("POST with valid CSRF: want 201, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestCSRF_MutatingRequestWithWrongToken_Blocked(t *testing.T) {
+	srv, _ := newAuthedServer(t)
+	cookie := sessionCookieFor(t, srv, "admin")
+
+	w := postJSONWithCSRF(t, srv, "/api/v1/projects", map[string]string{
+		"name": "CSRF Bad",
+		"slug": "csrf-bad",
+	}, cookie, "wrong-token")
+	if w.Code != http.StatusForbidden {
+		t.Errorf("POST with wrong CSRF: want 403, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestCSRF_GETRequestWithoutToken_Allowed(t *testing.T) {
+	srv, _ := newAuthedServer(t)
+	cookie := sessionCookieFor(t, srv, "admin")
+
+	w := getJSON(t, srv, "/api/v1/projects", cookie)
+	if w.Code != http.StatusOK {
+		t.Errorf("GET without CSRF: want 200, got %d", w.Code)
+	}
+}
+
+func TestCSRF_NoAuthConfigured_Skipped(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	w := postJSON(t, srv, "/api/v1/projects", map[string]string{
+		"name": "No Auth",
+		"slug": "no-auth",
+	}, nil)
+	if w.Code != http.StatusCreated {
+		t.Errorf("POST without auth: want 201, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -73,20 +73,12 @@ func newRateLimiter(perMinute, burst float64) *rateLimiter {
 	}
 }
 
-// allow returns true if the request is within the rate limit, false if it
-// should be rejected. It also cleans up stale buckets (idle > 10 min).
+// allow returns true if the request is within the rate limit.
 func (rl *rateLimiter) allow(ip string) bool {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
 	now := time.Now()
-
-	// Clean up stale buckets on every access.
-	for k, b := range rl.buckets {
-		if now.Sub(b.lastSeen) > 10*time.Minute {
-			delete(rl.buckets, k)
-		}
-	}
 
 	b, ok := rl.buckets[ip]
 	if !ok {
@@ -94,7 +86,6 @@ func (rl *rateLimiter) allow(ip string) bool {
 		rl.buckets[ip] = b
 	}
 
-	// Refill tokens based on elapsed time.
 	elapsed := now.Sub(b.lastSeen).Seconds()
 	b.tokens += elapsed * rl.rate
 	if b.tokens > rl.capacity {
@@ -109,14 +100,98 @@ func (rl *rateLimiter) allow(ip string) bool {
 	return true
 }
 
+// cleanup removes stale buckets (idle > 10 min).
+func (rl *rateLimiter) cleanup() {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := time.Now()
+	for k, b := range rl.buckets {
+		if now.Sub(b.lastSeen) > 10*time.Minute {
+			delete(rl.buckets, k)
+		}
+	}
+}
+
+// startCleanup runs periodic cleanup in a background goroutine until ctx is cancelled.
+func (rl *rateLimiter) startCleanup(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				rl.cleanup()
+			}
+		}
+	}()
+}
+
 // clientIP extracts the real client IP address from the request.
-// It respects X-Forwarded-For when present (for reverse-proxy deployments),
-// taking the first IP in the chain. Falls back to RemoteAddr.
-func clientIP(r *http.Request) string {
-	// Respect X-Forwarded-For from trusted proxies (single hop).
-	// In production, a reverse proxy (Traefik/nginx) sets this.
+// When trustedProxies is configured, X-Forwarded-For is only respected if the
+// direct connection comes from one of those IPs. When no trusted proxies are
+// configured, X-Forwarded-For is trusted unconditionally (backwards compatible).
+func (s *Server) clientIP(r *http.Request) string {
+	remoteIP, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		remoteIP = r.RemoteAddr
+	}
+
+	xff := r.Header.Get("X-Forwarded-For")
+	if xff == "" {
+		return remoteIP
+	}
+
+	if len(s.trustedProxies) > 0 && !s.isTrustedProxy(remoteIP) {
+		return remoteIP
+	}
+
+	if idx := strings.IndexByte(xff, ','); idx >= 0 {
+		xff = strings.TrimSpace(xff[:idx])
+	} else {
+		xff = strings.TrimSpace(xff)
+	}
+	if xff != "" {
+		return xff
+	}
+	return remoteIP
+}
+
+func (s *Server) isTrustedProxy(ip string) bool {
+	for _, trusted := range s.trustedProxies {
+		if trusted == ip {
+			return true
+		}
+	}
+	return false
+}
+
+// middleware returns an http.Handler that enforces the rate limit.
+// It falls back to RemoteAddr for IP extraction (used for routes not
+// bound to a Server, e.g. in tests).
+func (rl *rateLimiter) middleware(next http.Handler) http.Handler {
+	return rl.middlewareWithIP(next, defaultClientIP)
+}
+
+func (rl *rateLimiter) middlewareWithIP(next http.Handler, extractIP func(*http.Request) string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ip := extractIP(r)
+
+		if !rl.allow(ip) {
+			retryAfter := int(60.0 / rl.rate)
+			w.Header().Set("Retry-After", fmt.Sprintf("%d", retryAfter))
+			jsonError(w, "too many requests", http.StatusTooManyRequests)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func defaultClientIP(r *http.Request) string {
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		// Take the first IP in the chain.
 		if idx := strings.IndexByte(xff, ','); idx >= 0 {
 			xff = strings.TrimSpace(xff[:idx])
 		} else {
@@ -131,22 +206,6 @@ func clientIP(r *http.Request) string {
 		return r.RemoteAddr
 	}
 	return ip
-}
-
-// middleware returns an http.Handler that enforces the rate limit.
-func (rl *rateLimiter) middleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ip := clientIP(r)
-
-		if !rl.allow(ip) {
-			retryAfter := int(60.0 / rl.rate)
-			w.Header().Set("Retry-After", fmt.Sprintf("%d", retryAfter))
-			jsonError(w, "too many requests", http.StatusTooManyRequests)
-			return
-		}
-
-		next.ServeHTTP(w, r)
-	})
 }
 
 // --------------------------------------------------------------------------

--- a/internal/api/ratelimit_cleanup_test.go
+++ b/internal/api/ratelimit_cleanup_test.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRateLimiter_StaleCleanup_DoesNotBlockRequests(t *testing.T) {
+	rl := newRateLimiter(6000, 100) // very high rate — should never reject
+
+	// Simulate many distinct IPs.
+	for i := 0; i < 1000; i++ {
+		ip := "10.0.0." + time.Now().Format("150405") + ":" + string(rune(i))
+		rl.allow(ip)
+	}
+
+	// The current request should still be fast and not blocked.
+	start := time.Now()
+	allowed := rl.allow("fresh-ip")
+	elapsed := time.Since(start)
+
+	if !allowed {
+		t.Error("fresh IP was unexpectedly rate-limited")
+	}
+	if elapsed > 10*time.Millisecond {
+		t.Errorf("allow() took %v — cleanup may be too expensive", elapsed)
+	}
+}
+
+func TestRateLimiter_StaleBucketsAreRemoved(t *testing.T) {
+	rl := newRateLimiter(60, 1)
+
+	rl.allow("stale-ip")
+
+	// Manually age the bucket.
+	rl.mu.Lock()
+	b := rl.buckets["stale-ip"]
+	b.lastSeen = time.Now().Add(-15 * time.Minute)
+	rl.buckets["stale-ip"] = b
+	rl.mu.Unlock()
+
+	// Trigger cleanup.
+	rl.cleanup()
+
+	rl.mu.Lock()
+	_, exists := rl.buckets["stale-ip"]
+	rl.mu.Unlock()
+
+	if exists {
+		t.Error("stale bucket was not cleaned up")
+	}
+}

--- a/internal/api/ratelimit_test.go
+++ b/internal/api/ratelimit_test.go
@@ -65,12 +65,12 @@ func TestRateLimiter_MiddlewareReturns429(t *testing.T) {
 }
 
 func TestClientIP_XForwardedFor(t *testing.T) {
-	// Test that X-Forwarded-For is used when present
 	req := httptest.NewRequest("GET", "/", nil)
 	req.Header.Set("X-Forwarded-For", "1.2.3.4, 5.6.7.8")
 	req.RemoteAddr = "127.0.0.1:9999"
 
-	got := clientIP(req)
+	srv := &Server{} // no trusted proxies — backwards compat
+	got := srv.clientIP(req)
 	if got != "1.2.3.4" {
 		t.Errorf("X-Forwarded-For: want 1.2.3.4, got %q", got)
 	}
@@ -80,7 +80,8 @@ func TestClientIP_RemoteAddr_Fallback(t *testing.T) {
 	req := httptest.NewRequest("GET", "/", nil)
 	req.RemoteAddr = "10.0.0.1:8080"
 
-	got := clientIP(req)
+	srv := &Server{}
+	got := srv.clientIP(req)
 	if got != "10.0.0.1" {
 		t.Errorf("RemoteAddr fallback: want 10.0.0.1, got %q", got)
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -21,6 +21,42 @@ type Pinger interface {
 	Ping(ctx context.Context) error
 }
 
+// ServerConfig holds all configuration for the API server.
+type ServerConfig struct {
+	Ingest         *ingest.Handler
+	Projects       service.Projects
+	Funnels        service.Funnels
+	ABTests        service.ABTests
+	Flags          service.Flags
+	Events         service.Events
+	Sessions       service.Sessions
+	APIKeys        service.APIKeys
+	Widgets        service.Widgets
+	UserAuth       *auth.UserAuthenticator
+	SessionManager *auth.SessionManager
+	AllowedOrigins []string
+	SessionSecret  string
+	PublicURL      string
+	DB             Pinger
+	Version        string
+	TrustedProxies []string
+
+	LoginRatePerMinute  float64
+	LoginRateBurst      float64
+	APIRatePerMinute    float64
+	APIRateBurst        float64
+	IngestRatePerMinute float64
+	IngestRateBurst     float64
+	SetupRatePerMinute  float64
+	SetupRateBurst      float64
+
+	MetricsToken     string
+	BugbarnEndpoint  string
+	BugbarnIngestKey string
+	DogfoodAPIKey    string
+	DogfoodProject   string
+}
+
 // Server is the main HTTP API server.
 type Server struct {
 	mux              *http.ServeMux
@@ -45,66 +81,52 @@ type Server struct {
 	bugbarnIngestKey string
 	dogfoodAPIKey    string
 	dogfoodProject   string
+	trustedProxies   []string
 
 	loginLimiter  *rateLimiter
 	eventsLimiter *rateLimiter
-	apiLimiter    *rateLimiter // configurable — for all session-authenticated endpoints
+	apiLimiter    *rateLimiter
+	setupLimiter  *rateLimiter
 }
 
 // NewServer creates the API server and registers all routes.
-func NewServer(
-	ingestHandler *ingest.Handler,
-	projects service.Projects,
-	funnels service.Funnels,
-	abtests service.ABTests,
-	flags service.Flags,
-	events service.Events,
-	sessions service.Sessions,
-	apikeys service.APIKeys,
-	widgets service.Widgets,
-	userAuth *auth.UserAuthenticator,
-	sessionManager *auth.SessionManager,
-	allowedOrigins []string,
-	sessionSecret string,
-	publicURL string,
-	loginRatePerMinute float64,
-	loginRateBurst float64,
-	apiRatePerMinute float64,
-	apiRateBurst float64,
-	ingestRatePerMinute float64,
-	ingestRateBurst float64,
-	db Pinger,
-	version string,
-	bugbarnEndpoint string,
-	bugbarnIngestKey string,
-	dogfoodAPIKey string,
-	dogfoodProject string,
-) *Server {
+func NewServer(cfg ServerConfig) *Server {
+	setupRate := cfg.SetupRatePerMinute
+	if setupRate == 0 {
+		setupRate = 10
+	}
+	setupBurst := cfg.SetupRateBurst
+	if setupBurst == 0 {
+		setupBurst = 5
+	}
+
 	s := &Server{
 		mux:              http.NewServeMux(),
-		db:               db,
-		version:          version,
-		projects:         projects,
-		funnels:          funnels,
-		abtests:          abtests,
-		flags:            flags,
-		events:           events,
-		sessions:         sessions,
-		apikeys:          apikeys,
-		widgets:          widgets,
-		ingest:           ingestHandler,
-		userAuth:         userAuth,
-		sessionManager:   sessionManager,
-		allowedOrigins:   allowedOrigins,
-		sessionSecret:    sessionSecret,
-		publicURL:        publicURL,
-		bugbarnEndpoint:  bugbarnEndpoint,
-		bugbarnIngestKey: bugbarnIngestKey,
-		dogfoodAPIKey:    dogfoodAPIKey,
-		dogfoodProject:   dogfoodProject,
-		loginLimiter:     newRateLimiter(loginRatePerMinute, loginRateBurst),
-		eventsLimiter:    newRateLimiter(ingestRatePerMinute, ingestRateBurst),
-		apiLimiter:       newRateLimiter(apiRatePerMinute, apiRateBurst),
+		db:               cfg.DB,
+		version:          cfg.Version,
+		projects:         cfg.Projects,
+		funnels:          cfg.Funnels,
+		abtests:          cfg.ABTests,
+		flags:            cfg.Flags,
+		events:           cfg.Events,
+		sessions:         cfg.Sessions,
+		apikeys:          cfg.APIKeys,
+		widgets:          cfg.Widgets,
+		ingest:           cfg.Ingest,
+		userAuth:         cfg.UserAuth,
+		sessionManager:   cfg.SessionManager,
+		allowedOrigins:   cfg.AllowedOrigins,
+		sessionSecret:    cfg.SessionSecret,
+		publicURL:        cfg.PublicURL,
+		bugbarnEndpoint:  cfg.BugbarnEndpoint,
+		bugbarnIngestKey: cfg.BugbarnIngestKey,
+		dogfoodAPIKey:    cfg.DogfoodAPIKey,
+		dogfoodProject:   cfg.DogfoodProject,
+		trustedProxies:   cfg.TrustedProxies,
+		loginLimiter:     newRateLimiter(cfg.LoginRatePerMinute, cfg.LoginRateBurst),
+		eventsLimiter:    newRateLimiter(cfg.IngestRatePerMinute, cfg.IngestRateBurst),
+		apiLimiter:       newRateLimiter(cfg.APIRatePerMinute, cfg.APIRateBurst),
+		setupLimiter:     newRateLimiter(setupRate, setupBurst),
 	}
 	s.registerRoutes()
 	return s
@@ -116,7 +138,7 @@ func (s *Server) registerRoutes() {
 
 	// Public
 	s.mux.HandleFunc("GET /api/v1/health", s.handleHealth)
-	s.mux.HandleFunc("GET /api/v1/setup/{slug}", s.handleSetup)
+	s.mux.Handle("GET /api/v1/setup/{slug}", s.setupLimiter.middleware(http.HandlerFunc(s.handleSetup)))
 	s.mux.HandleFunc("GET /api/v1/client-config", s.handleClientConfig)
 
 	// Ingest (API key required)
@@ -252,12 +274,11 @@ func (s *Server) setCORSHeaders(w http.ResponseWriter, r *http.Request) {
 }
 
 // requireSession wraps a handler to enforce session cookie authentication.
-// It also applies the apiLimiter rate limit for authenticated endpoints.
+// It also applies the apiLimiter rate limit and CSRF validation on mutating methods.
 func (s *Server) requireSession(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if s.sessionManager == nil || !s.userAuth.Enabled() {
-			// No auth configured — apply rate limit and allow through.
-			if !s.apiLimiter.allow(clientIP(r)) {
+			if !s.apiLimiter.allow(s.clientIP(r)) {
 				jsonError(w, "too many requests", http.StatusTooManyRequests)
 				return
 			}
@@ -277,7 +298,16 @@ func (s *Server) requireSession(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 
-		if !s.apiLimiter.allow(clientIP(r)) {
+		if isMutating(r.Method) {
+			expected := auth.CSRFToken(cookie.Value)
+			got := r.Header.Get("X-FunnelBarn-CSRF")
+			if got == "" || got != expected {
+				jsonError(w, "csrf token invalid", http.StatusForbidden)
+				return
+			}
+		}
+
+		if !s.apiLimiter.allow(s.clientIP(r)) {
 			jsonError(w, "too many requests", http.StatusTooManyRequests)
 			return
 		}
@@ -285,6 +315,10 @@ func (s *Server) requireSession(next http.HandlerFunc) http.HandlerFunc {
 		slog.Debug("session valid", "username", username)
 		next(w, r)
 	}
+}
+
+func isMutating(method string) bool {
+	return method == http.MethodPost || method == http.MethodPut || method == http.MethodDelete || method == http.MethodPatch
 }
 
 // mapServiceError maps domain/service errors to appropriate HTTP status codes.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -132,6 +132,15 @@ func NewServer(cfg ServerConfig) *Server {
 	return s
 }
 
+// StartCleanup begins periodic rate limiter cleanup goroutines.
+// Call this once with a context that is cancelled on shutdown.
+func (s *Server) StartCleanup(ctx context.Context) {
+	s.loginLimiter.startCleanup(ctx)
+	s.eventsLimiter.startCleanup(ctx)
+	s.apiLimiter.startCleanup(ctx)
+	s.setupLimiter.startCleanup(ctx)
+}
+
 func (s *Server) registerRoutes() {
 	// Metrics — open when no token configured, bearer-protected otherwise.
 	s.mux.Handle("GET /metrics", s.metricsHandler())

--- a/internal/api/trusted_proxy_test.go
+++ b/internal/api/trusted_proxy_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClientIP_TrustedProxy_UsesXFF(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	req.Header.Set("X-Forwarded-For", "203.0.113.50")
+
+	srv := &Server{trustedProxies: []string{"10.0.0.1"}}
+	got := srv.clientIP(req)
+	if got != "203.0.113.50" {
+		t.Errorf("trusted proxy: want 203.0.113.50, got %q", got)
+	}
+}
+
+func TestClientIP_UntrustedProxy_IgnoresXFF(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "192.168.1.100:1234"
+	req.Header.Set("X-Forwarded-For", "spoofed-ip")
+
+	srv := &Server{trustedProxies: []string{"10.0.0.1"}}
+	got := srv.clientIP(req)
+	if got != "192.168.1.100" {
+		t.Errorf("untrusted proxy: want 192.168.1.100, got %q", got)
+	}
+}
+
+func TestClientIP_NoTrustedProxiesConfigured_UsesXFF(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	req.Header.Set("X-Forwarded-For", "203.0.113.50")
+
+	srv := &Server{}
+	got := srv.clientIP(req)
+	if got != "203.0.113.50" {
+		t.Errorf("no proxies configured (backwards compat): want 203.0.113.50, got %q", got)
+	}
+}
+
+func TestClientIP_NoXFF_UsesRemoteAddr(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "192.168.1.100:1234"
+
+	srv := &Server{}
+	got := srv.clientIP(req)
+	if got != "192.168.1.100" {
+		t.Errorf("no XFF: want 192.168.1.100, got %q", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,9 @@ type Config struct {
 	IngestRateBurst     float64
 	SpanBarnEndpoint    string
 	SpanBarnAPIKey      string
+	TrustedProxies      []string
+	SetupRatePerMinute  float64
+	SetupRateBurst      float64
 }
 
 // Load reads config from config files and environment variables.
@@ -145,6 +148,27 @@ func Load() Config {
 
 	cfg.SpanBarnEndpoint = os.Getenv("FUNNELBARN_SPANBARN_ENDPOINT")
 	cfg.SpanBarnAPIKey = os.Getenv("FUNNELBARN_SPANBARN_API_KEY")
+
+	if raw := os.Getenv("FUNNELBARN_TRUSTED_PROXIES"); raw != "" {
+		for _, p := range strings.Split(raw, ",") {
+			if trimmed := strings.TrimSpace(p); trimmed != "" {
+				cfg.TrustedProxies = append(cfg.TrustedProxies, trimmed)
+			}
+		}
+	}
+
+	cfg.SetupRatePerMinute = 10
+	cfg.SetupRateBurst = 5
+	if raw := os.Getenv("FUNNELBARN_SETUP_RATE_PER_MINUTE"); raw != "" {
+		if parsed, err := strconv.ParseFloat(raw, 64); err == nil && parsed > 0 {
+			cfg.SetupRatePerMinute = parsed
+		}
+	}
+	if raw := os.Getenv("FUNNELBARN_SETUP_RATE_BURST"); raw != "" {
+		if parsed, err := strconv.ParseFloat(raw, 64); err == nil && parsed > 0 {
+			cfg.SetupRateBurst = parsed
+		}
+	}
 
 	cfg.LogLevel = slog.LevelInfo
 	if raw := os.Getenv("FUNNELBARN_LOG_LEVEL"); raw != "" {

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -18,7 +18,7 @@ type ProjectRepo interface {
 	ProjectByID(ctx context.Context, id string) (repository.Project, error)
 	ProjectBySlug(ctx context.Context, slug string) (repository.Project, error)
 	ListProjects(ctx context.Context) ([]repository.Project, error)
-	UpdateProject(ctx context.Context, id, name string) (repository.Project, error)
+	UpdateProject(ctx context.Context, id, name, domain string) (repository.Project, error)
 	DeleteProject(ctx context.Context, id string) error
 	ApproveProject(ctx context.Context, id string) (repository.Project, error)
 	EnsureProject(ctx context.Context, slug string) (repository.Project, error)
@@ -47,6 +47,19 @@ type ABTestRepo interface {
 	AnalyzeABTest(ctx context.Context, t repository.ABTest, from, to time.Time) ([]repository.ABTestResult, error)
 }
 
+// FlagRepo is the persistence port for feature flags.
+type FlagRepo interface {
+	CreateFlag(ctx context.Context, f repository.FeatureFlag) (repository.FeatureFlag, error)
+	FlagByID(ctx context.Context, id string) (repository.FeatureFlag, error)
+	FlagByKey(ctx context.Context, projectID, flagKey string) (repository.FeatureFlag, error)
+	ListFlags(ctx context.Context, projectID string) ([]repository.FeatureFlag, error)
+	UpdateFlag(ctx context.Context, f repository.FeatureFlag) (repository.FeatureFlag, error)
+	DeleteFlag(ctx context.Context, id string) error
+	RecordEvaluation(ctx context.Context, eval repository.FlagEvaluation) error
+	CountEvaluationsByVariant(ctx context.Context, flagID string, from, to time.Time) (map[string]int64, error)
+	CountConversionsByVariant(ctx context.Context, flagID, conversionEvent, projectID string, from, to time.Time) (map[string]int64, error)
+}
+
 // EventRepo is the persistence port for events and analytics queries.
 type EventRepo interface {
 	InsertEvent(ctx context.Context, e repository.Event) error
@@ -56,6 +69,7 @@ type EventRepo interface {
 	TopPages(ctx context.Context, projectID string, from, to time.Time, limit int) ([]repository.PageStat, error)
 	TopReferrers(ctx context.Context, projectID string, from, to time.Time, limit int) ([]repository.ReferrerStat, error)
 	DailyEventCounts(ctx context.Context, projectID string, from, to time.Time) ([]repository.TimeSeriesPoint, error)
+	HourlyEventCounts(ctx context.Context, projectID string, from, to time.Time) ([]repository.TimeSeriesPoint, error)
 	DailyUniqueSessions(ctx context.Context, projectID string, from, to time.Time) ([]repository.TimeSeriesPoint, error)
 	TopBrowsers(ctx context.Context, projectID string, from, to time.Time, limit int) ([]repository.BrowserStat, error)
 	TopDeviceTypes(ctx context.Context, projectID string, from, to time.Time) ([]repository.DeviceStat, error)
@@ -64,6 +78,9 @@ type EventRepo interface {
 	BounceRate(ctx context.Context, projectID string, from, to time.Time) (float64, error)
 	AvgEventsPerSession(ctx context.Context, projectID string, from, to time.Time) (float64, error)
 	UniqueSessionCount(ctx context.Context, projectID string, from, to time.Time) (int64, error)
+	DistinctEventNames(ctx context.Context, projectID string) ([]string, error)
+	DistinctEventProperties(ctx context.Context, projectID, eventName string) ([]string, error)
+	DistinctPropertyValues(ctx context.Context, projectID, eventName, property string, limit int) ([]string, error)
 }
 
 // SessionRepo is the persistence port for sessions.
@@ -82,6 +99,16 @@ type APIKeyRepo interface {
 	DeleteAPIKey(ctx context.Context, id string) error
 	ValidAPIKeySHA256(ctx context.Context, keySHA256 string) (projectID string, scope string, found bool, err error)
 	TouchAPIKey(ctx context.Context, keySHA256 string) error
+}
+
+// WidgetRepo is the persistence port for dashboard widgets.
+type WidgetRepo interface {
+	CreateWidget(ctx context.Context, w repository.DashboardWidget) (repository.DashboardWidget, error)
+	WidgetByID(ctx context.Context, id string) (repository.DashboardWidget, error)
+	ListWidgets(ctx context.Context, projectID string) ([]repository.DashboardWidget, error)
+	UpdateWidget(ctx context.Context, w repository.DashboardWidget) (repository.DashboardWidget, error)
+	DeleteWidget(ctx context.Context, id string) error
+	WidgetBreakdown(ctx context.Context, projectID, eventName, property string, window, limit int) ([]repository.PropertyBreakdown, error)
 }
 
 // EventPersister is the narrow interface worker.PersistEvent requires.

--- a/internal/ports/ports_test.go
+++ b/internal/ports/ports_test.go
@@ -1,0 +1,29 @@
+package ports_test
+
+import (
+	"github.com/wiebe-xyz/funnelbarn/internal/ports"
+	"github.com/wiebe-xyz/funnelbarn/internal/repository"
+	"github.com/wiebe-xyz/funnelbarn/internal/repository/mock"
+)
+
+// Compile-time checks: *repository.Store satisfies every port interface.
+var _ ports.ProjectRepo = (*repository.Store)(nil)
+var _ ports.FunnelRepo = (*repository.Store)(nil)
+var _ ports.ABTestRepo = (*repository.Store)(nil)
+var _ ports.FlagRepo = (*repository.Store)(nil)
+var _ ports.EventRepo = (*repository.Store)(nil)
+var _ ports.SessionRepo = (*repository.Store)(nil)
+var _ ports.APIKeyRepo = (*repository.Store)(nil)
+var _ ports.WidgetRepo = (*repository.Store)(nil)
+var _ ports.EventPersister = (*repository.Store)(nil)
+
+// Compile-time checks: *mock.Store satisfies every port interface.
+var _ ports.ProjectRepo = (*mock.Store)(nil)
+var _ ports.FunnelRepo = (*mock.Store)(nil)
+var _ ports.ABTestRepo = (*mock.Store)(nil)
+var _ ports.FlagRepo = (*mock.Store)(nil)
+var _ ports.EventRepo = (*mock.Store)(nil)
+var _ ports.SessionRepo = (*mock.Store)(nil)
+var _ ports.APIKeyRepo = (*mock.Store)(nil)
+var _ ports.WidgetRepo = (*mock.Store)(nil)
+var _ ports.EventPersister = (*mock.Store)(nil)

--- a/internal/repository/flags.go
+++ b/internal/repository/flags.go
@@ -152,6 +152,14 @@ func (s *Store) CountEvaluationsByVariant(ctx context.Context, flagID string, fr
 	return result, rows.Err()
 }
 
+func (s *Store) PurgeOldEvaluations(ctx context.Context, cutoff time.Time) (int64, error) {
+	result, err := s.db.ExecContext(ctx, `DELETE FROM flag_evaluations WHERE created_at < ?`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 func (s *Store) CountConversionsByVariant(ctx context.Context, flagID, conversionEvent, projectID string, from, to time.Time) (map[string]int64, error) {
 	const q = `
 		SELECT fe.variant, COUNT(DISTINCT fe.context_hash)

--- a/internal/repository/interface.go
+++ b/internal/repository/interface.go
@@ -89,6 +89,7 @@ type Querier interface {
 	RecordEvaluation(ctx context.Context, eval FlagEvaluation) error
 	CountEvaluationsByVariant(ctx context.Context, flagID string, from, to time.Time) (map[string]int64, error)
 	CountConversionsByVariant(ctx context.Context, flagID, conversionEvent, projectID string, from, to time.Time) (map[string]int64, error)
+	PurgeOldEvaluations(ctx context.Context, cutoff time.Time) (int64, error)
 
 	// Widgets
 	CreateWidget(ctx context.Context, w DashboardWidget) (DashboardWidget, error)

--- a/internal/repository/migrations/00005_add_ingest_id_index.sql
+++ b/internal/repository/migrations/00005_add_ingest_id_index.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+CREATE INDEX IF NOT EXISTS idx_events_ingest_id ON events (ingest_id);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_events_ingest_id;

--- a/internal/repository/mock/mock.go
+++ b/internal/repository/mock/mock.go
@@ -668,6 +668,10 @@ func (s *Store) CountConversionsByVariant(_ context.Context, _, _, _ string, _, 
 	return map[string]int64{}, nil
 }
 
+func (s *Store) PurgeOldEvaluations(_ context.Context, cutoff time.Time) (int64, error) {
+	return 0, nil
+}
+
 // ── Widgets ──────────────────────────────────────────────────────────────────
 
 func (s *Store) CreateWidget(_ context.Context, w repository.DashboardWidget) (repository.DashboardWidget, error) {

--- a/internal/repository/purge_evaluations_test.go
+++ b/internal/repository/purge_evaluations_test.go
@@ -1,0 +1,51 @@
+package repository_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wiebe-xyz/funnelbarn/internal/repository"
+)
+
+func TestStore_PurgeOldEvaluations(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	p, err := s.CreateProject(ctx, "PurgeEval", "purge-eval")
+	require.NoError(t, err)
+
+	f, err := s.CreateFlag(ctx, repository.FeatureFlag{
+		ProjectID:      p.ID,
+		FlagKey:        "test-flag",
+		Name:           "Test Flag",
+		FlagType:       "boolean",
+		Variants:       `{"on":true,"off":false}`,
+		DefaultVariant: "off",
+		Split:          `{"on":50,"off":50}`,
+		Status:         "active",
+	})
+	require.NoError(t, err)
+
+	for i := 0; i < 5; i++ {
+		err = s.RecordEvaluation(ctx, repository.FlagEvaluation{
+			FlagID:      f.ID,
+			ProjectID:   p.ID,
+			Variant:     "on",
+			ContextHash: "hash",
+		})
+		require.NoError(t, err)
+	}
+
+	// Purge with future cutoff — should remove all.
+	n, err := s.PurgeOldEvaluations(ctx, time.Now().Add(time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), n)
+
+	// Purge again — should remove 0.
+	n2, err := s.PurgeOldEvaluations(ctx, time.Now().Add(time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n2)
+}

--- a/internal/service/abtests.go
+++ b/internal/service/abtests.go
@@ -8,16 +8,17 @@ import (
 	"time"
 
 	"github.com/wiebe-xyz/funnelbarn/internal/domain"
+	"github.com/wiebe-xyz/funnelbarn/internal/ports"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 )
 
 // ABTestService handles A/B test business logic.
 type ABTestService struct {
-	store repository.Querier
+	store ports.ABTestRepo
 }
 
 // NewABTestService creates a new ABTestService.
-func NewABTestService(store repository.Querier) *ABTestService {
+func NewABTestService(store ports.ABTestRepo) *ABTestService {
 	return &ABTestService{store: store}
 }
 

--- a/internal/service/apikeys.go
+++ b/internal/service/apikeys.go
@@ -5,16 +5,17 @@ import (
 	"strings"
 
 	"github.com/wiebe-xyz/funnelbarn/internal/domain"
+	"github.com/wiebe-xyz/funnelbarn/internal/ports"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 )
 
 // APIKeyService handles API key business logic.
 type APIKeyService struct {
-	store repository.Querier
+	store ports.APIKeyRepo
 }
 
 // NewAPIKeyService creates a new APIKeyService.
-func NewAPIKeyService(store repository.Querier) *APIKeyService {
+func NewAPIKeyService(store ports.APIKeyRepo) *APIKeyService {
 	return &APIKeyService{store: store}
 }
 

--- a/internal/service/events.go
+++ b/internal/service/events.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"time"
 
+	"github.com/wiebe-xyz/funnelbarn/internal/ports"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 )
 
 // EventService handles event business logic.
 type EventService struct {
-	store repository.Querier
+	store ports.EventRepo
 }
 
 // NewEventService creates a new EventService.
-func NewEventService(store repository.Querier) *EventService {
+func NewEventService(store ports.EventRepo) *EventService {
 	return &EventService{store: store}
 }
 

--- a/internal/service/flags.go
+++ b/internal/service/flags.go
@@ -11,6 +11,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
+	"github.com/wiebe-xyz/funnelbarn/internal/ports"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 	"github.com/wiebe-xyz/funnelbarn/internal/tracing"
 )
@@ -24,10 +25,10 @@ type FlagEvalResult struct {
 }
 
 type FlagService struct {
-	store repository.Querier
+	store ports.FlagRepo
 }
 
-func NewFlagService(store repository.Querier) *FlagService {
+func NewFlagService(store ports.FlagRepo) *FlagService {
 	return &FlagService{store: store}
 }
 

--- a/internal/service/funnels.go
+++ b/internal/service/funnels.go
@@ -9,16 +9,17 @@ import (
 	"time"
 
 	"github.com/wiebe-xyz/funnelbarn/internal/domain"
+	"github.com/wiebe-xyz/funnelbarn/internal/ports"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 )
 
 // FunnelService handles funnel business logic.
 type FunnelService struct {
-	store repository.Querier
+	store ports.FunnelRepo
 }
 
 // NewFunnelService creates a new FunnelService.
-func NewFunnelService(store repository.Querier) *FunnelService {
+func NewFunnelService(store ports.FunnelRepo) *FunnelService {
 	return &FunnelService{store: store}
 }
 

--- a/internal/service/projects.go
+++ b/internal/service/projects.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/wiebe-xyz/funnelbarn/internal/domain"
+	"github.com/wiebe-xyz/funnelbarn/internal/ports"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 )
 
@@ -30,11 +31,11 @@ func normalizeSlug(s string) string {
 
 // ProjectService handles project business logic.
 type ProjectService struct {
-	store repository.Querier
+	store ports.ProjectRepo
 }
 
 // NewProjectService creates a new ProjectService.
-func NewProjectService(store repository.Querier) *ProjectService {
+func NewProjectService(store ports.ProjectRepo) *ProjectService {
 	return &ProjectService{store: store}
 }
 

--- a/internal/service/sessions.go
+++ b/internal/service/sessions.go
@@ -3,16 +3,17 @@ package service
 import (
 	"context"
 
+	"github.com/wiebe-xyz/funnelbarn/internal/ports"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 )
 
 // SessionService handles session business logic.
 type SessionService struct {
-	store repository.Querier
+	store ports.SessionRepo
 }
 
 // NewSessionService creates a new SessionService.
-func NewSessionService(store repository.Querier) *SessionService {
+func NewSessionService(store ports.SessionRepo) *SessionService {
 	return &SessionService{store: store}
 }
 

--- a/internal/service/widgets.go
+++ b/internal/service/widgets.go
@@ -3,14 +3,15 @@ package service
 import (
 	"context"
 
+	"github.com/wiebe-xyz/funnelbarn/internal/ports"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 )
 
 type WidgetService struct {
-	store repository.Querier
+	store ports.WidgetRepo
 }
 
-func NewWidgetService(store repository.Querier) *WidgetService {
+func NewWidgetService(store ports.WidgetRepo) *WidgetService {
 	return &WidgetService{store: store}
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -8,11 +8,26 @@ export class ApiError extends Error {
   }
 }
 
+function getCookie(name: string): string | undefined {
+  const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'))
+  return match ? decodeURIComponent(match[1]) : undefined
+}
+
 async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json', ...options.headers as Record<string, string> }
+
+  const method = (options.method || 'GET').toUpperCase()
+  if (method === 'POST' || method === 'PUT' || method === 'DELETE' || method === 'PATCH') {
+    const csrfToken = getCookie('funnelbarn_csrf')
+    if (csrfToken) {
+      headers['X-FunnelBarn-CSRF'] = csrfToken
+    }
+  }
+
   const res = await fetch(path, {
-    headers: { 'Content-Type': 'application/json', ...options.headers },
-    credentials: 'include',
     ...options,
+    headers,
+    credentials: 'include',
   })
 
   if (res.status === 401) {


### PR DESCRIPTION
## Summary

- **CSRF validation**: double-submit cookie pattern — `requireSession` now validates `X-FunnelBarn-CSRF` header on mutating requests; frontend `api.ts` reads `funnelbarn_csrf` cookie and sends the header automatically
- **Security hardening**: trusted proxy config for X-Forwarded-For, setup endpoint rate limiting, periodic rate limiter cleanup (was O(n) per-request), spool rotation race fix, `ingest_id` index, flag evaluations purge job
- **Architecture**: `NewServer` refactored from 24 positional params to `ServerConfig` struct; all 8 services now accept narrow ports interfaces instead of the `repository.Querier` god interface (adds `FlagRepo`, `WidgetRepo`, fixes `UpdateProject` signature)

## Test plan

- [x] All Go tests pass (`go test ./...`)
- [x] All frontend tests pass (vitest)
- [x] gofmt clean
- [x] New test files: `csrf_test.go`, `trusted_proxy_test.go`, `ratelimit_cleanup_test.go`, `purge_evaluations_test.go`, `ports_test.go`
- [x] Compile-time interface satisfaction checks for `*repository.Store` and `*mock.Store` against all port interfaces
- [ ] CI quality gates (go vet, staticcheck, eslint, tsc)
- [ ] Testing/staging auto-deploy on merge