### PR TITLE
feat: resizable widgets and clickable URL values

### DIFF
--- a/internal/api/widgets.go
+++ b/internal/api/widgets.go
@@ -40,6 +40,7 @@ func (s *Server) handleCreateWidget(w http.ResponseWriter, r *http.Request) {
 		Property  string `json:"property"`
 		Title     string `json:"title"`
 		Position  int    `json:"position"`
+		Size      int    `json:"size"`
 	}
 	if err := readJSON(r, &body); err != nil {
 		jsonError(w, "invalid json", http.StatusBadRequest)
@@ -56,6 +57,7 @@ func (s *Server) handleCreateWidget(w http.ResponseWriter, r *http.Request) {
 		Property:  body.Property,
 		Title:     body.Title,
 		Position:  body.Position,
+		Size:      body.Size,
 	})
 	if err != nil {
 		mapServiceError(w, err, "handleCreateWidget")
@@ -76,6 +78,7 @@ func (s *Server) handleUpdateWidget(w http.ResponseWriter, r *http.Request) {
 		Property  string `json:"property"`
 		Title     string `json:"title"`
 		Position  int    `json:"position"`
+		Size      int    `json:"size"`
 	}
 	if err := readJSON(r, &body); err != nil {
 		jsonError(w, "invalid json", http.StatusBadRequest)
@@ -88,6 +91,7 @@ func (s *Server) handleUpdateWidget(w http.ResponseWriter, r *http.Request) {
 		Property:  body.Property,
 		Title:     body.Title,
 		Position:  body.Position,
+		Size:      body.Size,
 	})
 	if err != nil {
 		mapServiceError(w, err, "handleUpdateWidget")

--- a/internal/repository/migrations/00006_widget_size.sql
+++ b/internal/repository/migrations/00006_widget_size.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE dashboard_widgets ADD COLUMN size INTEGER NOT NULL DEFAULT 1;
+
+-- +goose Down
+ALTER TABLE dashboard_widgets DROP COLUMN size;

--- a/internal/repository/widgets.go
+++ b/internal/repository/widgets.go
@@ -29,6 +29,7 @@ type DashboardWidget struct {
 	Property  string    `json:"property"`
 	Title     string    `json:"title"`
 	Position  int       `json:"position"`
+	Size      int       `json:"size"`
 	CreatedAt time.Time `json:"created_at"`
 }
 
@@ -45,8 +46,11 @@ func (s *Store) CreateWidget(ctx context.Context, w DashboardWidget) (DashboardW
 		return DashboardWidget{}, fmt.Errorf("generate uuid: %w", err)
 	}
 
-	const q = `INSERT INTO dashboard_widgets (id, project_id, event_name, property, title, position) VALUES (?, ?, ?, ?, ?, ?)`
-	if _, err := s.db.ExecContext(ctx, q, w.ID, w.ProjectID, w.EventName, w.Property, w.Title, w.Position); err != nil {
+	if w.Size < 1 || w.Size > 3 {
+		w.Size = 1
+	}
+	const q = `INSERT INTO dashboard_widgets (id, project_id, event_name, property, title, position, size) VALUES (?, ?, ?, ?, ?, ?, ?)`
+	if _, err := s.db.ExecContext(ctx, q, w.ID, w.ProjectID, w.EventName, w.Property, w.Title, w.Position, w.Size); err != nil {
 		return DashboardWidget{}, fmt.Errorf("insert widget: %w", err)
 	}
 
@@ -54,16 +58,16 @@ func (s *Store) CreateWidget(ctx context.Context, w DashboardWidget) (DashboardW
 }
 
 func (s *Store) WidgetByID(ctx context.Context, id string) (DashboardWidget, error) {
-	const q = `SELECT id, project_id, event_name, property, COALESCE(title,''), position, created_at FROM dashboard_widgets WHERE id = ?`
+	const q = `SELECT id, project_id, event_name, property, COALESCE(title,''), position, size, created_at FROM dashboard_widgets WHERE id = ?`
 	var w DashboardWidget
-	if err := s.db.QueryRowContext(ctx, q, id).Scan(&w.ID, &w.ProjectID, &w.EventName, &w.Property, &w.Title, &w.Position, &w.CreatedAt); err != nil {
+	if err := s.db.QueryRowContext(ctx, q, id).Scan(&w.ID, &w.ProjectID, &w.EventName, &w.Property, &w.Title, &w.Position, &w.Size, &w.CreatedAt); err != nil {
 		return DashboardWidget{}, err
 	}
 	return w, nil
 }
 
 func (s *Store) ListWidgets(ctx context.Context, projectID string) ([]DashboardWidget, error) {
-	const q = `SELECT id, project_id, event_name, property, COALESCE(title,''), position, created_at FROM dashboard_widgets WHERE project_id = ? ORDER BY position, created_at`
+	const q = `SELECT id, project_id, event_name, property, COALESCE(title,''), position, size, created_at FROM dashboard_widgets WHERE project_id = ? ORDER BY position, created_at`
 	rows, err := s.db.QueryContext(ctx, q, projectID)
 	if err != nil {
 		return nil, err
@@ -73,7 +77,7 @@ func (s *Store) ListWidgets(ctx context.Context, projectID string) ([]DashboardW
 	var widgets []DashboardWidget
 	for rows.Next() {
 		var w DashboardWidget
-		if err := rows.Scan(&w.ID, &w.ProjectID, &w.EventName, &w.Property, &w.Title, &w.Position, &w.CreatedAt); err != nil {
+		if err := rows.Scan(&w.ID, &w.ProjectID, &w.EventName, &w.Property, &w.Title, &w.Position, &w.Size, &w.CreatedAt); err != nil {
 			return nil, err
 		}
 		widgets = append(widgets, w)
@@ -82,8 +86,11 @@ func (s *Store) ListWidgets(ctx context.Context, projectID string) ([]DashboardW
 }
 
 func (s *Store) UpdateWidget(ctx context.Context, w DashboardWidget) (DashboardWidget, error) {
-	const q = `UPDATE dashboard_widgets SET event_name=?, property=?, title=?, position=? WHERE id=?`
-	if _, err := s.db.ExecContext(ctx, q, w.EventName, w.Property, w.Title, w.Position, w.ID); err != nil {
+	if w.Size < 1 || w.Size > 3 {
+		w.Size = 1
+	}
+	const q = `UPDATE dashboard_widgets SET event_name=?, property=?, title=?, position=?, size=? WHERE id=?`
+	if _, err := s.db.ExecContext(ctx, q, w.EventName, w.Property, w.Title, w.Position, w.Size, w.ID); err != nil {
 		return DashboardWidget{}, fmt.Errorf("update widget: %w", err)
 	}
 	return s.WidgetByID(ctx, w.ID)

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -211,13 +211,13 @@ export const api = {
   listWidgets: (projectId: string) =>
     request<{ widgets: DashboardWidget[] }>(`/api/v1/projects/${projectId}/widgets`),
 
-  createWidget: (projectId: string, data: { event_name: string; property: string; title: string; position?: number }) =>
+  createWidget: (projectId: string, data: { event_name: string; property: string; title: string; position?: number; size?: number }) =>
     request<DashboardWidget>(`/api/v1/projects/${projectId}/widgets`, {
       method: 'POST',
       body: JSON.stringify(data),
     }),
 
-  updateWidget: (projectId: string, widgetId: string, data: { event_name: string; property: string; title: string; position?: number }) =>
+  updateWidget: (projectId: string, widgetId: string, data: { event_name: string; property: string; title: string; position?: number; size?: number }) =>
     request<DashboardWidget>(`/api/v1/projects/${projectId}/widgets/${widgetId}`, {
       method: 'PUT',
       body: JSON.stringify(data),
@@ -342,6 +342,7 @@ export interface DashboardWidget {
   property: string
   title: string
   position: number
+  size: number
   created_at: string
 }
 

--- a/web/src/pages/Insights.tsx
+++ b/web/src/pages/Insights.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback } from 'react'
 import { useParams } from 'react-router-dom'
-import { Plus, Trash2, Lightbulb, X } from 'lucide-react'
+import { Plus, Trash2, Lightbulb, X, Columns2, Columns3, Square } from 'lucide-react'
 import Shell from '../components/shell/Shell'
 import { api } from '../lib/api'
 import type { DashboardWidget, PropertyBreakdown } from '../lib/api'
@@ -50,6 +50,28 @@ export default function Insights() {
     try {
       await api.deleteWidget(projectId, widgetId)
       setWidgets((prev) => prev.filter((w) => w.widget.id !== widgetId))
+    } catch {
+      // silent
+    }
+  }
+
+  const handleResize = async (widgetId: string) => {
+    if (!projectId) return
+    const entry = widgets.find((w) => w.widget.id === widgetId)
+    if (!entry) return
+    const currentSize = entry.widget.size || 1
+    const nextSize = currentSize >= 3 ? 1 : currentSize + 1
+    try {
+      const updated = await api.updateWidget(projectId, widgetId, {
+        event_name: entry.widget.event_name,
+        property: entry.widget.property,
+        title: entry.widget.title,
+        position: entry.widget.position,
+        size: nextSize,
+      })
+      setWidgets((prev) =>
+        prev.map((w) => w.widget.id === widgetId ? { ...w, widget: updated } : w)
+      )
     } catch {
       // silent
     }
@@ -152,13 +174,14 @@ export default function Insights() {
           </button>
         </div>
       ) : (
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))', gap: '1rem' }}>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '1rem' }}>
           {widgets.map(({ widget, breakdown }) => (
             <WidgetCard
               key={widget.id}
               widget={widget}
               breakdown={breakdown}
               onDelete={() => handleDelete(widget.id)}
+              onResize={() => handleResize(widget.id)}
             />
           ))}
         </div>
@@ -175,14 +198,61 @@ export default function Insights() {
   )
 }
 
-function WidgetCard({ widget, breakdown, onDelete }: {
+function isUrl(value: string): boolean {
+  return /^https?:\/\//.test(value)
+}
+
+function BreakdownValue({ value }: { value: string }) {
+  if (isUrl(value)) {
+    return (
+      <a
+        href={value}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{
+          color: C.amber,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          maxWidth: '70%',
+          textDecoration: 'none',
+        }}
+        title={value}
+        onMouseOver={(e) => (e.currentTarget.style.textDecoration = 'underline')}
+        onMouseOut={(e) => (e.currentTarget.style.textDecoration = 'none')}
+      >
+        {value}
+      </a>
+    )
+  }
+  return (
+    <span style={{
+      color: C.text,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+      maxWidth: '70%',
+    }} title={value}>
+      {value}
+    </span>
+  )
+}
+
+const sizeIcons = { 1: Square, 2: Columns2, 3: Columns3 } as const
+const sizeLabels = { 1: 'Small (1 col)', 2: 'Medium (2 cols)', 3: 'Wide (3 cols)' } as const
+
+function WidgetCard({ widget, breakdown, onDelete, onResize }: {
   widget: DashboardWidget
   breakdown: PropertyBreakdown[]
   onDelete: () => void
+  onResize: () => void
 }) {
   const isCountOnly = !widget.property
   const maxCount = breakdown.length > 0 ? breakdown[0].count : 1
   const total = breakdown.reduce((sum, r) => sum + r.count, 0)
+  const size = (widget.size || 1) as 1 | 2 | 3
+  const nextSize = size >= 3 ? 1 : (size + 1) as 1 | 2 | 3
+  const SizeIcon = sizeIcons[nextSize]
 
   const subtitle = widget.property
     ? `${widget.event_name} → ${widget.property}`
@@ -194,6 +264,7 @@ function WidgetCard({ widget, breakdown, onDelete }: {
       border: `1px solid ${C.border}`,
       borderRadius: 12,
       overflow: 'hidden',
+      gridColumn: `span ${size}`,
     }}>
       <div style={{
         padding: '1rem 1.25rem',
@@ -212,21 +283,38 @@ function WidgetCard({ widget, breakdown, onDelete }: {
             </div>
           )}
         </div>
-        <button
-          onClick={onDelete}
-          style={{
-            background: 'transparent',
-            border: 'none',
-            color: C.muted,
-            cursor: 'pointer',
-            padding: 4,
-            borderRadius: 4,
-            display: 'flex',
-          }}
-          title="Delete widget"
-        >
-          <Trash2 size={14} />
-        </button>
+        <div style={{ display: 'flex', gap: 4 }}>
+          <button
+            onClick={onResize}
+            style={{
+              background: 'transparent',
+              border: 'none',
+              color: C.muted,
+              cursor: 'pointer',
+              padding: 4,
+              borderRadius: 4,
+              display: 'flex',
+            }}
+            title={sizeLabels[nextSize]}
+          >
+            <SizeIcon size={14} />
+          </button>
+          <button
+            onClick={onDelete}
+            style={{
+              background: 'transparent',
+              border: 'none',
+              color: C.muted,
+              cursor: 'pointer',
+              padding: 4,
+              borderRadius: 4,
+              display: 'flex',
+            }}
+            title="Delete widget"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
       </div>
 
       <div style={{ padding: '1rem 1.25rem' }}>
@@ -244,15 +332,7 @@ function WidgetCard({ widget, breakdown, onDelete }: {
             {breakdown.map((row) => (
               <div key={row.value}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, marginBottom: 4 }}>
-                  <span style={{
-                    color: C.text,
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                    maxWidth: '70%',
-                  }} title={row.value}>
-                    {row.value}
-                  </span>
+                  <BreakdownValue value={row.value} />
                   <span style={{ color: C.muted, flexShrink: 0, marginLeft: 8 }}>
                     {row.count} <span style={{ fontSize: 11 }}>({total > 0 ? Math.round(row.count / total * 100) : 0}%)</span>
                   </span>


### PR DESCRIPTION
## Summary
- Widgets can be resized to span 1, 2, or 3 columns via a toggle button in the header (cycles through sizes, persisted to DB)
- Breakdown values that are URLs (http/https) are now rendered as clickable links that open in a new tab
- New migration `00006_widget_size.sql` adds `size` column to `dashboard_widgets`

## Test plan
- [ ] Click resize icon on a widget → cycles 1→2→3→1 columns, persists on reload
- [ ] URL breakdown values (e.g. page_view → url) are clickable amber links
- [ ] Non-URL values still render as plain text
- [ ] Existing widgets default to size 1