### PR TITLE
feat: widget metadata breakdowns and count-only mode

### DIFF
--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+
+	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 )
 
 // addPaginationHeaders sets a Link header for the next page when more results
@@ -60,7 +62,8 @@ func (s *Server) handleEventProperties(w http.ResponseWriter, r *http.Request) {
 	if props == nil {
 		props = []string{}
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"properties": props})
+	all := append(repository.MetadataColumns(), props...)
+	writeJSON(w, http.StatusOK, map[string]any{"properties": all})
 }
 
 // handleEventPropertyValues returns distinct values for a property key on a given event name.

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -386,8 +386,9 @@ func TestHandleEventProperties_Success(t *testing.T) {
 		Properties []string `json:"properties"`
 	}
 	_ = json.Unmarshal(w.Body.Bytes(), &resp)
-	if len(resp.Properties) != 2 {
-		t.Fatalf("want 2 properties, got %d: %v", len(resp.Properties), resp.Properties)
+	expectedCount := len(repository.MetadataColumns()) + 2
+	if len(resp.Properties) != expectedCount {
+		t.Fatalf("want %d properties (12 metadata + 2 custom), got %d: %v", expectedCount, len(resp.Properties), resp.Properties)
 	}
 }
 

--- a/internal/api/widgets.go
+++ b/internal/api/widgets.go
@@ -45,8 +45,8 @@ func (s *Server) handleCreateWidget(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "invalid json", http.StatusBadRequest)
 		return
 	}
