### PR TITLE
fix: stop reporting expected errors to BugBarn

### DIFF
--- a/web/src/lib/projects.tsx
+++ b/web/src/lib/projects.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useState, ReactNode, useCallback } from 'react'
-import { api, Project } from './api'
+import { api, ApiError, Project } from './api'
 import { reportError } from './bugbarn'
 
 const STORAGE_KEY = 'funnelbarn_default_project'
@@ -30,7 +30,14 @@ export function ProjectProvider({ children }: { children: ReactNode }) {
     setIsLoading(true)
     api.listProjects()
       .then((d) => setProjects(d.projects || []))
-      .catch((e) => { reportError(e, { source: 'ProjectProvider.listProjects' }); setProjects([]) })
+      .catch((e) => {
+        // 401 is expected when the session has expired or the user isn't logged in yet;
+        // the API client already redirects to /login. Don't pollute BugBarn with it.
+        if (!(e instanceof ApiError && e.status === 401)) {
+          reportError(e, { source: 'ProjectProvider.listProjects' })
+        }
+        setProjects([])
+      })
       .finally(() => setIsLoading(false))
   }, [])
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -18,6 +18,11 @@ window.onerror = (message, source, lineno, colno, error) => {
 
 // Global unhandled promise rejection handler.
 window.onunhandledrejection = (event: PromiseRejectionEvent) => {
+  // ServiceWorker registration failures (typically untrusted TLS in dev/test
+  // environments or sandboxed browsers) are not actionable from app code.
+  const msg = event.reason instanceof Error ? event.reason.message : String(event.reason)
+  if (msg.includes('Failed to register a ServiceWorker')) return
+
   reportError(event.reason, {
     source: 'window.onunhandledrejection',
   })


### PR DESCRIPTION
## Summary

Two BugBarn issues in the freshly-routed `funnelbarn` project (FUN-1 / FUN-2) were app-side noise, not real bugs:

- **FUN-2 — Unauthorized at ProjectProvider.listProjects (4 events).** `api.request()` already redirects to `/login` on 401, but `ProjectProvider`'s `.catch()` then re-reported the same `ApiError(401)` to BugBarn. Only forward non-401 errors.
- **FUN-1 — ServiceWorker SSL registration failure (9 events).** Internal `*.nijmegen.wiebe.xyz` subdomains use a Caddy-issued cert that headless browsers (Playwright e2e) don't trust, so SW registration fails. Not actionable from app code — filter it from `window.onunhandledrejection`.

## Test plan

- [x] `npx tsc --noEmit` + `vitest run` pass locally (102 tests).
- [ ] After deploy: FUN-1 and FUN-2 stop accumulating new events in BugBarn.