### PR TITLE
fix: relax CORS, route self-reporting to funnelbarn project, expand tracing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,4 +62,6 @@ FUNNELBARN_ADMIN_PASSWORD=changeme
 # Get your project key from: https://bugbarn.wiebe.xyz/api/v1/setup/funnelbarn
 FUNNELBARN_SELF_ENDPOINT=https://bugbarn.wiebe.xyz
 # FUNNELBARN_SELF_API_KEY=<set via SOPS secret or FUNNELBARN_BUGBARN_API_KEY in CI>
+# Project slug in BugBarn that errors are routed to (default: funnelbarn)
+# FUNNELBARN_SELF_PROJECT=funnelbarn
 FUNNELBARN_ENVIRONMENT=production

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -127,6 +127,7 @@ jobs:
           curl -sf -X POST "${BUGBARN_ENDPOINT}/api/v1/releases" \
             -H "Content-Type: application/json" \
             -H "X-BugBarn-Api-Key: ${BUGBARN_API_KEY}" \
+            -H "X-BugBarn-Project: funnelbarn" \
             -d "{
               \"name\": \"${GITHUB_SHA:0:7}\",
               \"environment\": \"testing\",
@@ -208,6 +209,7 @@ jobs:
           curl -sf -X POST "${BUGBARN_ENDPOINT}/api/v1/releases" \
             -H "Content-Type: application/json" \
             -H "X-BugBarn-Api-Key: ${BUGBARN_API_KEY}" \
+            -H "X-BugBarn-Project: funnelbarn" \
             -d "{
               \"name\": \"${GITHUB_SHA:0:7}\",
               \"environment\": \"staging\",

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -150,6 +150,7 @@ jobs:
           curl -sf -X POST "${BUGBARN_ENDPOINT}/api/v1/releases" \
             -H "Content-Type: application/json" \
             -H "X-BugBarn-Api-Key: ${BUGBARN_API_KEY}" \
+            -H "X-BugBarn-Project: funnelbarn" \
             -d "{
               \"name\": \"${{ github.event.inputs.production_version }}\",
               \"environment\": \"production\",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 - **PR quality gates** (`ci.yml`): go fmt, go vet, staticcheck, tsc, eslint, vitest — runs on all PRs
 - **Testing** (`build-and-test.yml`): auto-deploys every push to `main` → `funnelbarn-testing` namespace
 - **Staging** (`build-and-test.yml`): auto-deploys every push to `main` → `funnelbarn-staging` namespace (runs after testing succeeds)
-- **Production** (`deploy-production.yml`): manual workflow_dispatch — provide a git tag (e.g. `v0.1.0`), it resolves the tag to a commit SHA, verifies images exist in GHCR, then deploys to `funnelbarn` namespace
+- **Production** (`deploy-production.yml`): manual workflow_dispatch — provide a git tag (e.g. `v0.1.0`), it resolves the tag to a commit SHA, verifies images exist in GHCR, then deploys to `funnelbarn-production` namespace
 - Images are tagged by commit SHA in GHCR (`ghcr.io/webwiebe/funnelbarn/service` and `ghcr.io/webwiebe/funnelbarn/web`)
 - All deploy jobs run on self-hosted runners; CI quality checks run on ubuntu
 

--- a/README.md
+++ b/README.md
@@ -115,10 +115,19 @@ funnelbarn user create --username admin --password yourpassword
 | `FUNNELBARN_ADMIN_PASSWORD_BCRYPT` | — | Admin password (bcrypt hash) |
 | `FUNNELBARN_SESSION_SECRET` | random | HMAC secret for session tokens |
 | `FUNNELBARN_SESSION_TTL_SECONDS` | `43200` | Session TTL (12 hours) |
-| `FUNNELBARN_ALLOWED_ORIGINS` | — | CORS origins (CSV) |
+| `FUNNELBARN_ALLOWED_ORIGINS` | — | CORS origins (CSV). Empty = allow any origin (reflected). |
 | `FUNNELBARN_PUBLIC_URL` | — | Public server URL |
 | `FUNNELBARN_SELF_ENDPOINT` | — | BugBarn endpoint for self-reporting |
 | `FUNNELBARN_SELF_API_KEY` | — | BugBarn API key for self-reporting |
