### PR TITLE
fix: hourly 7d chart + responsive Insights grid

### DIFF
--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -73,7 +73,7 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var timeSeries []repository.TimeSeriesPoint
-	if rangeParam == "24h" {
+	if rangeParam == "24h" || rangeParam == "7d" {
 		timeSeries, err = s.events.HourlyEventCounts(ctx, projectID, from, to)
 	} else {
 		timeSeries, err = s.events.DailyEventCounts(ctx, projectID, from, to)

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-
-	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 )
 
 // addPaginationHeaders sets a Link header for the next page when more results
@@ -62,7 +60,12 @@ func (s *Server) handleEventProperties(w http.ResponseWriter, r *http.Request) {
 	if props == nil {
 		props = []string{}
 	}
-	all := append(repository.MetadataColumns(), props...)
+	populated, err := s.events.PopulatedMetadataColumns(r.Context(), projectID, eventName)
+	if err != nil {
+		mapServiceError(w, err, "handleEventProperties.metadata")
+		return
+	}
+	all := append(populated, props...)
 	writeJSON(w, http.StatusOK, map[string]any{"properties": all})
 }
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -375,6 +375,8 @@ func TestHandleEventProperties_Success(t *testing.T) {
 	_ = store.InsertEvent(ctx, repository.Event{
 		ID: "ep1", ProjectID: p.ID, SessionID: "s1", Name: "signup",
 		Properties: `{"plan":"pro","source":"ads"}`,
+		URL:        "https://example.com",
+		Browser:    "Chrome",
 		IngestID:   "i-ep1", OccurredAt: now(),
 	})
 
@@ -386,9 +388,10 @@ func TestHandleEventProperties_Success(t *testing.T) {
 		Properties []string `json:"properties"`
 	}
 	_ = json.Unmarshal(w.Body.Bytes(), &resp)
-	expectedCount := len(repository.MetadataColumns()) + 2
+	// 2 populated metadata columns (url, browser) + 2 custom JSON properties (plan, source)
+	expectedCount := 4
 	if len(resp.Properties) != expectedCount {
-		t.Fatalf("want %d properties (12 metadata + 2 custom), got %d: %v", expectedCount, len(resp.Properties), resp.Properties)
+		t.Fatalf("want %d properties (2 metadata + 2 custom), got %d: %v", expectedCount, len(resp.Properties), resp.Properties)
 	}
 }
 

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -81,6 +81,7 @@ type EventRepo interface {
 	DistinctEventNames(ctx context.Context, projectID string) ([]string, error)
 	DistinctEventProperties(ctx context.Context, projectID, eventName string) ([]string, error)
 	DistinctPropertyValues(ctx context.Context, projectID, eventName, property string, limit int) ([]string, error)
+	PopulatedMetadataColumns(ctx context.Context, projectID, eventName string) ([]string, error)
 }
 
 // SessionRepo is the persistence port for sessions.

--- a/internal/repository/events.go
+++ b/internal/repository/events.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 )
 
@@ -688,6 +689,40 @@ func (s *Store) DistinctPropertyValues(ctx context.Context, projectID, eventName
 		vals = append(vals, v)
 	}
 	return vals, rows.Err()
+}
+
+// PopulatedMetadataColumns returns only metadata columns that have at least
+// one non-empty value for the given project and event name.
+func (s *Store) PopulatedMetadataColumns(ctx context.Context, projectID, eventName string) ([]string, error) {
+	q := `SELECT `
+	for i, col := range metadataColumns {
+		if i > 0 {
+			q += `, `
+		}
+		q += fmt.Sprintf(`MAX(CASE WHEN %s IS NOT NULL AND %s != '' THEN 1 ELSE 0 END)`, col, col)
+	}
+	q += ` FROM events WHERE project_id = ? AND name = ? LIMIT 1000`
+
+	row := s.db.QueryRowContext(ctx, q, projectID, eventName)
+	flags := make([]int, len(metadataColumns))
+	ptrs := make([]any, len(metadataColumns))
+	for i := range flags {
+		ptrs[i] = &flags[i]
+	}
+	if err := row.Scan(ptrs...); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var populated []string
+	for i, f := range flags {
+		if f == 1 {
+			populated = append(populated, metadataColumns[i])
+		}
+	}
+	return populated, nil
 }
 
 // TopOS is an alias for TopOSSystems kept for backward compatibility in tests.

