### PR TITLE
feat: targeting rules for feature flags

### DIFF
--- a/internal/api/flags.go
+++ b/internal/api/flags.go
@@ -3,11 +3,13 @@ package api
 import (
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
+	"github.com/wiebe-xyz/funnelbarn/internal/service"
 	"github.com/wiebe-xyz/funnelbarn/internal/tracing"
 )
 
@@ -43,6 +45,7 @@ func (s *Server) handleCreateFlag(w http.ResponseWriter, r *http.Request) {
 		DefaultVariant  string `json:"default_variant"`
 		Split           string `json:"split"`
 		ConversionEvent string `json:"conversion_event"`
+		TargetingRules  string `json:"targeting_rules"`
 	}
 	if err := readJSON(r, &body); err != nil {
 		jsonError(w, "invalid json", http.StatusBadRequest)
@@ -55,6 +58,13 @@ func (s *Server) handleCreateFlag(w http.ResponseWriter, r *http.Request) {
 	if body.FlagType == "" {
 		body.FlagType = "boolean"
 	}
+	if body.TargetingRules == "" {
+		body.TargetingRules = "[]"
+	}
+	if err := service.ValidateTargetingRules(body.TargetingRules); err != nil {
+		jsonError(w, err.Error(), http.StatusUnprocessableEntity)
+		return
+	}
 
 	flag, err := s.flags.CreateFlag(r.Context(), repository.FeatureFlag{
 		ProjectID:       projectID,
@@ -65,6 +75,7 @@ func (s *Server) handleCreateFlag(w http.ResponseWriter, r *http.Request) {
 		DefaultVariant:  body.DefaultVariant,
 		Split:           body.Split,
 		ConversionEvent: body.ConversionEvent,
+		TargetingRules:  body.TargetingRules,
 		Status:          "active",
 	})
 	if err != nil {
@@ -103,11 +114,18 @@ func (s *Server) handleUpdateFlag(w http.ResponseWriter, r *http.Request) {
 		DefaultVariant  string `json:"default_variant"`
 		Split           string `json:"split"`
 		ConversionEvent string `json:"conversion_event"`
+		TargetingRules  string `json:"targeting_rules"`
 		Status          string `json:"status"`
 	}
 	if err := readJSON(r, &body); err != nil {
 		jsonError(w, "invalid json", http.StatusBadRequest)
 		return
+	}
+	if body.TargetingRules != "" {
+		if err := service.ValidateTargetingRules(body.TargetingRules); err != nil {
+			jsonError(w, err.Error(), http.StatusUnprocessableEntity)
+			return
+		}
 	}
 
 	flag, err := s.flags.UpdateFlag(r.Context(), repository.FeatureFlag{
@@ -118,6 +136,7 @@ func (s *Server) handleUpdateFlag(w http.ResponseWriter, r *http.Request) {
 		DefaultVariant:  body.DefaultVariant,
 		Split:           body.Split,
 		ConversionEvent: body.ConversionEvent,
+		TargetingRules:  body.TargetingRules,
 		Status:          body.Status,
 	})
 	if err != nil {
@@ -206,9 +225,9 @@ func (s *Server) handleEvaluateFlag(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body struct {
-		FlagKey      string            `json:"flag_key"`
-		DefaultValue any               `json:"default_value"`
-		Context      map[string]string `json:"context"`
+		FlagKey      string         `json:"flag_key"`
+		DefaultValue any            `json:"default_value"`
+		Context      map[string]any `json:"context"`
 	}
 	if err := readJSON(r, &body); err != nil {
 		jsonError(w, "invalid json", http.StatusBadRequest)
@@ -219,7 +238,7 @@ func (s *Server) handleEvaluateFlag(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if body.Context == nil {
-		body.Context = map[string]string{}
+		body.Context = map[string]any{}
 	}
 
 	ctx, span := tracing.StartSpan(r.Context(), "flags.evaluate.handler",
@@ -230,12 +249,17 @@ func (s *Server) handleEvaluateFlag(w http.ResponseWriter, r *http.Request) {
 
 	result, err := s.flags.EvaluateFlag(ctx, projectID, body.FlagKey, body.Context)
 	if err != nil {
+		errorCode := "GENERAL"
+		if strings.Contains(err.Error(), "flag not found") {
+			errorCode = "FLAG_NOT_FOUND"
+		}
 		writeJSON(w, http.StatusOK, map[string]any{
-			"value":    body.DefaultValue,
-			"variant":  "",
-			"reason":   "ERROR",
-			"flag_key": body.FlagKey,
-			"error":    err.Error(),
+			"value":      body.DefaultValue,
+			"variant":    "",
+			"reason":     "ERROR",
+			"flag_key":   body.FlagKey,
+			"error_code": errorCode,
+			"error":      err.Error(),
 		})
 		return
 	}

--- a/internal/repository/flags.go
+++ b/internal/repository/flags.go
@@ -17,6 +17,7 @@ type FeatureFlag struct {
 	DefaultVariant  string    `json:"default_variant"`
 	Split           string    `json:"split"`
 	ConversionEvent string    `json:"conversion_event"`
+	TargetingRules  string    `json:"targeting_rules"`
 	Status          string    `json:"status"`
 	CreatedAt       time.Time `json:"created_at"`
 }
@@ -46,10 +47,13 @@ func (s *Store) CreateFlag(ctx context.Context, f FeatureFlag) (FeatureFlag, err
 	if err != nil {
 		return FeatureFlag{}, fmt.Errorf("generate uuid: %w", err)
 	}
-	const q = `INSERT INTO feature_flags (id, project_id, flag_key, name, flag_type, variants, default_variant, split, conversion_event, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	if f.TargetingRules == "" {
+		f.TargetingRules = "[]"
+	}
+	const q = `INSERT INTO feature_flags (id, project_id, flag_key, name, flag_type, variants, default_variant, split, conversion_event, targeting_rules, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	if _, err := s.db.ExecContext(ctx, q,
 		f.ID, f.ProjectID, f.FlagKey, f.Name, f.FlagType,
-		f.Variants, f.DefaultVariant, f.Split, f.ConversionEvent, f.Status,
+		f.Variants, f.DefaultVariant, f.Split, f.ConversionEvent, f.TargetingRules, f.Status,
 	); err != nil {
 		return FeatureFlag{}, fmt.Errorf("create flag: %w", err)
 	}
@@ -57,12 +61,12 @@ func (s *Store) CreateFlag(ctx context.Context, f FeatureFlag) (FeatureFlag, err
 }
 
 func (s *Store) FlagByID(ctx context.Context, id string) (FeatureFlag, error) {
-	const q = `SELECT id, project_id, flag_key, name, flag_type, variants, default_variant, split, COALESCE(conversion_event,''), status, created_at FROM feature_flags WHERE id = ?`
+	const q = `SELECT id, project_id, flag_key, name, flag_type, variants, default_variant, split, COALESCE(conversion_event,''), COALESCE(targeting_rules,'[]'), status, created_at FROM feature_flags WHERE id = ?`
 	var f FeatureFlag
 	if err := s.db.QueryRowContext(ctx, q, id).Scan(
 		&f.ID, &f.ProjectID, &f.FlagKey, &f.Name, &f.FlagType,
 		&f.Variants, &f.DefaultVariant, &f.Split, &f.ConversionEvent,
-		&f.Status, &f.CreatedAt,
+		&f.TargetingRules, &f.Status, &f.CreatedAt,
 	); err != nil {
 		return FeatureFlag{}, err
 	}
@@ -70,12 +74,12 @@ func (s *Store) FlagByID(ctx context.Context, id string) (FeatureFlag, error) {
 }
 
 func (s *Store) FlagByKey(ctx context.Context, projectID, flagKey string) (FeatureFlag, error) {
-	const q = `SELECT id, project_id, flag_key, name, flag_type, variants, default_variant, split, COALESCE(conversion_event,''), status, created_at FROM feature_flags WHERE project_id = ? AND flag_key = ?`
+	const q = `SELECT id, project_id, flag_key, name, flag_type, variants, default_variant, split, COALESCE(conversion_event,''), COALESCE(targeting_rules,'[]'), status, created_at FROM feature_flags WHERE project_id = ? AND flag_key = ?`
 	var f FeatureFlag
 	if err := s.db.QueryRowContext(ctx, q, projectID, flagKey).Scan(
 		&f.ID, &f.ProjectID, &f.FlagKey, &f.Name, &f.FlagType,
 		&f.Variants, &f.DefaultVariant, &f.Split, &f.ConversionEvent,
-		&f.Status, &f.CreatedAt,
+		&f.TargetingRules, &f.Status, &f.CreatedAt,
 	); err != nil {
 		return FeatureFlag{}, err
 	}
@@ -83,7 +87,7 @@ func (s *Store) FlagByKey(ctx context.Context, projectID, flagKey string) (Featu
 }
 
 func (s *Store) ListFlags(ctx context.Context, projectID string) ([]FeatureFlag, error) {
-	const q = `SELECT id, project_id, flag_key, name, flag_type, variants, default_variant, split, COALESCE(conversion_event,''), status, created_at FROM feature_flags WHERE project_id = ? ORDER BY created_at DESC`
+	const q = `SELECT id, project_id, flag_key, name, flag_type, variants, default_variant, split, COALESCE(conversion_event,''), COALESCE(targeting_rules,'[]'), status, created_at FROM feature_flags WHERE project_id = ? ORDER BY created_at DESC`
 	rows, err := s.db.QueryContext(ctx, q, projectID)
 	if err != nil {
 		return nil, err
@@ -96,7 +100,7 @@ func (s *Store) ListFlags(ctx context.Context, projectID string) ([]FeatureFlag,
 		if err := rows.Scan(
 			&f.ID, &f.ProjectID, &f.FlagKey, &f.Name, &f.FlagType,
 			&f.Variants, &f.DefaultVariant, &f.Split, &f.ConversionEvent,
-			&f.Status, &f.CreatedAt,
+			&f.TargetingRules, &f.Status, &f.CreatedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -106,10 +110,13 @@ func (s *Store) ListFlags(ctx context.Context, projectID string) ([]FeatureFlag,
 }
 
 func (s *Store) UpdateFlag(ctx context.Context, f FeatureFlag) (FeatureFlag, error) {
-	const q = `UPDATE feature_flags SET name=?, flag_type=?, variants=?, default_variant=?, split=?, conversion_event=?, status=? WHERE id=?`
+	if f.TargetingRules == "" {
+		f.TargetingRules = "[]"
+	}
+	const q = `UPDATE feature_flags SET name=?, flag_type=?, variants=?, default_variant=?, split=?, conversion_event=?, targeting_rules=?, status=? WHERE id=?`
 	if _, err := s.db.ExecContext(ctx, q,
 		f.Name, f.FlagType, f.Variants, f.DefaultVariant, f.Split,
-		f.ConversionEvent, f.Status, f.ID,
+		f.ConversionEvent, f.TargetingRules, f.Status, f.ID,
 	); err != nil {
 		return FeatureFlag{}, fmt.Errorf("update flag: %w", err)
 	}

--- a/internal/repository/migrations/00007_targeting_rules.sql
+++ b/internal/repository/migrations/00007_targeting_rules.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE feature_flags ADD COLUMN targeting_rules TEXT NOT NULL DEFAULT '[]';
+
+-- +goose Down
+ALTER TABLE feature_flags DROP COLUMN targeting_rules;

--- a/internal/service/flags.go
+++ b/internal/service/flags.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -16,12 +17,68 @@ import (
 	"github.com/wiebe-xyz/funnelbarn/internal/tracing"
 )
 
-// FlagEvalResult is the result of evaluating a feature flag.
+// FlagEvalResult follows the OpenFeature resolution details structure.
 type FlagEvalResult struct {
-	Value   any    `json:"value"`
-	Variant string `json:"variant"`
-	Reason  string `json:"reason"`
-	FlagKey string `json:"flag_key"`
+	Value        any            `json:"value"`
+	Variant      string         `json:"variant"`
+	Reason       string         `json:"reason"`
+	FlagKey      string         `json:"flag_key"`
+	ErrorCode    string         `json:"error_code,omitempty"`
+	FlagMetadata map[string]any `json:"flag_metadata,omitempty"`
+}
+
+type TargetingCondition struct {
+	ContextKey string `json:"context_key"`
+	Operator   string `json:"operator"`
+	Value      string `json:"value"`
+}
+
+type TargetingRule struct {
+	Name       string               `json:"name"`
+	Variant    string               `json:"variant"`
+	Match      string               `json:"match"`
+	Conditions []TargetingCondition `json:"conditions"`
+}
+
+var validOperators = map[string]bool{
+	"eq": true, "neq": true,
+	"contains": true, "not_contains": true,
+	"starts_with": true, "ends_with": true,
+	"in": true, "not_in": true,
+	"present": true, "not_present": true,
+}
+
+func ValidateTargetingRules(rulesJSON string) error {
+	if rulesJSON == "" || rulesJSON == "[]" {
+		return nil
+	}
+	var rules []TargetingRule
+	if err := json.Unmarshal([]byte(rulesJSON), &rules); err != nil {
+		return fmt.Errorf("invalid targeting rules JSON: %w", err)
+	}
+	for i, r := range rules {
+		if r.Name == "" {
+			return fmt.Errorf("rule %d: name is required", i)
+		}
+		if r.Variant == "" {
+			return fmt.Errorf("rule %d: variant is required", i)
+		}
+		if r.Match != "all" && r.Match != "any" {
+			return fmt.Errorf("rule %d: match must be \"all\" or \"any\"", i)
+		}
+		if len(r.Conditions) == 0 {
+			return fmt.Errorf("rule %d: at least one condition is required", i)
+		}
+		for j, c := range r.Conditions {
+			if c.ContextKey == "" {
+				return fmt.Errorf("rule %d, condition %d: context_key is required", i, j)
+			}
+			if !validOperators[c.Operator] {
+				return fmt.Errorf("rule %d, condition %d: unknown operator %q", i, j, c.Operator)
+			}
+		}
+	}
+	return nil
 }
 
 type FlagService struct {
@@ -56,7 +113,7 @@ func (svc *FlagService) DeleteFlag(ctx context.Context, id string) error {
 	return svc.store.DeleteFlag(ctx, id)
 }
 
-func (svc *FlagService) EvaluateFlag(ctx context.Context, projectID, flagKey string, evalContext map[string]string) (FlagEvalResult, error) {
+func (svc *FlagService) EvaluateFlag(ctx context.Context, projectID, flagKey string, evalContext map[string]any) (FlagEvalResult, error) {
 	ctx, span := tracing.StartSpan(ctx, "flags.evaluate",
 		attribute.String("flag.key", flagKey),
 		attribute.String("project.id", projectID),
@@ -80,12 +137,36 @@ func (svc *FlagService) EvaluateFlag(ctx context.Context, projectID, flagKey str
 		}, nil
 	}
 
-	targetingKey := evalContext["targetingKey"]
+	targetingKey := contextString(evalContext, "targetingKey")
 	if targetingKey == "" {
-		targetingKey = evalContext["targeting_key"]
+		targetingKey = contextString(evalContext, "targeting_key")
 	}
 	if targetingKey == "" {
-		targetingKey = evalContext["session_id"]
+		targetingKey = contextString(evalContext, "session_id")
+	}
+	sessionID := contextString(evalContext, "session_id")
+
+	if variant, ruleName, matched := evaluateTargetingRules(flag.TargetingRules, evalContext); matched {
+		val, _ := variantValue(flag.Variants, variant)
+		span.SetAttributes(
+			attribute.String("flag.variant", variant),
+			attribute.String("flag.reason", "TARGETING_MATCH"),
+			attribute.String("flag.rule_name", ruleName),
+		)
+		_ = svc.store.RecordEvaluation(ctx, repository.FlagEvaluation{
+			FlagID:      flag.ID,
+			ProjectID:   flag.ProjectID,
+			Variant:     variant,
+			ContextHash: hashContext(targetingKey),
+			SessionID:   sessionID,
+		})
+		return FlagEvalResult{
+			Value:        val,
+			Variant:      variant,
+			Reason:       "TARGETING_MATCH",
+			FlagKey:      flag.FlagKey,
+			FlagMetadata: map[string]any{"evaluated_rule_name": ruleName},
+		}, nil
 	}
 
 	variant := resolveVariant(flag.Split, flag.FlagKey, targetingKey, flag.DefaultVariant)
@@ -93,7 +174,7 @@ func (svc *FlagService) EvaluateFlag(ctx context.Context, projectID, flagKey str
 
 	span.SetAttributes(
 		attribute.String("flag.variant", variant),
-		attribute.String("flag.reason", "SPLIT_EVALUATION"),
+		attribute.String("flag.reason", "SPLIT"),
 	)
 
 	_ = svc.store.RecordEvaluation(ctx, repository.FlagEvaluation{
@@ -101,13 +182,13 @@ func (svc *FlagService) EvaluateFlag(ctx context.Context, projectID, flagKey str
 		ProjectID:   flag.ProjectID,
 		Variant:     variant,
 		ContextHash: hashContext(targetingKey),
-		SessionID:   evalContext["session_id"],
+		SessionID:   sessionID,
 	})
 
 	return FlagEvalResult{
 		Value:   val,
 		Variant: variant,
-		Reason:  "SPLIT_EVALUATION",
+		Reason:  "SPLIT",
 		FlagKey: flag.FlagKey,
 	}, nil
 }
@@ -192,4 +273,104 @@ func variantValue(variantsJSON, variant string) (any, error) {
 func hashContext(targetingKey string) string {
 	h := sha256.Sum256([]byte(targetingKey))
 	return fmt.Sprintf("%x", h[:16])
+}
+
+func contextString(ctx map[string]any, key string) string {
+	v, ok := ctx[key]
+	if !ok {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+func evaluateTargetingRules(rulesJSON string, ctx map[string]any) (variant, ruleName string, matched bool) {
+	if rulesJSON == "" || rulesJSON == "[]" {
+		return "", "", false
+	}
+	var rules []TargetingRule
+	if err := json.Unmarshal([]byte(rulesJSON), &rules); err != nil {
+		return "", "", false
+	}
+	for _, rule := range rules {
+		if len(rule.Conditions) == 0 {
+			continue
+		}
+		if matchesRule(rule, ctx) {
+			return rule.Variant, rule.Name, true
+		}
+	}
+	return "", "", false
+}
+
+func matchesRule(rule TargetingRule, ctx map[string]any) bool {
+	if rule.Match == "any" {
+		for _, c := range rule.Conditions {
+			if evaluateCondition(c, ctx) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, c := range rule.Conditions {
+		if !evaluateCondition(c, ctx) {
+			return false
+		}
+	}
+	return true
+}
+
+func evaluateCondition(c TargetingCondition, ctx map[string]any) bool {
+	raw, exists := ctx[c.ContextKey]
+
+	if c.Operator == "present" {
+		return exists
+	}
+	if c.Operator == "not_present" {
+		return !exists
+	}
+
+	if !exists {
+		return false
+	}
+
+	var actual string
+	if s, ok := raw.(string); ok {
+		actual = s
+	} else {
+		actual = fmt.Sprintf("%v", raw)
+	}
+
+	switch c.Operator {
+	case "eq":
+		return actual == c.Value
+	case "neq":
+		return actual != c.Value
+	case "contains":
+		return strings.Contains(actual, c.Value)
+	case "not_contains":
+		return !strings.Contains(actual, c.Value)
+	case "starts_with":
+		return strings.HasPrefix(actual, c.Value)
+	case "ends_with":
+		return strings.HasSuffix(actual, c.Value)
+	case "in":
+		for _, v := range strings.Split(c.Value, ",") {
+			if actual == strings.TrimSpace(v) {
+				return true
+			}
+		}
+		return false
+	case "not_in":
+		for _, v := range strings.Split(c.Value, ",") {
+			if actual == strings.TrimSpace(v) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/service/flags_test.go
+++ b/internal/service/flags_test.go
@@ -1,0 +1,372 @@
+package service_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/wiebe-xyz/funnelbarn/internal/repository"
+	"github.com/wiebe-xyz/funnelbarn/internal/repository/mock"
+	"github.com/wiebe-xyz/funnelbarn/internal/service"
+)
+
+func createTestFlag(t *testing.T, svc *service.FlagService, projectID string, flagKey string, variants map[string]any, split map[string]int, defaultVariant string) repository.FeatureFlag {
+	t.Helper()
+	variantsJSON, _ := json.Marshal(variants)
+	splitJSON, _ := json.Marshal(split)
+	f, err := svc.CreateFlag(context.Background(), repository.FeatureFlag{
+		ProjectID:      projectID,
+		FlagKey:        flagKey,
+		Name:           flagKey,
+		FlagType:       "boolean",
+		Variants:       string(variantsJSON),
+		DefaultVariant: defaultVariant,
+		Split:          string(splitJSON),
+		TargetingRules: "[]",
+		Status:         "active",
+	})
+	require.NoError(t, err)
+	return f
+}
+
+func TestFlagService_EvaluateFlag_Split(t *testing.T) {
+	store := mock.New()
+	svc := service.NewFlagService(store)
+	createTestFlag(t, svc, "proj-1", "my-flag",
+		map[string]any{"on": true, "off": false},
+		map[string]int{"on": 50, "off": 50},
+		"off",
+	)
+
+	result, err := svc.EvaluateFlag(context.Background(), "proj-1", "my-flag", map[string]any{
+		"targetingKey": "user-123",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "SPLIT", result.Reason)
+	require.Equal(t, "my-flag", result.FlagKey)
+	require.Contains(t, []string{"on", "off"}, result.Variant)
+}
+
+func TestFlagService_EvaluateFlag_Disabled(t *testing.T) {
+	store := mock.New()
+	svc := service.NewFlagService(store)
+	variantsJSON, _ := json.Marshal(map[string]any{"on": true, "off": false})
+	splitJSON, _ := json.Marshal(map[string]int{"on": 50, "off": 50})
+	_, err := svc.CreateFlag(context.Background(), repository.FeatureFlag{
+		ProjectID:      "proj-1",
+		FlagKey:        "disabled-flag",
+		Name:           "disabled-flag",
+		FlagType:       "boolean",
+		Variants:       string(variantsJSON),
+		DefaultVariant: "off",
+		Split:          string(splitJSON),
+		TargetingRules: "[]",
+		Status:         "paused",
+	})
+	require.NoError(t, err)
+
+	result, err := svc.EvaluateFlag(context.Background(), "proj-1", "disabled-flag", map[string]any{})
+	require.NoError(t, err)
+	require.Equal(t, "DISABLED", result.Reason)
+	require.Equal(t, "off", result.Variant)
+	require.Equal(t, false, result.Value)
+}
+
+func TestFlagService_EvaluateFlag_NotFound(t *testing.T) {
+	store := mock.New()
+	svc := service.NewFlagService(store)
+
+	_, err := svc.EvaluateFlag(context.Background(), "proj-1", "nonexistent", map[string]any{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "flag not found")
+}
+
+func TestFlagService_EvaluateFlag_TargetingMatch(t *testing.T) {
+	store := mock.New()
+	svc := service.NewFlagService(store)
+
+	rules := []service.TargetingRule{
+		{
+			Name:    "Developer Override",
+			Variant: "off",
+			Match:   "all",
+			Conditions: []service.TargetingCondition{
+				{ContextKey: "bypassLaunchGate", Operator: "eq", Value: "true"},
+			},
+		},
+	}
+	rulesJSON, _ := json.Marshal(rules)
+
+	variantsJSON, _ := json.Marshal(map[string]any{"on": true, "off": false})
+	splitJSON, _ := json.Marshal(map[string]int{"on": 100})
+	_, err := svc.CreateFlag(context.Background(), repository.FeatureFlag{
+		ProjectID:      "proj-1",
+		FlagKey:        "launch-gate",
+		Name:           "Launch Gate",
+		FlagType:       "boolean",
+		Variants:       string(variantsJSON),
+		DefaultVariant: "on",
+		Split:          string(splitJSON),
+		TargetingRules: string(rulesJSON),
+		Status:         "active",
+	})
+	require.NoError(t, err)
+
+	result, err := svc.EvaluateFlag(context.Background(), "proj-1", "launch-gate", map[string]any{
+		"targetingKey":      "user-456",
+		"bypassLaunchGate": "true",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "TARGETING_MATCH", result.Reason)
+	require.Equal(t, "off", result.Variant)
+	require.Equal(t, false, result.Value)
+	require.Equal(t, "Developer Override", result.FlagMetadata["evaluated_rule_name"])
+}
+
+func TestFlagService_EvaluateFlag_TargetingNoMatch_FallsThrough(t *testing.T) {
+	store := mock.New()
+	svc := service.NewFlagService(store)
+
+	rules := []service.TargetingRule{
+		{
+			Name:    "Developer Override",
+			Variant: "off",
+			Match:   "all",
+			Conditions: []service.TargetingCondition{
+				{ContextKey: "bypassLaunchGate", Operator: "eq", Value: "true"},
+			},
+		},
+	}
+	rulesJSON, _ := json.Marshal(rules)
+
+	variantsJSON, _ := json.Marshal(map[string]any{"on": true, "off": false})
+	splitJSON, _ := json.Marshal(map[string]int{"on": 100})
+	_, err := svc.CreateFlag(context.Background(), repository.FeatureFlag{
+		ProjectID:      "proj-1",
+		FlagKey:        "launch-gate",
+		Name:           "Launch Gate",
+		FlagType:       "boolean",
+		Variants:       string(variantsJSON),
+		DefaultVariant: "on",
+		Split:          string(splitJSON),
+		TargetingRules: string(rulesJSON),
+		Status:         "active",
+	})
+	require.NoError(t, err)
+
+	result, err := svc.EvaluateFlag(context.Background(), "proj-1", "launch-gate", map[string]any{
+		"targetingKey": "user-789",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "SPLIT", result.Reason)
+	require.Equal(t, "on", result.Variant)
+}
+
+func TestFlagService_EvaluateFlag_TargetingAnyMatch(t *testing.T) {
+	store := mock.New()
+	svc := service.NewFlagService(store)
+
+	rules := []service.TargetingRule{
+		{
+			Name:    "Internal Users",
+			Variant: "on",
+			Match:   "any",
+			Conditions: []service.TargetingCondition{
+				{ContextKey: "email", Operator: "ends_with", Value: "@wiebe.xyz"},
+				{ContextKey: "email", Operator: "ends_with", Value: "@funnelbarn.com"},
+			},
+		},
+	}
+	rulesJSON, _ := json.Marshal(rules)
+	variantsJSON, _ := json.Marshal(map[string]any{"on": true, "off": false})
+	splitJSON, _ := json.Marshal(map[string]int{"off": 100})
+	_, err := svc.CreateFlag(context.Background(), repository.FeatureFlag{
+		ProjectID:      "proj-1",
+		FlagKey:        "beta-feature",
+		Name:           "Beta Feature",
+		FlagType:       "boolean",
+		Variants:       string(variantsJSON),
+		DefaultVariant: "off",
+		Split:          string(splitJSON),
+		TargetingRules: string(rulesJSON),
+		Status:         "active",
+	})
+	require.NoError(t, err)
+
+	result, err := svc.EvaluateFlag(context.Background(), "proj-1", "beta-feature", map[string]any{
+		"targetingKey": "user-internal",
+		"email":        "dev@funnelbarn.com",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "TARGETING_MATCH", result.Reason)
+	require.Equal(t, "on", result.Variant)
+}
+
+func TestValidateTargetingRules(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"empty string", "", false},
+		{"empty array", "[]", false},
+		{"valid rule", `[{"name":"test","variant":"on","match":"all","conditions":[{"context_key":"x","operator":"eq","value":"1"}]}]`, false},
+		{"missing name", `[{"name":"","variant":"on","match":"all","conditions":[{"context_key":"x","operator":"eq","value":"1"}]}]`, true},
+		{"missing variant", `[{"name":"test","variant":"","match":"all","conditions":[{"context_key":"x","operator":"eq","value":"1"}]}]`, true},
+		{"invalid match", `[{"name":"test","variant":"on","match":"none","conditions":[{"context_key":"x","operator":"eq","value":"1"}]}]`, true},
+		{"no conditions", `[{"name":"test","variant":"on","match":"all","conditions":[]}]`, true},
+		{"unknown operator", `[{"name":"test","variant":"on","match":"all","conditions":[{"context_key":"x","operator":"regex","value":".*"}]}]`, true},
+		{"invalid json", `not json`, true},
+		{"missing context_key", `[{"name":"test","variant":"on","match":"all","conditions":[{"context_key":"","operator":"eq","value":"1"}]}]`, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := service.ValidateTargetingRules(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestFlagService_EvaluateFlag_Operators(t *testing.T) {
+	tests := []struct {
+		name     string
+		operator string
+		value    string
+		ctx      map[string]any
+		match    bool
+	}{
+		{"eq match", "eq", "hello", map[string]any{"x": "hello"}, true},
+		{"eq no match", "eq", "hello", map[string]any{"x": "world"}, false},
+		{"neq match", "neq", "hello", map[string]any{"x": "world"}, true},
+		{"neq no match", "neq", "hello", map[string]any{"x": "hello"}, false},
+		{"contains match", "contains", "ell", map[string]any{"x": "hello"}, true},
+		{"contains no match", "contains", "xyz", map[string]any{"x": "hello"}, false},
+		{"not_contains match", "not_contains", "xyz", map[string]any{"x": "hello"}, true},
+		{"not_contains no match", "not_contains", "ell", map[string]any{"x": "hello"}, false},
+		{"starts_with match", "starts_with", "hel", map[string]any{"x": "hello"}, true},
+		{"starts_with no match", "starts_with", "wor", map[string]any{"x": "hello"}, false},
+		{"ends_with match", "ends_with", "llo", map[string]any{"x": "hello"}, true},
+		{"ends_with no match", "ends_with", "wor", map[string]any{"x": "hello"}, false},
+		{"in match", "in", "a,hello,b", map[string]any{"x": "hello"}, true},
+		{"in no match", "in", "a,b,c", map[string]any{"x": "hello"}, false},
+		{"not_in match", "not_in", "a,b,c", map[string]any{"x": "hello"}, true},
+		{"not_in no match", "not_in", "a,hello,b", map[string]any{"x": "hello"}, false},
+		{"present match", "present", "", map[string]any{"x": "anything"}, true},
+		{"present no match", "present", "", map[string]any{}, false},
+		{"not_present match", "not_present", "", map[string]any{}, true},
+		{"not_present no match", "not_present", "", map[string]any{"x": "anything"}, false},
+		{"numeric coercion", "eq", "42", map[string]any{"x": 42}, true},
+		{"missing key", "eq", "hello", map[string]any{}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := mock.New()
+			svc := service.NewFlagService(store)
+
+			rules := []service.TargetingRule{
+				{
+					Name:    "test-rule",
+					Variant: "on",
+					Match:   "all",
+					Conditions: []service.TargetingCondition{
+						{ContextKey: "x", Operator: tt.operator, Value: tt.value},
+					},
+				},
+			}
+			rulesJSON, _ := json.Marshal(rules)
+			variantsJSON, _ := json.Marshal(map[string]any{"on": true, "off": false})
+			splitJSON, _ := json.Marshal(map[string]int{"off": 100})
+
+			_, err := svc.CreateFlag(context.Background(), repository.FeatureFlag{
+				ProjectID:      "proj-1",
+				FlagKey:        "op-test-" + tt.name,
+				Name:           "op-test",
+				FlagType:       "boolean",
+				Variants:       string(variantsJSON),
+				DefaultVariant: "off",
+				Split:          string(splitJSON),
+				TargetingRules: string(rulesJSON),
+				Status:         "active",
+			})
+			require.NoError(t, err)
+
+			tt.ctx["targetingKey"] = "user-1"
+			result, err := svc.EvaluateFlag(context.Background(), "proj-1", "op-test-"+tt.name, tt.ctx)
+			require.NoError(t, err)
+
+			if tt.match {
+				require.Equal(t, "TARGETING_MATCH", result.Reason)
+				require.Equal(t, "on", result.Variant)
+			} else {
+				require.Equal(t, "SPLIT", result.Reason)
+				require.Equal(t, "off", result.Variant)
+			}
+		})
+	}
+}
+
+func TestFlagService_CRUD(t *testing.T) {
+	store := mock.New()
+	svc := service.NewFlagService(store)
+	ctx := context.Background()
+
+	f := createTestFlag(t, svc, "proj-1", "test-crud",
+		map[string]any{"on": true, "off": false},
+		map[string]int{"on": 50, "off": 50},
+		"off",
+	)
+
+	got, err := svc.GetFlag(ctx, f.ID)
+	require.NoError(t, err)
+	require.Equal(t, f.FlagKey, got.FlagKey)
+
+	gotByKey, err := svc.GetFlagByKey(ctx, "proj-1", "test-crud")
+	require.NoError(t, err)
+	require.Equal(t, f.ID, gotByKey.ID)
+
+	list, err := svc.ListFlags(ctx, "proj-1")
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+
+	updated, err := svc.UpdateFlag(ctx, repository.FeatureFlag{
+		ID:             f.ID,
+		Name:           "Updated Name",
+		Variants:       f.Variants,
+		DefaultVariant: f.DefaultVariant,
+		Split:          f.Split,
+		TargetingRules: f.TargetingRules,
+		Status:         "active",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "Updated Name", updated.Name)
+
+	err = svc.DeleteFlag(ctx, f.ID)
+	require.NoError(t, err)
+
+	list, err = svc.ListFlags(ctx, "proj-1")
+	require.NoError(t, err)
+	require.Len(t, list, 0)
+}
+
+func TestFlagService_DeterministicSplit(t *testing.T) {
+	store := mock.New()
+	svc := service.NewFlagService(store)
+	createTestFlag(t, svc, "proj-1", "deterministic-flag",
+		map[string]any{"on": true, "off": false},
+		map[string]int{"on": 50, "off": 50},
+		"off",
+	)
+
+	r1, err := svc.EvaluateFlag(context.Background(), "proj-1", "deterministic-flag", map[string]any{"targetingKey": "same-user"})
+	require.NoError(t, err)
+	r2, err := svc.EvaluateFlag(context.Background(), "proj-1", "deterministic-flag", map[string]any{"targetingKey": "same-user"})
+	require.NoError(t, err)
+	require.Equal(t, r1.Variant, r2.Variant)
+}

--- a/internal/service/flags_test.go
+++ b/internal/service/flags_test.go
@@ -114,7 +114,7 @@ func TestFlagService_EvaluateFlag_TargetingMatch(t *testing.T) {
 	require.NoError(t, err)
 
 	result, err := svc.EvaluateFlag(context.Background(), "proj-1", "launch-gate", map[string]any{
-		"targetingKey":      "user-456",
+		"targetingKey":     "user-456",
 		"bypassLaunchGate": "true",
 	})
 	require.NoError(t, err)

--- a/internal/service/interfaces.go
+++ b/internal/service/interfaces.go
@@ -42,7 +42,7 @@ type Flags interface {
 	ListFlags(ctx context.Context, projectID string) ([]repository.FeatureFlag, error)
 	UpdateFlag(ctx context.Context, f repository.FeatureFlag) (repository.FeatureFlag, error)
 	DeleteFlag(ctx context.Context, id string) error
-	EvaluateFlag(ctx context.Context, projectID, flagKey string, evalContext map[string]string) (FlagEvalResult, error)
+	EvaluateFlag(ctx context.Context, projectID, flagKey string, evalContext map[string]any) (FlagEvalResult, error)
 	AnalyzeFlag(ctx context.Context, flag repository.FeatureFlag, from, to time.Time) ([]repository.FlagAnalysisResult, error)
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -167,6 +167,7 @@ export const api = {
     default_variant: string
     split: string
     conversion_event?: string
+    targeting_rules?: string
   }) =>
     request<FeatureFlag>(`/api/v1/projects/${projectId}/flags`, {
       method: 'POST',
@@ -179,6 +180,7 @@ export const api = {
     default_variant: string
     split: string
     conversion_event: string
+    targeting_rules: string
     status: string
   }>) =>
     request<FeatureFlag>(`/api/v1/projects/${projectId}/flags/${flagId}`, {
@@ -307,6 +309,21 @@ export interface ApiKey {
   created_at: string
 }
 
+export type TargetingOperator = 'eq' | 'neq' | 'contains' | 'not_contains' | 'starts_with' | 'ends_with' | 'in' | 'not_in' | 'present' | 'not_present'
+
+export interface TargetingCondition {
+  context_key: string
+  operator: TargetingOperator
+  value: string
+}
+
+export interface TargetingRule {
+  name: string
+  variant: string
+  match: 'all' | 'any'
+  conditions: TargetingCondition[]
+}
+
 export interface FeatureFlag {
   id: string
   project_id: string
@@ -317,6 +334,7 @@ export interface FeatureFlag {
   default_variant: string
   split: string
   conversion_event?: string
+  targeting_rules: string
   status: string
   created_at: string
 }

--- a/web/src/pages/Flags.tsx
+++ b/web/src/pages/Flags.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import { Flag, Plus, X, Pause, Play, Trash2 } from 'lucide-react'
+import { Flag, Plus, X, Pause, Play, Trash2, ChevronDown, ChevronRight } from 'lucide-react'
 import Shell from '../components/shell/Shell'
 import { api } from '../lib/api'
-import type { FeatureFlag, FlagAnalysis } from '../lib/api'
+import type { FeatureFlag, FlagAnalysis, TargetingRule, TargetingOperator } from '../lib/api'
 import { useProjects } from '../lib/projects'
 import { reportError } from '../lib/bugbarn'
 import { Skeleton } from '../components/ui/Skeleton'
@@ -161,7 +161,7 @@ function FlagDetail({ flag, projectId, onUpdated, onDeleted }: {
         {flag.conversion_event && <div>Conversion: <span style={{ color: C.text }}>{flag.conversion_event}</span></div>}
       </div>
 
-      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 24 }}>
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 16 }}>
         {Object.entries(split).map(([variant, pct]) => (
           <div key={variant} style={{
             background: C.bg, border: `1px solid ${C.border}`, borderRadius: 8,
@@ -173,6 +173,8 @@ function FlagDetail({ flag, projectId, onUpdated, onDeleted }: {
           </div>
         ))}
       </div>
+
+      <TargetingRulesDisplay rulesJSON={flag.targeting_rules} />
 
       {loading ? (
         <div style={{ display: 'flex', gap: '1rem' }}>
@@ -216,6 +218,42 @@ function FlagDetail({ flag, projectId, onUpdated, onDeleted }: {
   )
 }
 
+function TargetingRulesDisplay({ rulesJSON }: { rulesJSON: string }) {
+  const rules: TargetingRule[] = (() => { try { return JSON.parse(rulesJSON || '[]') } catch { return [] } })()
+  if (rules.length === 0) return null
+  return (
+    <div style={{ marginBottom: 24 }}>
+      <div style={{ fontSize: 12, color: C.muted, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: 8 }}>
+        Targeting Rules ({rules.length})
+      </div>
+      {rules.map((rule, i) => (
+        <div key={i} style={{
+          background: C.bg, border: `1px solid ${C.border}`, borderRadius: 8,
+          padding: '10px 12px', marginBottom: 6, fontSize: 13,
+        }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4 }}>
+            <span style={{ color: C.text, fontWeight: 600 }}>{rule.name || `Rule ${i + 1}`}</span>
+            <span style={{ color: C.amber }}>→ {rule.variant}</span>
+          </div>
+          <div style={{ color: C.muted, fontSize: 12 }}>
+            {rule.match === 'all' ? 'ALL' : 'ANY'} of:{' '}
+            {rule.conditions.map((c, j) => (
+              <span key={j}>
+                {j > 0 && <span style={{ color: C.amber }}> {rule.match === 'all' ? '&&' : '||'} </span>}
+                <code style={{ color: C.text }}>{c.context_key}</code>
+                {' '}<span style={{ color: C.amber }}>{c.operator}</span>{' '}
+                {c.operator !== 'present' && c.operator !== 'not_present' && (
+                  <code style={{ color: C.text }}>"{c.value}"</code>
+                )}
+              </span>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
 function CreateFlagModal({ projectId, onClose, onCreated }: {
   projectId: string; onClose: () => void; onCreated: (f: FeatureFlag) => void
 }) {
@@ -227,6 +265,8 @@ function CreateFlagModal({ projectId, onClose, onCreated }: {
   const [eventNames, setEventNames] = useState<string[]>([])
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [targetingRules, setTargetingRules] = useState<TargetingRule[]>([])
+  const [showRules, setShowRules] = useState(false)
 
   // String variants
   const [variantAKey, setVariantAKey] = useState('control')
@@ -263,6 +303,7 @@ function CreateFlagModal({ projectId, onClose, onCreated }: {
         default_variant: flagType === 'boolean' ? 'off' : variantAKey,
         split: JSON.stringify(split),
         conversion_event: conversionEvent,
+        targeting_rules: targetingRules.length > 0 ? JSON.stringify(targetingRules) : '[]',
       })
       onCreated(f)
     } catch (e) {
@@ -342,10 +383,117 @@ function CreateFlagModal({ projectId, onClose, onCreated }: {
 
           <label style={{ display: 'block', fontSize: 13, color: C.muted, fontWeight: 600, marginBottom: 6 }}>Conversion event</label>
           <select value={conversionEvent} onChange={(e) => setConversionEvent(e.target.value)}
-            style={{ ...inputStyle, marginBottom: 8 }}>
+            style={{ ...inputStyle, marginBottom: 16 }}>
             <option value="">Select an event (optional)...</option>
             {eventNames.map((n) => <option key={n} value={n}>{n}</option>)}
           </select>
+
+          <div style={{ border: `1px solid ${C.border}`, borderRadius: 10, overflow: 'hidden' }}>
+            <button onClick={() => setShowRules(!showRules)} type="button" style={{
+              width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+              padding: '0.75rem 1rem', background: 'transparent', border: 'none',
+              color: C.muted, fontSize: 13, fontWeight: 600, cursor: 'pointer',
+            }}>
+              <span>Targeting Rules ({targetingRules.length})</span>
+              {showRules ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+            </button>
+
+            {showRules && (
+              <div style={{ padding: '0 1rem 1rem', borderTop: `1px solid ${C.border}` }}>
+                {targetingRules.map((rule, ri) => {
+                  const variantKeys = flagType === 'boolean' ? ['on', 'off'] : [variantAKey, variantBKey]
+                  return (
+                    <div key={ri} style={{ background: C.bg, border: `1px solid ${C.border}`, borderRadius: 8, padding: '0.75rem', marginTop: '0.75rem' }}>
+                      <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
+                        <input value={rule.name} placeholder="Rule name" onChange={(e) => {
+                          const updated = [...targetingRules]; updated[ri] = { ...rule, name: e.target.value }; setTargetingRules(updated)
+                        }} style={{ ...inputStyle, flex: 2 }} />
+                        <select value={rule.variant} onChange={(e) => {
+                          const updated = [...targetingRules]; updated[ri] = { ...rule, variant: e.target.value }; setTargetingRules(updated)
+                        }} style={{ ...inputStyle, flex: 1 }}>
+                          {variantKeys.map((v) => <option key={v} value={v}>{v}</option>)}
+                        </select>
+                        <button onClick={() => setTargetingRules(targetingRules.filter((_, i) => i !== ri))} type="button"
+                          style={{ background: 'transparent', border: 'none', color: C.error, cursor: 'pointer', padding: 4 }}>
+                          <X size={14} />
+                        </button>
+                      </div>
+
+                      <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
+                        {(['all', 'any'] as const).map((m) => (
+                          <button key={m} type="button" onClick={() => {
+                            const updated = [...targetingRules]; updated[ri] = { ...rule, match: m }; setTargetingRules(updated)
+                          }} style={{
+                            padding: '0.25rem 0.6rem', fontSize: 12, fontWeight: 600, cursor: 'pointer',
+                            border: `1px solid ${rule.match === m ? C.amber : C.border}`, borderRadius: 6,
+                            background: rule.match === m ? 'rgba(245,158,11,0.1)' : 'transparent',
+                            color: rule.match === m ? C.amber : C.muted,
+                          }}>
+                            {m === 'all' ? 'ALL (AND)' : 'ANY (OR)'}
+                          </button>
+                        ))}
+                      </div>
+
+                      {rule.conditions.map((cond, ci) => (
+                        <div key={ci} style={{ display: 'flex', gap: 4, marginBottom: 4 }}>
+                          <input value={cond.context_key} placeholder="context key" onChange={(e) => {
+                            const updated = [...targetingRules]
+                            const conds = [...rule.conditions]; conds[ci] = { ...cond, context_key: e.target.value }
+                            updated[ri] = { ...rule, conditions: conds }; setTargetingRules(updated)
+                          }} style={{ ...inputStyle, flex: 2, fontSize: 12, padding: '0.4rem 0.6rem', fontFamily: 'monospace' }} />
+                          <select value={cond.operator} onChange={(e) => {
+                            const updated = [...targetingRules]
+                            const conds = [...rule.conditions]; conds[ci] = { ...cond, operator: e.target.value as TargetingOperator }
+                            updated[ri] = { ...rule, conditions: conds }; setTargetingRules(updated)
+                          }} style={{ ...inputStyle, flex: 1.5, fontSize: 12, padding: '0.4rem 0.4rem' }}>
+                            {(['eq', 'neq', 'contains', 'not_contains', 'starts_with', 'ends_with', 'in', 'not_in', 'present', 'not_present'] as const).map((op) => (
+                              <option key={op} value={op}>{op}</option>
+                            ))}
+                          </select>
+                          {cond.operator !== 'present' && cond.operator !== 'not_present' && (
+                            <input value={cond.value} placeholder="value" onChange={(e) => {
+                              const updated = [...targetingRules]
+                              const conds = [...rule.conditions]; conds[ci] = { ...cond, value: e.target.value }
+                              updated[ri] = { ...rule, conditions: conds }; setTargetingRules(updated)
+                            }} style={{ ...inputStyle, flex: 2, fontSize: 12, padding: '0.4rem 0.6rem' }} />
+                          )}
+                          <button onClick={() => {
+                            const updated = [...targetingRules]
+                            updated[ri] = { ...rule, conditions: rule.conditions.filter((_, i) => i !== ci) }
+                            setTargetingRules(updated)
+                          }} type="button" style={{ background: 'transparent', border: 'none', color: C.muted, cursor: 'pointer', padding: 2 }}>
+                            <X size={12} />
+                          </button>
+                        </div>
+                      ))}
+
+                      <button onClick={() => {
+                        const updated = [...targetingRules]
+                        updated[ri] = { ...rule, conditions: [...rule.conditions, { context_key: '', operator: 'eq', value: '' }] }
+                        setTargetingRules(updated)
+                      }} type="button" style={{
+                        background: 'transparent', border: 'none', color: C.amber,
+                        fontSize: 12, cursor: 'pointer', padding: '4px 0', fontWeight: 600,
+                      }}>
+                        + Add condition
+                      </button>
+                    </div>
+                  )
+                })}
+
+                <button onClick={() => setTargetingRules([...targetingRules, {
+                  name: '', variant: flagType === 'boolean' ? 'off' : variantAKey,
+                  match: 'all', conditions: [{ context_key: '', operator: 'eq', value: '' }],
+                }])} type="button" style={{
+                  marginTop: '0.75rem', width: '100%', padding: '0.5rem',
+                  background: 'transparent', border: `1px dashed ${C.border}`, borderRadius: 8,
+                  color: C.amber, fontSize: 13, fontWeight: 600, cursor: 'pointer',
+                }}>
+                  + Add rule
+                </button>
+              </div>
+            )}
+          </div>
         </div>
 
         <div style={{ padding: '1rem 1.5rem', borderTop: `1px solid ${C.border}`, display: 'flex', justifyContent: 'flex-end', gap: 8 }}>


### PR DESCRIPTION
## Summary
- Feature flags can now have targeting rules evaluated before the percentage split
- Each rule has AND/OR condition groups with 10 operators: `eq`, `neq`, `contains`, `not_contains`, `starts_with`, `ends_with`, `in`, `not_in`, `present`, `not_present`
- Rules evaluated in order, first match wins, no match falls through to split
- OpenFeature alignment: reason codes (`TARGETING_MATCH`, `SPLIT`, `DISABLED`), `map[string]any` context, `error_code` in responses, `flag_metadata.evaluated_rule_name`
- UI: collapsible targeting rules editor in Create Flag modal, read-only display in flag detail view

## Test plan
- [ ] Create flag with no targeting rules → split works as before
- [ ] Create flag with targeting rule (e.g. `bypassLaunchGate eq "true"`) → verify TARGETING_MATCH response
- [ ] Evaluate without matching context → falls through to SPLIT
- [ ] Test AND/OR condition groups
- [ ] Verify `present`/`not_present` operators
- [ ] Existing flags still work (migration defaults to `[]`)