+| `FUNNELBARN_SELF_PROJECT` | `funnelbarn` | BugBarn project slug for self-reporting |
+| `FUNNELBARN_ENVIRONMENT` | `production` | Environment tag attached to self-reported events |
+| `FUNNELBARN_DOGFOOD_API_KEY` | — | API key the web app uses to send its own analytics to FunnelBarn |
+| `FUNNELBARN_DOGFOOD_PROJECT` | `funnelbarn` | Project slug the web app dogfoods into |
+| `FUNNELBARN_SPANBARN_ENDPOINT` | — | SpanBarn endpoint for distributed tracing |
+| `FUNNELBARN_SPANBARN_API_KEY` | — | SpanBarn API key |
+| `FUNNELBARN_TRUSTED_PROXIES` | — | CIDRs/IPs whose `X-Forwarded-For` headers are trusted (CSV) |
+| `FUNNELBARN_SETUP_RATE_PER_MINUTE` | `10` | Setup endpoint rate limit (requests/min) |
+| `FUNNELBARN_SETUP_RATE_BURST` | `5` | Setup endpoint burst capacity |
 | `FUNNELBARN_LOG_LEVEL` | `info` | Log verbosity: `debug`, `info`, `warn`, `error` |
 | `FUNNELBARN_LOGIN_RATE_PER_MINUTE` | `20` | Login endpoint rate limit (requests/min) |
 | `FUNNELBARN_LOGIN_RATE_BURST` | `20` | Login endpoint burst capacity |