-	if body.EventName == "" || body.Property == "" {
-		jsonError(w, "event_name and property are required", http.StatusUnprocessableEntity)
+	if body.EventName == "" {
+		jsonError(w, "event_name is required", http.StatusUnprocessableEntity)
 		return
 	}
 

--- a/internal/repository/widgets.go
+++ b/internal/repository/widgets.go
@@ -3,8 +3,23 @@ package repository
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 )
+
+var metadataColumns = []string{
+	"url", "referrer", "referrer_domain",
+	"utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content",
+	"browser", "os", "device_type", "country_code",
+}
+
+func IsMetadataColumn(name string) bool {
+	return slices.Contains(metadataColumns, name)
+}
+
+func MetadataColumns() []string {
+	return metadataColumns
+}
 
 // DashboardWidget is a user-configured breakdown card on the Insights page.
 type DashboardWidget struct {
@@ -80,27 +95,51 @@ func (s *Store) DeleteWidget(ctx context.Context, id string) error {
 }
 
 // WidgetBreakdown returns the top-N property value counts from the last `window` events
-// of the given event type. This is the rolling window query.
+// of the given event type. When property is empty, returns only the total count.
+// When property is a metadata column (url, browser, etc.), queries the column directly.
+// Otherwise, extracts from the JSON properties field.
 func (s *Store) WidgetBreakdown(ctx context.Context, projectID, eventName, property string, window, limit int) ([]PropertyBreakdown, error) {
-	if !validPropertyName.MatchString(property) {
-		return nil, fmt.Errorf("invalid property name: %s", property)
+	if property == "" {
+		return s.widgetCount(ctx, projectID, eventName, window)
 	}
 
-	q := fmt.Sprintf(`
-		SELECT val, COUNT(*) AS cnt
-		FROM (
-			SELECT json_extract(properties, '$.%s') AS val
+	var q string
+	if IsMetadataColumn(property) {
+		q = fmt.Sprintf(`
+			SELECT val, COUNT(*) AS cnt
 			FROM (
-				SELECT properties FROM events
-				WHERE project_id = ? AND name = ?
-				ORDER BY occurred_at DESC
-				LIMIT ?
+				SELECT %s AS val
+				FROM (
+					SELECT %s FROM events
+					WHERE project_id = ? AND name = ?
+					ORDER BY occurred_at DESC
+					LIMIT ?
+				)
 			)
-		)
-		WHERE val IS NOT NULL AND val != ''
-		GROUP BY val
-		ORDER BY cnt DESC
-		LIMIT ?`, property)
+			WHERE val IS NOT NULL AND val != ''
+			GROUP BY val
+			ORDER BY cnt DESC
+			LIMIT ?`, property, property)
+	} else {
+		if !validPropertyName.MatchString(property) {
+			return nil, fmt.Errorf("invalid property name: %s", property)
+		}
+		q = fmt.Sprintf(`
+			SELECT val, COUNT(*) AS cnt
+			FROM (
+				SELECT json_extract(properties, '$.%s') AS val
+				FROM (
+					SELECT properties FROM events
+					WHERE project_id = ? AND name = ?
+					ORDER BY occurred_at DESC
+					LIMIT ?
+				)
+			)
+			WHERE val IS NOT NULL AND val != ''
+			GROUP BY val
+			ORDER BY cnt DESC
+			LIMIT ?`, property)
+	}
 
 	rows, err := s.db.QueryContext(ctx, q, projectID, eventName, window, limit)
 	if err != nil {
@@ -117,4 +156,13 @@ func (s *Store) WidgetBreakdown(ctx context.Context, projectID, eventName, prope
 		results = append(results, r)
 	}
 	return results, rows.Err()
+}
+
+func (s *Store) widgetCount(ctx context.Context, projectID, eventName string, window int) ([]PropertyBreakdown, error) {
+	const q = `SELECT COUNT(*) FROM (SELECT 1 FROM events WHERE project_id = ? AND name = ? ORDER BY occurred_at DESC LIMIT ?)`
+	var count int64
+	if err := s.db.QueryRowContext(ctx, q, projectID, eventName, window).Scan(&count); err != nil {
+		return nil, fmt.Errorf("widget count: %w", err)
+	}
+	return []PropertyBreakdown{{Value: "_total", Count: count}}, nil
 }

--- a/web/src/pages/Insights.tsx
+++ b/web/src/pages/Insights.tsx
@@ -180,8 +180,13 @@ function WidgetCard({ widget, breakdown, onDelete }: {
   breakdown: PropertyBreakdown[]
   onDelete: () => void
 }) {
+  const isCountOnly = !widget.property
   const maxCount = breakdown.length > 0 ? breakdown[0].count : 1
   const total = breakdown.reduce((sum, r) => sum + r.count, 0)
+
+  const subtitle = widget.property
+    ? `${widget.event_name} → ${widget.property}`
+    : widget.event_name
 
   return (
     <div style={{
@@ -199,11 +204,11 @@ function WidgetCard({ widget, breakdown, onDelete }: {
       }}>
         <div>
           <div style={{ fontSize: 14, fontWeight: 700, color: C.text }}>
-            {widget.title || `${widget.event_name} → ${widget.property}`}
+            {widget.title || subtitle}
           </div>
           {widget.title && (
             <div style={{ fontSize: 12, color: C.muted, marginTop: 2 }}>
-              {widget.event_name} → {widget.property}
+              {subtitle}
             </div>
           )}
         </div>
@@ -228,6 +233,11 @@ function WidgetCard({ widget, breakdown, onDelete }: {
         {breakdown.length === 0 ? (
           <div style={{ color: C.muted, fontSize: 13, textAlign: 'center', padding: '1rem 0' }}>
             No data yet
+          </div>
+        ) : isCountOnly ? (
+          <div style={{ textAlign: 'center', padding: '1rem 0' }}>
+            <div style={{ fontSize: 36, fontWeight: 800, color: C.amber }}>{breakdown[0].count.toLocaleString()}</div>
+            <div style={{ fontSize: 13, color: C.muted, marginTop: 4 }}>events</div>
           </div>
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
@@ -314,13 +324,16 @@ function AddWidgetModal({ projectId, onClose, onAdded }: {
   }, [projectId, selectedEvent])
 
   const handleSave = async () => {
-    if (!selectedEvent || !selectedProperty) return
+    if (!selectedEvent) return
     setSaving(true)
     try {
+      const defaultTitle = selectedProperty
+        ? `${selectedEvent} → ${selectedProperty}`
+        : `${selectedEvent} (count)`
       await api.createWidget(projectId, {
         event_name: selectedEvent,
         property: selectedProperty,
-        title: title || `${selectedEvent} → ${selectedProperty}`,
+        title: title || defaultTitle,
       })
       onAdded()
     } catch {
@@ -399,7 +412,7 @@ function AddWidgetModal({ projectId, onClose, onAdded }: {
           )}
 
           <label style={{ display: 'block', fontSize: 13, fontWeight: 600, color: C.muted, marginBottom: 6, marginTop: 16 }}>
-            Property
+            Property (optional)
           </label>
           {loadingProps ? (
             <Skeleton height={40} />
@@ -419,7 +432,7 @@ function AddWidgetModal({ projectId, onClose, onAdded }: {
                 boxSizing: 'border-box',
               }}
             >
-              <option value="">{selectedEvent ? 'Select a property...' : 'Select an event first'}</option>
+              <option value="">{selectedEvent ? 'None (total count)' : 'Select an event first'}</option>
               {properties.map((p) => (
                 <option key={p} value={p}>{p}</option>
               ))}
@@ -433,7 +446,7 @@ function AddWidgetModal({ projectId, onClose, onAdded }: {
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            placeholder={selectedEvent && selectedProperty ? `${selectedEvent} → ${selectedProperty}` : 'Widget title'}
+            placeholder={selectedEvent ? (selectedProperty ? `${selectedEvent} → ${selectedProperty}` : `${selectedEvent} (count)`) : 'Widget title'}
             style={{
               width: '100%',
               padding: '0.6rem 0.75rem',
@@ -471,16 +484,16 @@ function AddWidgetModal({ projectId, onClose, onAdded }: {
           </button>
           <button
             onClick={handleSave}
-            disabled={!selectedEvent || !selectedProperty || saving}
+            disabled={!selectedEvent || saving}
             style={{
               padding: '0.5rem 1rem',
-              background: !selectedEvent || !selectedProperty || saving ? '#4a4d5a' : C.amber,
+              background: !selectedEvent || saving ? '#4a4d5a' : C.amber,
               border: 'none',
               borderRadius: 8,
-              color: !selectedEvent || !selectedProperty || saving ? C.muted : '#000',
+              color: !selectedEvent || saving ? C.muted : '#000',
               fontSize: 13,
               fontWeight: 700,
-              cursor: !selectedEvent || !selectedProperty || saving ? 'default' : 'pointer',
+              cursor: !selectedEvent || saving ? 'default' : 'pointer',
             }}
           >
             {saving ? 'Adding...' : 'Add Widget'}


### PR DESCRIPTION
## Summary
- Widgets can now break down events by built-in metadata columns (url, referrer, browser, os, device_type, country_code, UTM params) — not just custom JSON properties
- Property is now optional: selecting no property creates a count-only widget that displays the total event count as a large number
- The event-properties endpoint returns metadata columns alongside custom properties for easy discovery in the dropdown

## Test plan
- [ ] Create a page_view widget with no property → shows total count
- [ ] Create a page_view widget with `url` or `browser` → shows breakdown by that metadata field
- [ ] Create a widget with a custom JSON property → still works as before
- [ ] Verify the property dropdown shows metadata fields first, then custom properties