--- a/internal/repository/mock/mock.go
+++ b/internal/repository/mock/mock.go
@@ -571,6 +571,10 @@ func (s *Store) DistinctPropertyValues(_ context.Context, _, _, _ string, _ int)
 	return nil, nil
 }
 
+func (s *Store) PopulatedMetadataColumns(_ context.Context, _, _ string) ([]string, error) {
+	return nil, nil
+}
+
 func (s *Store) PurgeOldEvents(ctx context.Context, cutoff time.Time) (int64, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/service/events.go
+++ b/internal/service/events.go
@@ -93,3 +93,7 @@ func (svc *EventService) DistinctEventProperties(ctx context.Context, projectID,
 func (svc *EventService) DistinctPropertyValues(ctx context.Context, projectID, eventName, property string, limit int) ([]string, error) {
 	return svc.store.DistinctPropertyValues(ctx, projectID, eventName, property, limit)
 }
+
+func (svc *EventService) PopulatedMetadataColumns(ctx context.Context, projectID, eventName string) ([]string, error) {
+	return svc.store.PopulatedMetadataColumns(ctx, projectID, eventName)
+}

--- a/internal/service/interfaces.go
+++ b/internal/service/interfaces.go
@@ -75,6 +75,7 @@ type Events interface {
 	DistinctEventNames(ctx context.Context, projectID string) ([]string, error)
 	DistinctEventProperties(ctx context.Context, projectID, eventName string) ([]string, error)
 	DistinctPropertyValues(ctx context.Context, projectID, eventName, property string, limit int) ([]string, error)
+	PopulatedMetadataColumns(ctx context.Context, projectID, eventName string) ([]string, error)
 }
 
 // Widgets is the interface for dashboard widget operations.

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -152,13 +152,19 @@ export default function Dashboard() {
       .catch(() => setTopFunnelRate(null))
   }, [projectId])
 
-  // Format time series for chart — hourly labels for 24h, daily for 7d/30d
-  const chartData = data?.events_time_series?.map((pt) => ({
-    time: range === '24h'
-      ? new Date(pt.time).toLocaleTimeString('en-US', { hour: 'numeric', hour12: true })
-      : new Date(pt.time).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
-    events: pt.count,
-  })) ?? []
+  // Format time series for chart — hourly labels for 24h/7d, daily for 30d
+  const chartData = data?.events_time_series?.map((pt) => {
+    const d = new Date(pt.time)
+    let time: string
+    if (range === '24h') {
+      time = d.toLocaleTimeString('en-US', { hour: 'numeric', hour12: true })
+    } else if (range === '7d') {
+      time = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', hour12: true })
+    } else {
+      time = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+    }
+    return { time, events: pt.count }
+  }) ?? []
 
   // Referrer data for pie chart
   const referrerData = data?.top_referrers?.slice(0, 6).map((r) => ({

--- a/web/src/pages/Insights.tsx
+++ b/web/src/pages/Insights.tsx
@@ -174,7 +174,7 @@ export default function Insights() {
           </button>
         </div>
       ) : (
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '1rem' }}>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(min(100%, 300px), 1fr))', gap: '1rem' }}>
           {widgets.map(({ widget, breakdown }) => (
             <WidgetCard
               key={widget.id}


### PR DESCRIPTION
## Summary
- Dashboard "Events over time" chart now uses hourly data points for the 7d range (was daily with only 7 points — now ~168 for much better resolution)
- Insights widget grid switches from fixed 3-column to responsive `auto-fill` so cards stack properly on mobile
- Property picker in "Add Widget" now only shows metadata columns that have actual data for the selected event (no more empty utm_term, referrer, etc.)

## Test plan
- [ ] Check 7d dashboard chart shows hourly granularity
- [ ] Check 30d chart still shows daily
- [ ] Check 24h chart still shows hourly
- [ ] Open Insights on mobile — widgets should stack to 1 column
- [ ] On desktop, widgets still lay out in a 3-column grid with resize working
- [ ] Add Widget → pick an event → property dropdown only shows columns with data