--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -17,6 +17,7 @@ import (
 	"syscall"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/crypto/bcrypt"
 
 	bb "github.com/wiebe-xyz/bugbarn-go"
@@ -142,7 +143,7 @@ func run() error {
 		bb.Init(bb.Options{
 			APIKey:      cfg.SelfAPIKey,
 			Endpoint:    cfg.SelfEndpoint,
-			ProjectSlug: "funnelbarn",
+			ProjectSlug: cfg.SelfProject,
 			Environment: cfg.SelfEnvironment,
 		})
 		defer bb.Shutdown(2 * time.Second)
@@ -213,6 +214,7 @@ func run() error {
 		TrustedProxies:      cfg.TrustedProxies,
 		BugbarnEndpoint:     cfg.SelfEndpoint,
 		BugbarnIngestKey:    cfg.SelfAPIKey,
+		BugbarnProject:      cfg.SelfProject,
 		DogfoodAPIKey:       cfg.DogfoodAPIKey,
 		DogfoodProject:      cfg.DogfoodProject,
 	})
@@ -347,6 +349,10 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 				// Resolve project from the slug stored in the spool record.
 				// Each DB operation gets a 30s timeout so a stuck write can't block the worker.
 				opCtx, opCancel := context.WithTimeout(ctx, 30*time.Second)
+				opCtx, span := tracing.StartSpan(opCtx, "worker.persist_event",
+					attribute.String("ingest.id", record.IngestID),
+					attribute.String("project.slug", record.ProjectSlug),
+				)
 				if record.ProjectSlug != "" {
 					proj, err := store.EnsureProject(opCtx, record.ProjectSlug)
 					if err == nil {
@@ -357,6 +363,10 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 				}
 
 				persistErr := worker.PersistEvent(opCtx, store, event)
+				if persistErr != nil {
+					tracing.RecordError(span, persistErr)
+				}
+				span.End()
 				opCancel()
 				if persistErr != nil {
 					retryCounts[record.IngestID]++

--- a/deploy/SECRETS.md
+++ b/deploy/SECRETS.md
@@ -10,7 +10,7 @@ Used to decrypt Kubernetes secret manifests per environment.
 | Secret | Used by | Description |
 |--------|---------|-------------|
 | `SOPS_AGE_KEY_TESTING` | build-and-test.yml | Age private key for decrypting `deploy/k8s/testing/secret.yaml` |
-| `SOPS_AGE_KEY_STAGING` | deploy-staging.yml | Age private key for decrypting `deploy/k8s/staging/secret.yaml` |
+| `SOPS_AGE_KEY_STAGING` | build-and-test.yml (`deploy-staging` job) | Age private key for decrypting `deploy/k8s/staging/secret.yaml` |
 | `SOPS_AGE_KEY_PRODUCTION` | deploy-production.yml | Age private key for decrypting `deploy/k8s/production/secret.yaml` |
 
 ## MinIO / S3 Storage

--- a/deploy/etc/funnelbarn.conf.example
+++ b/deploy/etc/funnelbarn.conf.example
@@ -38,3 +38,4 @@ FUNNELBARN_SPOOL_DIR=/var/lib/funnelbarn/spool
 # BugBarn self-error-reporting (optional)
 # FUNNELBARN_SELF_ENDPOINT=https://bugbarn.wiebe.xyz
 # FUNNELBARN_SELF_API_KEY=
+# FUNNELBARN_SELF_PROJECT=funnelbarn

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 )
 
 require (
+	github.com/XSAM/otelsql v0.42.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/XSAM/otelsql v0.42.0 h1:Li0xF4eJUxG2e0x3D4rvRlys1f27yJKvjTh7ljkUP5o=
+github.com/XSAM/otelsql v0.42.0/go.mod h1:4mOrEv+cS1KmKzrvTktvJnstr5GtKSAK+QHvFR9OcpI=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=

--- a/internal/api/abtests.go
+++ b/internal/api/abtests.go
@@ -6,7 +6,10 @@ import (
 	"net/http"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
+	"github.com/wiebe-xyz/funnelbarn/internal/tracing"
 )
 
 // zTestTwoProportions performs a two-proportion z-test.
@@ -125,8 +128,15 @@ func (s *Server) handleABTestAnalysis(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	results, err := s.abtests.AnalyzeABTest(r.Context(), test, from, to)
+	ctx, span := tracing.StartSpan(r.Context(), "abtests.analyze",
+		attribute.String("project.id", test.ProjectID),
+		attribute.String("abtest.id", test.ID),
+		attribute.String("abtest.conversion_event", test.ConversionEvent),
+	)
+	results, err := s.abtests.AnalyzeABTest(ctx, test, from, to)
+	span.End()
 	if err != nil {
+		tracing.RecordError(span, err)
 		mapServiceError(w, err, "handleABTestAnalysis")
 		return
 	}

--- a/internal/api/client_config.go
+++ b/internal/api/client_config.go
@@ -8,6 +8,7 @@ func (s *Server) handleClientConfig(w http.ResponseWriter, r *http.Request) {
 	type response struct {
 		BugbarnEndpoint    string `json:"bugbarn_endpoint"`
 		BugbarnIngestKey   string `json:"bugbarn_ingest_key"`
+		BugbarnProject     string `json:"bugbarn_project,omitempty"`
 		FunnelbarnEndpoint string `json:"funnelbarn_endpoint,omitempty"`
 		FunnelbarnAPIKey   string `json:"funnelbarn_api_key,omitempty"`
 		FunnelbarnProject  string `json:"funnelbarn_project,omitempty"`
@@ -15,6 +16,7 @@ func (s *Server) handleClientConfig(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, response{
 		BugbarnEndpoint:    s.bugbarnEndpoint,
 		BugbarnIngestKey:   s.bugbarnIngestKey,
+		BugbarnProject:     s.bugbarnProject,
 		FunnelbarnEndpoint: s.publicURL,
 		FunnelbarnAPIKey:   s.dogfoodAPIKey,
 		FunnelbarnProject:  s.dogfoodProject,

--- a/internal/api/flags.go
+++ b/internal/api/flags.go
@@ -6,11 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
-
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 	"github.com/wiebe-xyz/funnelbarn/internal/service"
-	"github.com/wiebe-xyz/funnelbarn/internal/tracing"
 )
 
 func (s *Server) handleListFlags(w http.ResponseWriter, r *http.Request) {
@@ -241,13 +238,7 @@ func (s *Server) handleEvaluateFlag(w http.ResponseWriter, r *http.Request) {
 		body.Context = map[string]any{}
 	}
 
-	ctx, span := tracing.StartSpan(r.Context(), "flags.evaluate.handler",
-		attribute.String("flag.key", body.FlagKey),
-		attribute.String("project.id", projectID),
-	)
-	defer span.End()
-
-	result, err := s.flags.EvaluateFlag(ctx, projectID, body.FlagKey, body.Context)
+	result, err := s.flags.EvaluateFlag(r.Context(), projectID, body.FlagKey, body.Context)
 	if err != nil {
 		errorCode := "GENERAL"
 		if strings.Contains(err.Error(), "flag not found") {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -53,6 +53,7 @@ type ServerConfig struct {
 	MetricsToken     string
 	BugbarnEndpoint  string
 	BugbarnIngestKey string
+	BugbarnProject   string
 	DogfoodAPIKey    string
 	DogfoodProject   string
 }
@@ -79,6 +80,7 @@ type Server struct {
 	version          string
 	bugbarnEndpoint  string
 	bugbarnIngestKey string
+	bugbarnProject   string
 	dogfoodAPIKey    string
 	dogfoodProject   string
 	trustedProxies   []string
@@ -120,6 +122,7 @@ func NewServer(cfg ServerConfig) *Server {
 		publicURL:        cfg.PublicURL,
 		bugbarnEndpoint:  cfg.BugbarnEndpoint,
 		bugbarnIngestKey: cfg.BugbarnIngestKey,
+		bugbarnProject:   cfg.BugbarnProject,
 		dogfoodAPIKey:    cfg.DogfoodAPIKey,
 		dogfoodProject:   cfg.DogfoodProject,
 		trustedProxies:   cfg.TrustedProxies,
@@ -264,20 +267,35 @@ func (s *Server) setCORSHeaders(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(s.allowedOrigins) == 0 || (len(s.allowedOrigins) == 1 && s.allowedOrigins[0] == "") {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-	} else {
-		for _, allowed := range s.allowedOrigins {
-			if allowed == "*" || strings.EqualFold(allowed, origin) {
-				w.Header().Set("Access-Control-Allow-Origin", origin)
-				w.Header().Set("Vary", "Origin")
+	open := len(s.allowedOrigins) == 0 || (len(s.allowedOrigins) == 1 && s.allowedOrigins[0] == "")
+	allowed := open
+	if !allowed {
+		for _, o := range s.allowedOrigins {
+			if o == "*" || strings.EqualFold(o, origin) {
+				allowed = true
 				break
 			}
 		}
 	}
+	if !allowed {
+		return
+	}
 
-	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, "+auth.HeaderAPIKey+", X-FunnelBarn-CSRF")
+	// Always reflect the origin (not "*") so credentialed requests work — browsers
+	// reject Allow-Credentials: true combined with Allow-Origin: *.
+	w.Header().Set("Access-Control-Allow-Origin", origin)
+	w.Header().Add("Vary", "Origin")
+
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, PATCH, OPTIONS")
+	// Echo back any headers the client asked for in preflight; fall back to a
+	// permissive default list so trackers using non-standard headers aren't blocked.
+	reqHeaders := r.Header.Get("Access-Control-Request-Headers")
+	if reqHeaders != "" {
+		w.Header().Set("Access-Control-Allow-Headers", reqHeaders)
+		w.Header().Add("Vary", "Access-Control-Request-Headers")
+	} else {
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, "+auth.HeaderAPIKey+", X-FunnelBarn-CSRF, X-Requested-With")
+	}
 	w.Header().Set("Access-Control-Allow-Credentials", "true")
 	w.Header().Set("Access-Control-Max-Age", "86400")
 }

--- a/internal/api/setup_cors_test.go
+++ b/internal/api/setup_cors_test.go
@@ -242,8 +242,8 @@ func TestCORS_EmptyAllowedOriginsAllowsAll(t *testing.T) {
 	srv.ServeHTTP(w, req)
 
 	got := w.Header().Get("Access-Control-Allow-Origin")
-	if got != "*" {
-		t.Errorf("empty allowedOrigins: want ACAO=*, got %q", got)
+	if got != "https://example.com" {
+		t.Errorf("empty allowedOrigins: want reflected origin, got %q", got)
 	}
 }
 

--- a/internal/bblog/panic.go
+++ b/internal/bblog/panic.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"runtime/debug"
 	"time"
 )
@@ -17,9 +18,14 @@ func ReportPanic(endpoint, apiKey string, r any) {
 		return
 	}
 
+	project := os.Getenv("FUNNELBARN_SELF_PROJECT")
+	if project == "" {
+		project = "funnelbarn"
+	}
+
 	body, _ := json.Marshal(map[string]any{
 		"event":   "panic",
-		"project": "funnelbarn",
+		"project": project,
 		"properties": map[string]any{
 			"panic": fmt.Sprint(r),
 			"stack": string(debug.Stack()),
@@ -35,5 +41,6 @@ func ReportPanic(endpoint, apiKey string, r any) {
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-BugBarn-Api-Key", apiKey)
+	req.Header.Set("X-BugBarn-Project", project)
 	_, _ = http.DefaultClient.Do(req)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	PublicURL           string
 	SelfEndpoint        string
 	SelfAPIKey          string
+	SelfProject         string
 	SelfEnvironment     string
 	DogfoodAPIKey       string
 	DogfoodProject      string
@@ -67,6 +68,7 @@ func Load() Config {
 		PublicURL:           os.Getenv("FUNNELBARN_PUBLIC_URL"),
 		SelfEndpoint:        os.Getenv("FUNNELBARN_SELF_ENDPOINT"),
 		SelfAPIKey:          os.Getenv("FUNNELBARN_SELF_API_KEY"),
+		SelfProject:         getenv("FUNNELBARN_SELF_PROJECT", "funnelbarn"),
 		SelfEnvironment:     getenv("FUNNELBARN_ENVIRONMENT", "production"),
 		DogfoodAPIKey:       os.Getenv("FUNNELBARN_DOGFOOD_API_KEY"),
 		DogfoodProject:      getenv("FUNNELBARN_DOGFOOD_PROJECT", "funnelbarn"),

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -6,8 +6,10 @@ import (
 	"embed"
 	"fmt"
 
+	"github.com/XSAM/otelsql"
 	"github.com/pressly/goose/v3"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository/sqlcgen"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	_ "modernc.org/sqlite"
 )
 
@@ -26,7 +28,16 @@ func Open(path string) (*Store, error) {
 		path = ".data/funnelbarn.db"
 	}
 
-	db, err := sql.Open("sqlite", path+"?_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=on")
+	dsn := path + "?_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=on"
+	db, err := otelsql.Open("sqlite", dsn,
+		otelsql.WithAttributes(semconv.DBSystemSqlite),
+		otelsql.WithSpanOptions(otelsql.SpanOptions{
+			OmitConnPrepare:   true,
+			OmitConnResetSession: true,
+			OmitRows:          true,
+			DisableErrSkip:    true,
+		}),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite: %w", err)
 	}

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -32,10 +32,10 @@ func Open(path string) (*Store, error) {
 	db, err := otelsql.Open("sqlite", dsn,
 		otelsql.WithAttributes(semconv.DBSystemSqlite),
 		otelsql.WithSpanOptions(otelsql.SpanOptions{
-			OmitConnPrepare:   true,
+			OmitConnPrepare:      true,
 			OmitConnResetSession: true,
-			OmitRows:          true,
-			DisableErrSkip:    true,
+			OmitRows:             true,
+			DisableErrSkip:       true,
 		}),
 	)
 	if err != nil {

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -78,8 +78,8 @@ func Middleware(next http.Handler) http.Handler {
 			return
 		}
 
-		spanName := r.Method + " " + r.URL.Path
-		ctx, span := tracer.Start(r.Context(), spanName,
+		// Provisional name until the mux resolves the route pattern.
+		ctx, span := tracer.Start(r.Context(), r.Method,
 			trace.WithSpanKind(trace.SpanKindServer),
 			trace.WithAttributes(
 				semconv.HTTPMethod(r.Method),
@@ -91,8 +91,18 @@ func Middleware(next http.Handler) http.Handler {
 		defer span.End()
 
 		rw := &statusWriter{ResponseWriter: w}
-		next.ServeHTTP(rw, r.WithContext(ctx))
+		req := r.WithContext(ctx)
+		next.ServeHTTP(rw, req)
 
+		// After routing, req.Pattern is the matched route template
+		// (e.g. "GET /api/v1/projects/{id}/events") — low cardinality and
+		// much better for grouping in trace search.
+		if req.Pattern != "" {
+			span.SetName(req.Pattern)
+			span.SetAttributes(semconv.HTTPRoute(req.Pattern))
+		} else {
+			span.SetName(r.Method + " " + r.URL.Path)
+		}
 		span.SetAttributes(semconv.HTTPStatusCode(rw.status))
 		if rw.status >= 500 {
 			span.SetStatus(codes.Error, fmt.Sprintf("HTTP %d", rw.status))

--- a/web/src/lib/bugbarn.ts
+++ b/web/src/lib/bugbarn.ts
@@ -6,10 +6,12 @@
 interface ClientConfig {
   bugbarn_endpoint: string
   bugbarn_ingest_key: string
+  bugbarn_project?: string
 }
 
 let endpoint = ''
 let ingestKey = ''
+let project = ''
 let configReady = false
 const pendingQueue: BugBarnPayload[] = []
 
@@ -20,6 +22,7 @@ async function loadConfig(): Promise<void> {
     const cfg: ClientConfig = await res.json()
     endpoint = cfg.bugbarn_endpoint ?? ''
     ingestKey = cfg.bugbarn_ingest_key ?? ''
+    project = cfg.bugbarn_project ?? ''
   } catch {
     // Config fetch failed — reporting falls back to console.error.
   } finally {
@@ -43,12 +46,14 @@ function sendToBugBarn(payload: BugBarnPayload): void {
     return
   }
   try {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'X-BugBarn-Api-Key': ingestKey,
+    }
+    if (project) headers['X-BugBarn-Project'] = project
     fetch(`${endpoint}/api/v1/events`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-BugBarn-Api-Key': ingestKey,
-      },
+      headers,
       body: JSON.stringify(payload),
       keepalive: true,
     }).catch(() => {})


### PR DESCRIPTION
## Summary

Three related fixes wrapped together because they all touch the funnelbarn ⇄ bugbarn boundary.

### CORS — relax requirements
The previous handler combined `Access-Control-Allow-Origin: *` with `Allow-Credentials: true`, which browsers reject for credentialed requests. It also hardcoded the allowed-headers list, so any cross-origin caller using an unlisted header (e.g. `Authorization`) was blocked.

- Reflect the request `Origin` back instead of `*` (when the configured allowlist is empty/`*` or matches).
- Echo `Access-Control-Request-Headers` on preflight; add `Vary: Origin` and `Vary: Access-Control-Request-Headers`.
- Add `PATCH` to the methods list.

### BugBarn routing — stop dumping into "default project"
funnelbarn errors were landing in BugBarn's default project because most of our callers were sending `X-BugBarn-Api-Key` but **not** `X-BugBarn-Project`. Fixed everywhere:

- `internal/api/client_config.go` — `/api/v1/client-config` now exposes `bugbarn_project` to the browser.
- `web/src/lib/bugbarn.ts` — reads it and sends `X-BugBarn-Project` on every event.
- `cmd/funnelbarn/main.go` — Go SDK now picks up the slug from config (was hardcoded).
- `internal/bblog/panic.go` — emergency panic fallback now sets the header too.
- GitHub Actions release markers (`build-and-test.yml` × 2, `deploy-production.yml`) — same.

Configurable via `FUNNELBARN_SELF_PROJECT` (defaults to `funnelbarn`).

### OpenTelemetry — more spans, better names
Backend instrumentation was sparse: HTTP middleware covered the edge, but only a handful of handlers had custom spans, span names included raw paths (high cardinality), and there were no DB-level spans.

- **Route-pattern span names**: middleware now sets the span name from `req.Pattern` after routing (e.g. `GET /api/v1/projects/{id}/events`) and adds `http.route`.
- **DB tracing**: SQLite driver wrapped with `github.com/XSAM/otelsql`. Every `Query/Exec/Ping` becomes a child span tagged with `db.system=sqlite`. Funnel/A-B-test loop queries each get their own span automatically.
- **New parent spans**: `worker.persist_event` (spool-drain loop), `abtests.analyze`.
- **Removed**: redundant `flags.evaluate.handler` span (service-layer span already covers it).

### Docs
- `README.md` — env-var table was missing `FUNNELBARN_ENVIRONMENT`, `DOGFOOD_*`, `SPANBARN_*`, `TRUSTED_PROXIES`, `SETUP_RATE_*`, and the new `SELF_PROJECT`. Added.
- `CLAUDE.md` — production namespace `funnelbarn` → `funnelbarn-production`.
- `deploy/SECRETS.md` — `SOPS_AGE_KEY_STAGING` no longer references the non-existent `deploy-staging.yml`.
- `.env.example` / `deploy/etc/funnelbarn.conf.example` — documented `FUNNELBARN_SELF_PROJECT`.

## Test plan

- [ ] CORS: cross-origin GET from a non-allowlisted origin returns `Access-Control-Allow-Origin: <origin>` + `Vary: Origin` (not `*`); preflight echoes requested headers.
- [ ] After deploy: new errors from the funnelbarn web app land in the `funnelbarn` project in BugBarn, not `default`.
- [ ] After deploy: release marker on the next push to `main` appears in the `funnelbarn` project.
- [ ] If SpanBarn is configured: traces for a funnel-analyze request show route-templated span name, a `funnels.analyze` child, and per-step `sqlite.query` grandchildren.
- [ ] `go test ./...` passes (verified locally).