### PR TITLE
fix: refetch projects after login to avoid empty state

### DIFF
--- a/web/src/pages/Login.test.tsx
+++ b/web/src/pages/Login.test.tsx
@@ -15,6 +15,17 @@ vi.mock('../lib/auth', () => ({
   }),
 }))
 
+const mockRefetch = vi.fn()
+vi.mock('../lib/projects', () => ({
+  useProjects: () => ({
+    projects: [],
+    isLoading: false,
+    refetch: mockRefetch,
+    defaultProjectId: null,
+    setDefaultProjectId: vi.fn(),
+  }),
+}))
+
 vi.mock('react-router-dom', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react-router-dom')>()
   return { ...actual, useNavigate: () => mockNavigate }

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -1,6 +1,7 @@
 import { useState, FormEvent } from 'react'
 import { useNavigate, Navigate } from 'react-router-dom'
 import { useAuth } from '../lib/auth'
+import { useProjects } from '../lib/projects'
 import { ApiError } from '../lib/api'
 import { trackEvent } from '../lib/analytics'
 
@@ -16,6 +17,7 @@ const C = {
 
 export default function Login() {
   const { user, login, isLoading } = useAuth()
+  const { refetch: refetchProjects } = useProjects()
   const navigate = useNavigate()
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
@@ -33,6 +35,7 @@ export default function Login() {
     try {
       await login(username, password)
       trackEvent('login', { method: 'password' })
+      refetchProjects()
       navigate('/dashboard', { replace: true })
     } catch (err) {
       if (err instanceof ApiError && err.status === 401) {


### PR DESCRIPTION
## Summary
- After login, `ProjectProvider` had already fetched projects (while unauthenticated), returning an empty list
- The navigation to `/dashboard` rendered "No project selected" because the project list was empty
- Fix: call `refetchProjects()` after successful login so the project list loads while `DefaultProjectRoute` shows its spinner

## Test plan
- [ ] Log in with valid credentials — should land on the default project dashboard without needing a refresh
- [ ] Verify the project picker in the top nav is populated immediately after login