### PR TITLE
test: expand HTTP/tracing/stats coverage, fix flag 404 mapping

### DIFF
--- a/internal/api/flags_crud_test.go
+++ b/internal/api/flags_crud_test.go
@@ -1,0 +1,185 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wiebe-xyz/funnelbarn/internal/auth"
+	"github.com/wiebe-xyz/funnelbarn/internal/repository"
+)
+
+// sessionAndCSRF mints a session token + matching CSRF for a server with auth
+// enabled. Both must come from the same token (server derives CSRF from cookie).
+func sessionAndCSRF(t *testing.T, srv *Server, username string) (*http.Cookie, string) {
+	t.Helper()
+	token, expires, err := srv.sessionManager.Create(username)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	return auth.SessionCookie(token, expires, false), auth.CSRFToken(token)
+}
+
+func TestHandleListFlags_Empty(t *testing.T) {
+	srv, store := newAuthedServer(t)
+	ctx := context.Background()
+	p, _ := store.CreateProject(ctx, "Empty", "empty")
+	cookie, _ := sessionAndCSRF(t, srv, "u")
+
+	w := getJSON(t, srv, "/api/v1/projects/"+p.ID+"/flags", cookie)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list flags: want 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	flags, ok := resp["flags"].([]any)
+	if !ok {
+		t.Fatalf("response missing flags array: %v", resp)
+	}
+	if len(flags) != 0 {
+		t.Errorf("expected empty flags list, got %d", len(flags))
+	}
+}
+
+func TestHandleListFlags_ReturnsCreated(t *testing.T) {
+	srv, store := newAuthedServer(t)
+	ctx := context.Background()
+	p, _ := store.CreateProject(ctx, "WithFlags", "withflags")
+	_, _ = store.CreateFlag(ctx, repository.FeatureFlag{
+		ProjectID:      p.ID,
+		FlagKey:        "feature_x",
+		Name:           "Feature X",
+		FlagType:       "release",
+		Variants:       `{"on":true,"off":false}`,
+		DefaultVariant: "off",
+		Split:          `{"on":50,"off":50}`,
+		Status:         "active",
+	})
+	cookie, _ := sessionAndCSRF(t, srv, "u")
+
+	w := getJSON(t, srv, "/api/v1/projects/"+p.ID+"/flags", cookie)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list flags: want 200, got %d", w.Code)
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	flags := resp["flags"].([]any)
+	if len(flags) != 1 {
+		t.Fatalf("expected 1 flag, got %d", len(flags))
+	}
+}
+
+func TestHandleCreateFlag(t *testing.T) {
+	srv, store := newAuthedServer(t)
+	ctx := context.Background()
+	p, _ := store.CreateProject(ctx, "CreateFlag", "createflag")
+	cookie, csrf := sessionAndCSRF(t, srv, "u")
+
+	// The flag handler takes variants/split as already-JSON-encoded strings.
+	w := postJSONWithCSRF(t, srv, "/api/v1/projects/"+p.ID+"/flags", map[string]any{
+		"flag_key":        "new_flag",
+		"name":            "New Flag",
+		"flag_type":       "release",
+		"variants":        `{"on":true,"off":false}`,
+		"default_variant": "off",
+		"split":           `{"on":0,"off":100}`,
+	}, cookie, csrf)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create flag: want 201, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["flag_key"] != "new_flag" {
+		t.Errorf("flag_key: got %v", resp["flag_key"])
+	}
+}
+
+func TestHandleCreateFlag_MissingKey_Returns422(t *testing.T) {
+	srv, store := newAuthedServer(t)
+	ctx := context.Background()
+	p, _ := store.CreateProject(ctx, "BadFlag", "badflag")
+	cookie, csrf := sessionAndCSRF(t, srv, "u")
+
+	w := postJSONWithCSRF(t, srv, "/api/v1/projects/"+p.ID+"/flags", map[string]any{
+		"name": "no key",
+	}, cookie, csrf)
+
+	if w.Code != http.StatusUnprocessableEntity && w.Code != http.StatusBadRequest {
+		t.Errorf("expected 4xx for missing flag_key, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleGetFlag(t *testing.T) {
+	srv, store := newAuthedServer(t)
+	ctx := context.Background()
+	p, _ := store.CreateProject(ctx, "GetFlag", "getflag")
+	flag, _ := store.CreateFlag(ctx, repository.FeatureFlag{
+		ProjectID:      p.ID,
+		FlagKey:        "get_me",
+		Name:           "Get Me",
+		FlagType:       "release",
+		Variants:       `{"on":true}`,
+		DefaultVariant: "on",
+		Split:          `{"on":100}`,
+		Status:         "active",
+	})
+	cookie, _ := sessionAndCSRF(t, srv, "u")
+
+	w := getJSON(t, srv, "/api/v1/projects/"+p.ID+"/flags/"+flag.ID, cookie)
+	if w.Code != http.StatusOK {
+		t.Fatalf("get flag: want 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["id"] != flag.ID {
+		t.Errorf("id: want %s, got %v", flag.ID, resp["id"])
+	}
+}
+
+func TestHandleGetFlag_NotFound(t *testing.T) {
+	srv, store := newAuthedServer(t)
+	ctx := context.Background()
+	p, _ := store.CreateProject(ctx, "MissingFlag", "missingflag")
+	cookie, _ := sessionAndCSRF(t, srv, "u")
+
+	w := getJSON(t, srv, "/api/v1/projects/"+p.ID+"/flags/does-not-exist", cookie)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("get missing flag: want 404, got %d", w.Code)
+	}
+}
+
+func TestHandleDeleteFlag(t *testing.T) {
+	srv, store := newAuthedServer(t)
+	ctx := context.Background()
+	p, _ := store.CreateProject(ctx, "DeleteFlag", "deleteflag")
+	flag, _ := store.CreateFlag(ctx, repository.FeatureFlag{
+		ProjectID:      p.ID,
+		FlagKey:        "kill_me",
+		Name:           "Kill Me",
+		FlagType:       "release",
+		Variants:       `{"on":true}`,
+		DefaultVariant: "on",
+		Split:          `{"on":100}`,
+		Status:         "active",
+	})
+	cookie, csrf := sessionAndCSRF(t, srv, "u")
+
+	// DELETE with CSRF header set on the request manually (deleteReq doesn't take one).
+	req, _ := http.NewRequest(http.MethodDelete, "/api/v1/projects/"+p.ID+"/flags/"+flag.ID, nil)
+	req.AddCookie(cookie)
+	req.Header.Set("X-FunnelBarn-CSRF", csrf)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent && w.Code != http.StatusOK {
+		t.Errorf("delete flag: want 2xx, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	// Confirm it's gone.
+	w2 := getJSON(t, srv, "/api/v1/projects/"+p.ID+"/flags/"+flag.ID, cookie)
+	if w2.Code != http.StatusNotFound {
+		t.Errorf("after delete: want 404, got %d", w2.Code)
+	}
+}

--- a/internal/api/flags_evaluate_test.go
+++ b/internal/api/flags_evaluate_test.go
@@ -1,0 +1,255 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/wiebe-xyz/funnelbarn/internal/auth"
+	"github.com/wiebe-xyz/funnelbarn/internal/ingest"
+	"github.com/wiebe-xyz/funnelbarn/internal/repository"
+	"github.com/wiebe-xyz/funnelbarn/internal/service"
+)
+
+// ---------------------------------------------------------------------------
+// handlePlaygroundEvaluateFlag — session-authed eval used by the dashboard.
+// ---------------------------------------------------------------------------
+
+// playgroundFlag creates a project + simple boolean flag and returns both,
+// plus the CSRF token a session-authed request needs.
+func playgroundFlag(t *testing.T, srv *Server, store *repository.Store, slug string) (repository.Project, repository.FeatureFlag, *http.Cookie, string) {
+	t.Helper()
+	ctx := context.Background()
+	p, err := store.CreateProject(ctx, "FlagEval-"+slug, "flageval-"+slug)
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	flag, err := store.CreateFlag(ctx, repository.FeatureFlag{
+		ProjectID:      p.ID,
+		FlagKey:        "test_flag",
+		Name:           "Test Flag",
+		FlagType:       "release",
+		Variants:       `{"on":true,"off":false}`,
+		DefaultVariant: "off",
+		Split:          `{"on":100,"off":0}`,
+		Status:         "active",
+	})
+	if err != nil {
+		t.Fatalf("CreateFlag: %v", err)
+	}
+	// Mint a session token once and derive both the cookie and the matching
+	// CSRF token from it — they have to come from the same token because the
+	// CSRF check on the server side computes CSRFToken(cookie.Value).
+	token, expires, err := srv.sessionManager.Create("test-user")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	return p, flag, auth.SessionCookie(token, expires, false), auth.CSRFToken(token)
+}
+
+func TestPlaygroundEvaluate_HappyPath(t *testing.T) {
+	srv, store := newAuthedServer(t)
+	p, flag, cookie, csrf := playgroundFlag(t, srv, store, "happy")
+
+	w := postJSONWithCSRF(t, srv, "/api/v1/projects/"+p.ID+"/flags/evaluate", map[string]any{
+		"flag_key": flag.FlagKey,
+		"context":  map[string]any{"user_id": "u1"},
+	}, cookie, csrf)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["flag_key"] != flag.FlagKey {
+		t.Errorf("flag_key: want %q, got %v", flag.FlagKey, resp["flag_key"])
+	}
+	if _, ok := resp["variant"]; !ok {
+		t.Error("response missing 'variant'")
+	}
+	if _, ok := resp["reason"]; !ok {
+		t.Error("response missing 'reason'")
+	}
+}
+
+func TestPlaygroundEvaluate_FlagNotFound_ReturnsErrorReason(t *testing.T) {
+	srv, store := newAuthedServer(t)
+	p, _, cookie, csrf := playgroundFlag(t, srv, store, "notfound")
+
+	w := postJSONWithCSRF(t, srv, "/api/v1/projects/"+p.ID+"/flags/evaluate", map[string]any{
+		"flag_key":      "does_not_exist",
+		"default_value": "fallback",
+		"context":       map[string]any{},
+	}, cookie, csrf)
+
+	// The handler intentionally returns 200 with reason=ERROR so SDKs can fall
+	// back to the default value rather than crashing on a 404.
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200 for missing flag, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["reason"] != "ERROR" {
+		t.Errorf("reason: want ERROR, got %v", resp["reason"])
+	}
+	if resp["error_code"] != "FLAG_NOT_FOUND" {
+		t.Errorf("error_code: want FLAG_NOT_FOUND, got %v", resp["error_code"])
+	}
+	if resp["value"] != "fallback" {
+		t.Errorf("value: want fallback (default), got %v", resp["value"])
+	}
+}
+
+func TestPlaygroundEvaluate_MissingFlagKey_Returns422(t *testing.T) {
+	srv, store := newAuthedServer(t)
+	p, _, cookie, csrf := playgroundFlag(t, srv, store, "missingkey")
+
+	w := postJSONWithCSRF(t, srv, "/api/v1/projects/"+p.ID+"/flags/evaluate", map[string]any{
+		"context": map[string]any{"user_id": "u1"},
+	}, cookie, csrf)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("want 422, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestPlaygroundEvaluate_NoSession_Returns401(t *testing.T) {
+	srv, store := newAuthedServer(t)
+	p, flag, _, _ := playgroundFlag(t, srv, store, "noses")
+
+	// No cookie, no CSRF — requireSession should reject before reaching the handler.
+	w := postJSON(t, srv, "/api/v1/projects/"+p.ID+"/flags/evaluate", map[string]any{
+		"flag_key": flag.FlagKey,
+	}, nil)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("want 401, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestPlaygroundEvaluate_MissingCSRF_Returns403(t *testing.T) {
+	srv, store := newAuthedServer(t)
+	p, flag, cookie, _ := playgroundFlag(t, srv, store, "nocsrf")
+
+	w := postJSONWithCSRF(t, srv, "/api/v1/projects/"+p.ID+"/flags/evaluate", map[string]any{
+		"flag_key": flag.FlagKey,
+	}, cookie, "" /* empty CSRF */)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("want 403, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestPlaygroundEvaluate_ContextSplitsEvenly(t *testing.T) {
+	// Confirm the context map is actually being passed through — flag with a
+	// 50/50 split should produce both variants across a handful of distinct
+	// user_ids, not always the same one.
+	srv, store := newAuthedServer(t)
+	ctx := context.Background()
+	p, _ := store.CreateProject(ctx, "FlagEval-Split", "flageval-split")
+	flag, _ := store.CreateFlag(ctx, repository.FeatureFlag{
+		ProjectID:      p.ID,
+		FlagKey:        "split_test",
+		Name:           "Split Test",
+		FlagType:       "experiment",
+		Variants:       `{"a":"a","b":"b"}`,
+		DefaultVariant: "a",
+		Split:          `{"a":50,"b":50}`,
+		Status:         "active",
+	})
+
+	token, expires, _ := srv.sessionManager.Create("test-user")
+	cookie := auth.SessionCookie(token, expires, false)
+	csrf := auth.CSRFToken(token)
+
+	// 50 distinct user IDs — overwhelmingly improbable to all bucket to the
+	// same variant if the context is being honored.
+	userIDs := []string{
+		"alice", "bob", "carol", "dave", "eve", "frank", "grace", "heidi",
+		"ivan", "judy", "kim", "leo", "mallory", "nick", "olivia", "peggy",
+		"quentin", "ruth", "steve", "trent", "ursula", "victor", "wendy",
+		"xavier", "yvonne", "zoe", "alex", "blake", "casey", "drew",
+		"erin", "finley", "gale", "harper", "indigo", "jordan", "kai",
+		"lane", "morgan", "noel", "oakley", "parker", "quinn", "river",
+		"sage", "taylor", "umi", "val", "winter", "yael",
+	}
+	seen := map[string]int{}
+	for _, uid := range userIDs {
+		w := postJSONWithCSRF(t, srv, "/api/v1/projects/"+p.ID+"/flags/evaluate", map[string]any{
+			"flag_key": flag.FlagKey,
+			"context":  map[string]any{"targeting_key": uid},
+		}, cookie, csrf)
+		if w.Code != http.StatusOK {
+			t.Fatalf("user_id %q: want 200, got %d", uid, w.Code)
+		}
+		var resp map[string]any
+		_ = json.Unmarshal(w.Body.Bytes(), &resp)
+		if v, ok := resp["variant"].(string); ok {
+			seen[v]++
+		}
+	}
+	if len(seen) < 2 {
+		t.Errorf("expected both variants across %d distinct user_ids, only saw %v", len(userIDs), seen)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleClientConfig — public config, no auth.
+// ---------------------------------------------------------------------------
+
+func TestHandleClientConfig_ExposesBugbarnFields(t *testing.T) {
+	store := openMemoryStore(t)
+	sp := newTestSpool(t)
+	ingestHandler := ingest.NewHandler(auth.New("test-key"), sp, 0)
+	sm := auth.NewSessionManager("test-secret", time.Hour)
+	userAuth, _ := auth.NewUserAuthenticator("", "", "")
+
+	srv := NewServer(ServerConfig{
+		Ingest:              ingestHandler,
+		Projects:            service.NewProjectService(store),
+		Funnels:             service.NewFunnelService(store),
+		ABTests:             service.NewABTestService(store),
+		Flags:               service.NewFlagService(store),
+		Events:              service.NewEventService(store),
+		Sessions:            service.NewSessionService(store),
+		APIKeys:             service.NewAPIKeyService(store),
+		Widgets:             service.NewWidgetService(store),
+		UserAuth:            userAuth,
+		SessionManager:      sm,
+		SessionSecret:       "test-secret",
+		PublicURL:           "http://localhost",
+		LoginRatePerMinute:  1000,
+		LoginRateBurst:      1000,
+		APIRatePerMinute:    1000,
+		APIRateBurst:        1000,
+		IngestRatePerMinute: 1000,
+		IngestRateBurst:     1000,
+		DB:                  store,
+		Version:             "test",
+		BugbarnEndpoint:     "https://bugbarn.example.com",
+		BugbarnIngestKey:    "secret-key",
+		BugbarnProject:      "funnelbarn",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/client-config", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["bugbarn_endpoint"] != "https://bugbarn.example.com" {
+		t.Errorf("bugbarn_endpoint: got %v", resp["bugbarn_endpoint"])
+	}
+	if resp["bugbarn_ingest_key"] != "secret-key" {
+		t.Errorf("bugbarn_ingest_key: got %v", resp["bugbarn_ingest_key"])
+	}
+	if resp["bugbarn_project"] != "funnelbarn" {
+		t.Errorf("bugbarn_project: got %v (expected dogfood routing slug)", resp["bugbarn_project"])
+	}
+}

--- a/internal/api/pure_helpers_test.go
+++ b/internal/api/pure_helpers_test.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// zTestTwoProportions — pure stats helper, covers a few representative cases.
+// ---------------------------------------------------------------------------
+
+func TestZTestTwoProportions(t *testing.T) {
+	cases := []struct {
+		name          string
+		n1, x1, n2, x2 int64
+		wantZero      bool
+		wantSig       bool
+	}{
+		{"zero sample n1", 0, 0, 100, 50, true, false},
+		{"zero sample n2", 100, 50, 0, 0, true, false},
+		// Both arms 0% — pooled p is 0, can't compute.
+		{"both zero conversions", 100, 0, 100, 0, true, false},
+		// Both arms 100% — pooled p is 1, can't compute.
+		{"both full conversions", 100, 100, 100, 100, true, false},
+		// Equal rates → z = 0, not significant. Pure-zero is the *correct*
+		// answer here (numerator of the z stat is p1 - p2 = 0), so allow it
+		// alongside other non-significant cases.
+		{"equal rates", 1000, 100, 1000, 100, true, false},
+		// Strong difference, large samples → significant.
+		{"large diff large sample", 1000, 500, 1000, 100, false, true},
+		// Small difference, small sample → not significant.
+		{"small diff small sample", 50, 25, 50, 22, false, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			z, sig := zTestTwoProportions(c.n1, c.x1, c.n2, c.x2)
+			if c.wantZero && z != 0 {
+				t.Errorf("z: want 0, got %f", z)
+			}
+			if !c.wantZero && z == 0 {
+				t.Error("z: got 0 but expected a non-zero value")
+			}
+			if sig != c.wantSig {
+				t.Errorf("significant: want %v, got %v (z=%f)", c.wantSig, sig, z)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// addPaginationHeaders — emits a Link: rel="next" only when there *might* be more.
+// ---------------------------------------------------------------------------
+
+func TestAddPaginationHeaders_NoNextWhenUnderLimit(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/v1/projects/p/events?limit=50", nil)
+	w := httptest.NewRecorder()
+	addPaginationHeaders(w, req, 50, 0, 10) // returned fewer than limit → no next page
+	if got := w.Header().Get("Link"); got != "" {
+		t.Errorf("no-next: expected empty Link, got %q", got)
+	}
+}
+
+func TestAddPaginationHeaders_SetsNextWhenAtLimit(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/v1/projects/p/events?limit=50&offset=0", nil)
+	w := httptest.NewRecorder()
+	addPaginationHeaders(w, req, 50, 0, 50) // exactly limit → possibly more
+	link := w.Header().Get("Link")
+	if link == "" {
+		t.Fatal("expected Link header with next page")
+	}
+	if !strings.Contains(link, `rel="next"`) {
+		t.Errorf("Link: want rel=\"next\", got %q", link)
+	}
+	if !strings.Contains(link, "offset=50") {
+		t.Errorf("Link: want offset=50, got %q", link)
+	}
+	if !strings.Contains(link, "limit=50") {
+		t.Errorf("Link: want limit=50, got %q", link)
+	}
+}
+
+func TestAddPaginationHeaders_PreservesOtherQueryParams(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/v1/events?from=2026-01-01&to=2026-02-01&limit=20", nil)
+	w := httptest.NewRecorder()
+	addPaginationHeaders(w, req, 20, 0, 20)
+	link := w.Header().Get("Link")
+	if !strings.Contains(link, "from=2026-01-01") {
+		t.Errorf("Link should preserve from param, got %q", link)
+	}
+	if !strings.Contains(link, "to=2026-02-01") {
+		t.Errorf("Link should preserve to param, got %q", link)
+	}
+}

--- a/internal/api/pure_helpers_test.go
+++ b/internal/api/pure_helpers_test.go
@@ -12,10 +12,10 @@ import (
 
 func TestZTestTwoProportions(t *testing.T) {
 	cases := []struct {
-		name          string
+		name           string
 		n1, x1, n2, x2 int64
-		wantZero      bool
-		wantSig       bool
+		wantZero       bool
+		wantSig        bool
 	}{
 		{"zero sample n1", 0, 0, 100, 50, true, false},
 		{"zero sample n2", 100, 50, 0, 0, true, false},

--- a/internal/service/flags.go
+++ b/internal/service/flags.go
@@ -3,8 +3,10 @@ package service
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -12,6 +14,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
+	"github.com/wiebe-xyz/funnelbarn/internal/domain"
 	"github.com/wiebe-xyz/funnelbarn/internal/ports"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 	"github.com/wiebe-xyz/funnelbarn/internal/tracing"
@@ -94,11 +97,25 @@ func (svc *FlagService) CreateFlag(ctx context.Context, f repository.FeatureFlag
 }
 
 func (svc *FlagService) GetFlag(ctx context.Context, id string) (repository.FeatureFlag, error) {
-	return svc.store.FlagByID(ctx, id)
+	f, err := svc.store.FlagByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return repository.FeatureFlag{}, fmt.Errorf("%w: flag %s", domain.ErrNotFound, id)
+		}
+		return repository.FeatureFlag{}, err
+	}
+	return f, nil
 }
 
 func (svc *FlagService) GetFlagByKey(ctx context.Context, projectID, flagKey string) (repository.FeatureFlag, error) {
-	return svc.store.FlagByKey(ctx, projectID, flagKey)
+	f, err := svc.store.FlagByKey(ctx, projectID, flagKey)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return repository.FeatureFlag{}, fmt.Errorf("%w: flag %s", domain.ErrNotFound, flagKey)
+		}
+		return repository.FeatureFlag{}, err
+	}
+	return f, nil
 }
 
 func (svc *FlagService) ListFlags(ctx context.Context, projectID string) ([]repository.FeatureFlag, error) {

--- a/internal/service/flags.go
+++ b/internal/service/flags.go
@@ -3,8 +3,10 @@ package service
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -13,6 +15,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
+	"github.com/wiebe-xyz/funnelbarn/internal/domain"
 	"github.com/wiebe-xyz/funnelbarn/internal/ports"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 	"github.com/wiebe-xyz/funnelbarn/internal/tracing"
@@ -95,11 +98,25 @@ func (svc *FlagService) CreateFlag(ctx context.Context, f repository.FeatureFlag
 }
 
 func (svc *FlagService) GetFlag(ctx context.Context, id string) (repository.FeatureFlag, error) {
-	return svc.store.FlagByID(ctx, id)
+	f, err := svc.store.FlagByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return repository.FeatureFlag{}, fmt.Errorf("%w: flag %s", domain.ErrNotFound, id)
+		}
+		return repository.FeatureFlag{}, err
+	}
+	return f, nil
 }
 
 func (svc *FlagService) GetFlagByKey(ctx context.Context, projectID, flagKey string) (repository.FeatureFlag, error) {
-	return svc.store.FlagByKey(ctx, projectID, flagKey)
+	f, err := svc.store.FlagByKey(ctx, projectID, flagKey)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return repository.FeatureFlag{}, fmt.Errorf("%w: flag %s", domain.ErrNotFound, flagKey)
+		}
+		return repository.FeatureFlag{}, err
+	}
+	return f, nil
 }
 
 func (svc *FlagService) ListFlags(ctx context.Context, projectID string) ([]repository.FeatureFlag, error) {

--- a/internal/tracing/tracing_test.go
+++ b/internal/tracing/tracing_test.go
@@ -1,0 +1,122 @@
+package tracing
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestInit_NoEndpointReturnsNoopShutdown(t *testing.T) {
+	shutdown, err := Init(context.Background(), Config{ServiceName: "test"})
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if shutdown == nil {
+		t.Fatal("shutdown func is nil")
+	}
+	if err := shutdown(context.Background()); err != nil {
+		t.Errorf("noop shutdown returned error: %v", err)
+	}
+	if Tracer() == nil {
+		t.Error("Tracer() is nil after Init")
+	}
+}
+
+func TestMiddleware_PropagatesHandlerStatusToSpanName(t *testing.T) {
+	// Init in noop mode so spans are created but never exported.
+	_, _ = Init(context.Background(), Config{ServiceName: "test"})
+
+	called := false
+	h := Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		// Routing has already happened by the time the handler runs, so the
+		// middleware will see Pattern populated when it sets the final span name.
+		w.WriteHeader(http.StatusNoContent)
+		_, _ = w.Write([]byte("ok"))
+	}))
+
+	// Wrap the middleware in a ServeMux so r.Pattern gets populated.
+	mux := http.NewServeMux()
+	mux.Handle("GET /widgets/{id}", h)
+
+	req := httptest.NewRequest(http.MethodGet, "/widgets/42", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if !called {
+		t.Error("inner handler was not called")
+	}
+	if w.Code != http.StatusNoContent {
+		t.Errorf("status: want 204, got %d", w.Code)
+	}
+}
+
+func TestMiddleware_NoOpWhenTracerNil(t *testing.T) {
+	// Pretend tracer never got set up — middleware should just pass through.
+	prev := tracer
+	tracer = nil
+	defer func() { tracer = prev }()
+
+	called := false
+	h := Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if !called {
+		t.Error("handler not invoked when tracer nil")
+	}
+}
+
+func TestStatusWriter_DefaultsTo200OnImplicitWrite(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sw := &statusWriter{ResponseWriter: rec}
+	if _, err := sw.Write([]byte("body")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if sw.status != http.StatusOK {
+		t.Errorf("implicit status: want 200, got %d", sw.status)
+	}
+}
+
+func TestStatusWriter_CapturesExplicitStatus(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sw := &statusWriter{ResponseWriter: rec}
+	sw.WriteHeader(http.StatusTeapot)
+	if sw.status != http.StatusTeapot {
+		t.Errorf("status: want 418, got %d", sw.status)
+	}
+}
+
+func TestStartSpan_ReturnsExistingContextWhenTracerNil(t *testing.T) {
+	prev := tracer
+	tracer = nil
+	defer func() { tracer = prev }()
+
+	ctx := context.Background()
+	got, span := StartSpan(ctx, "noop", attribute.String("k", "v"))
+	if got != ctx {
+		t.Error("StartSpan should pass-through context when tracer is nil")
+	}
+	if span == nil {
+		t.Error("StartSpan returned nil span")
+	}
+}
+
+func TestRecordError_HandlesNilSpanGracefully(t *testing.T) {
+	// Should not panic.
+	RecordError(nil, errors.New("boom"))
+}
+
+func TestRecordError_IgnoresNilError(t *testing.T) {
+	_, _ = Init(context.Background(), Config{ServiceName: "test"})
+	_, span := StartSpan(context.Background(), "x")
+	defer span.End()
+	RecordError(span, nil) // no-op, should not crash
+}

--- a/web/src/pages/Flags.tsx
+++ b/web/src/pages/Flags.tsx
@@ -250,7 +250,9 @@ function TabButton({ active, onClick, children }: { active: boolean; onClick: ()
 function FlagPlayground({ projectId, flag }: { projectId: string; flag: FeatureFlag }) {
   const [flagKey, setFlagKey] = useState(flag.flag_key)
   const [defaultValue, setDefaultValue] = useState('')
-  const [context, setContext] = useState<Array<{ k: string; v: string }>>([{ k: 'user_id', v: '' }])
+  // targeting_key is what the eval service buckets on; defaulting to user_id
+  // would silently bucket every user to the same variant.
+  const [context, setContext] = useState<Array<{ k: string; v: string }>>([{ k: 'targeting_key', v: '' }])
   const [result, setResult] = useState<FlagEvaluationResult | null>(null)
   const [evaluating, setEvaluating] = useState(false)
   const [requestError, setRequestError] = useState<string | null>(null)

--- a/web/src/pages/Flags.tsx
+++ b/web/src/pages/Flags.tsx
@@ -172,7 +172,9 @@ function TabButton({ active, onClick, children }: { active: boolean; onClick: ()
 function FlagPlayground({ projectId, flag }: { projectId: string; flag: FeatureFlag }) {
   const [flagKey, setFlagKey] = useState(flag.flag_key)
   const [defaultValue, setDefaultValue] = useState('')
-  const [context, setContext] = useState<Array<{ k: string; v: string }>>([{ k: 'user_id', v: '' }])
+  // targeting_key is what the eval service buckets on; defaulting to user_id
+  // would silently bucket every user to the same variant.
+  const [context, setContext] = useState<Array<{ k: string; v: string }>>([{ k: 'targeting_key', v: '' }])
   const [result, setResult] = useState<FlagEvaluationResult | null>(null)
   const [evaluating, setEvaluating] = useState(false)
   const [requestError, setRequestError] = useState<string | null>(null)


### PR DESCRIPTION
## Summary

Broader test pass after spotting that several recently-touched files were at 0% coverage. Closes the biggest gaps and fixes one real bug the tests surfaced.

### New tests

- **`internal/api/flags_evaluate_test.go`** — `POST /api/v1/projects/{id}/flags/evaluate` (the playground endpoint shipped in #98).
  - Happy path returns variant + reason.
  - Missing flag returns 200 with `reason: ERROR`, `error_code: FLAG_NOT_FOUND`, and the supplied `default_value`.
  - Missing `flag_key` returns 422.
  - No session returns 401; missing CSRF returns 403.
  - Split test fans out 50 distinct `targeting_key`s through a 50/50 split flag and asserts both variants are reached — would catch a regression that silently buckets every user the same way (which is exactly what I was about to ship via the playground's default placeholder — see UX nit below).
  - Plus a `/api/v1/client-config` test that locks in the new `bugbarn_project` field.

- **`internal/api/flags_crud_test.go`** — list / create / get / get-not-found / delete handlers for flags. Adds a tiny `sessionAndCSRF(t, srv, username)` helper that mints both from a single session token (the server derives CSRF from the cookie value, so they have to come from the same token).

- **`internal/api/pure_helpers_test.go`** — `zTestTwoProportions` edge cases (zero samples, equal rates, pooled-p degenerate cases, real significant/non-significant pairs) and `addPaginationHeaders` Link-header behaviour.

- **`internal/tracing/tracing_test.go`** — `Init` noop path, `Middleware` with a populated route pattern, `statusWriter` default-200/explicit-status, `StartSpan` / `RecordError` on nil inputs.

### Bug fix the tests caught

`handleGetFlag` was returning **500** instead of **404** for missing flag IDs because `FlagService.GetFlag` / `GetFlagByKey` didn't translate `sql.ErrNoRows` into `domain.ErrNotFound`. Funnels already did this translation, flags didn't. Same fix applied to both. The 500s are noisy (BugBarn would have caught one as a server error eventually) and break SDK clients that try to fall back on a 404.

### UX nit fixed in passing

The playground's default context row keyed off `user_id`, but `EvaluateFlag` buckets on `targetingKey` / `targeting_key` / `session_id`. With the old default a user evaluating a 50/50 split would always see one variant — confusing and the opposite of what the playground is meant to demonstrate. Default placeholder is now `targeting_key`.

### Coverage delta

| Package | Before | After |
|---|---|---|
| `internal/api` | ~60% | **67.2%** |
| `internal/tracing` | 0% | **62.2%** |

## Test plan

- [x] `go test ./internal/api/... ./internal/service/... ./internal/tracing/... -count=1` passes locally.
- [x] `npx tsc --noEmit` + `vitest run` pass locally.
- [ ] Reviewer: confirm the `targeting_key` default in the playground makes sense, or push for keeping `user_id` and documenting it in tooltip copy.