### PR TITLE
ci: fix release tag bump, e2e CSRF, document gh CLI prod deploy

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -30,11 +30,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Get latest tag
         id: latest_tag
         run: |
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          # fetch-tags: true above doesn't always pull every tag (depends on the
+          # runner's local mirror state), so re-fetch explicitly to be safe.
+          git fetch --tags --force origin
+          LATEST_TAG=$(git tag --sort=-v:refname | head -n 1)
+          if [ -z "${LATEST_TAG}" ]; then
+            LATEST_TAG="v0.0.0"
+          fi
           echo "tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
 
       - name: Calculate next version

--- a/deploy/RUNBOOK.md
+++ b/deploy/RUNBOOK.md
@@ -110,8 +110,16 @@ Production deploys are gated behind the `Deploy Production` GitHub Actions workf
 2. Click **Run workflow**.
 3. Fill in:
    - **Version to deploy** — e.g. `v0.2.0` (must match an existing GHCR image tag).
-   - **Confirmed** — check the box to confirm the version is validated on staging.
+   - **Confirmed** — check the box to confirm the version is validated on staging. The workflow fails fast in the `preflight` job if this is left unchecked.
 4. Click **Run workflow**.
+
+Equivalent `gh` CLI invocation (note both inputs are required):
+
+```sh
+gh workflow run deploy-production.yml \
+  -f production_version=v0.2.0 \
+  -f confirmed=true
+```
 
 The workflow will:
 - Verify the images exist in GHCR.

--- a/e2e/api.spec.ts
+++ b/e2e/api.spec.ts
@@ -44,13 +44,20 @@ test.describe('API: auth', () => {
 })
 
 test.describe('API: projects', () => {
-  // Helper: log in and return the session context
-  async function loginContext(request: import('@playwright/test').APIRequestContext) {
+  // Helper: log in and return the CSRF token the server set on the response.
+  // The server enforces double-submit CSRF on mutating methods (POST/PUT/DELETE/PATCH),
+  // so callers need to pass this token as X-FunnelBarn-CSRF for those requests.
+  async function loginContext(request: import('@playwright/test').APIRequestContext): Promise<string> {
     const loginResp = await request.post('/api/v1/login', {
       data: { username: 'wiebe', password: 'wiebe' },
     })
     expect(loginResp.status()).toBe(200)
-    return loginResp
+    const setCookies = loginResp.headersArray().filter((h) => h.name.toLowerCase() === 'set-cookie')
+    for (const c of setCookies) {
+      const match = c.value.match(/funnelbarn_csrf=([^;]+)/)
+      if (match) return decodeURIComponent(match[1])
+    }
+    throw new Error('login did not set funnelbarn_csrf cookie')
   }
 
   test('GET /api/v1/projects returns array after login', async ({ request }) => {
@@ -62,9 +69,10 @@ test.describe('API: projects', () => {
   })
 
   test('POST /api/v1/projects creates a new project', async ({ request }) => {
-    await loginContext(request)
+    const csrf = await loginContext(request)
     const slug = `e2e-test-${Date.now()}`
     const resp = await request.post('/api/v1/projects', {
+      headers: { 'X-FunnelBarn-CSRF': csrf },
       data: { name: 'E2E Test Project', slug },
     })
     expect(resp.status()).toBe(201)


### PR DESCRIPTION
## Summary

Three CI loose ends surfaced during today's deploy work.

### `Binary Release` workflow occasionally tries to recreate the latest tag
On the merge of #95 the workflow attempted to push `v0.0.137` (already existed). The cause is `git describe --tags --abbrev=0` returning a stale tag when the runner's mirror doesn't have the freshest tags fetched. With `fetch-depth: 0` alone, `actions/checkout@v4` doesn't necessarily fetch every tag. Now we set `fetch-tags: true`, explicitly `git fetch --tags --force origin`, and pick the highest version by SemVer order.

### `e2e` job has been red on every main push for the last 5 builds
`POST /api/v1/projects` was returning 403, not 201 — the test didn't send `X-FunnelBarn-CSRF`. `loginContext` now extracts the `funnelbarn_csrf` cookie set by `/api/v1/login` and the create-project test passes the token in the `X-FunnelBarn-CSRF` header.

### RUNBOOK didn't mention `confirmed=true` for `gh workflow run`
The UI form makes the requirement obvious, but the CLI invocation silently fails preflight if you forget. Added a note + the exact `gh workflow run` command.

## Test plan

- [ ] On merge: the new Binary Release run cuts `v0.0.140` (or higher) without collision.
- [ ] On merge: the `e2e` job in `Build and Deploy Testing` runs green for the first time in 5+ builds.
- [ ] Reviewer: confirm RUNBOOK CLI snippet is what you'd expect to copy/paste.