### PR TITLE
fix: EnsureProject routes UUID-shaped slugs to existing projects

### DIFF
--- a/internal/repository/events_test.go
+++ b/internal/repository/events_test.go
@@ -477,6 +477,50 @@ func TestEnsureProject(t *testing.T) {
 	require.Equal(t, p1.ID, p2.ID)
 }
 
+// A misconfigured tracker that puts a project's ID into the
+// x-funnelbarn-project header (instead of the slug) used to spawn a
+// duplicate project named after the UUID. Now we recognise the UUID
+// shape and route the event to the existing project.
+func TestEnsureProject_UUIDSlug_RoutesToExistingProjectByID(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	real, err := s.CreateProject(ctx, "Places", "places")
+	require.NoError(t, err)
+
+	got, err := s.EnsureProject(ctx, real.ID) // tracker sent the UUID
+	require.NoError(t, err)
+	require.Equal(t, real.ID, got.ID)
+	require.Equal(t, "places", got.Slug, "must reuse the existing project, not create a new one")
+}
+
+// If the slug looks like a UUID but no project with that ID exists, we
+// refuse to auto-create — creating a UUID-named project is never the
+// right answer.
+func TestEnsureProject_UUIDSlug_NoMatchingProject_Refuses(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	_, err := s.EnsureProject(ctx, "00000000-0000-0000-0000-000000000000")
+	require.Error(t, err)
+
+	// And no project should have been written.
+	_, err = s.ProjectBySlug(ctx, "00000000-0000-0000-0000-000000000000")
+	require.Error(t, err, "no project should be created from a UUID-shaped slug")
+}
+
+// Normal slugs that happen to contain hex characters but aren't UUID-shaped
+// must still auto-create as before.
+func TestEnsureProject_NormalSlugAutoCreates(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	// "deadbeef" is hex but not the right length / layout.
+	p, err := s.EnsureProject(ctx, "deadbeef")
+	require.NoError(t, err)
+	require.Equal(t, "deadbeef", p.Slug)
+}
+
 // ---------------------------------------------------------------------------
 // API Keys — remaining gaps
 // ---------------------------------------------------------------------------

--- a/internal/repository/projects.go
+++ b/internal/repository/projects.go
@@ -53,6 +53,13 @@ func (s *Store) ProjectBySlug(ctx context.Context, slug string) (Project, error)
 }
 
 // EnsureProject fetches a project by slug, creating it if absent.
+//
+// As a defence against misconfigured trackers that send a project's *ID* in
+// the place of its slug (we have seen this happen multiple times — e.g. a
+// site copies a UUID out of the dashboard URL into its x-funnelbarn-project
+// header), if the supplied slug parses as a UUID and a project with that
+// exact ID already exists, we route the event to that existing project
+// instead of auto-creating a duplicate named after the UUID.
 func (s *Store) EnsureProject(ctx context.Context, slug string) (Project, error) {
 	p, err := s.ProjectBySlug(ctx, slug)
 	if err == nil {
@@ -61,7 +68,42 @@ func (s *Store) EnsureProject(ctx context.Context, slug string) (Project, error)
 	if err != sql.ErrNoRows {
 		return Project{}, err
 	}
+
+	if looksLikeUUID(slug) {
+		if byID, idErr := s.ProjectByID(ctx, slug); idErr == nil {
+			return byID, nil
+		} else if idErr != sql.ErrNoRows {
+			return Project{}, idErr
+		}
+		// UUID-shaped slug with no matching project either way — refuse to
+		// auto-create. A UUID is never a meaningful slug; creating one
+		// produces the "project shows up as a UUID in the picker" UX bug.
+		return Project{}, fmt.Errorf("slug %q looks like a UUID but no project with that ID exists; refusing to auto-create", slug)
+	}
+
 	return s.CreateProject(ctx, slug, slug)
+}
+
+// looksLikeUUID matches the canonical 8-4-4-4-12 hex layout, case-insensitive.
+// We don't validate the variant/version bits because we only need to recognise
+// "this is almost certainly a UUID someone pasted in", not strict RFC4122.
+func looksLikeUUID(s string) bool {
+	if len(s) != 36 {
+		return false
+	}
+	for i, r := range s {
+		switch i {
+		case 8, 13, 18, 23:
+			if r != '-' {
+				return false
+			}
+		default:
+			if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')) {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // EnsureProjectPending fetches a project by slug or creates it with status='pending'.


### PR DESCRIPTION
## Summary

Stops the bug that has now spawned **3** duplicate projects in production from a single root cause: trackers that put a project's *ID* in the \`x-funnelbarn-project\` header where the slug should go. The worker's \`EnsureProject(slug)\` happily auto-created a new project named after the UUID each time.

Production damage to date:
- \`dc5f3791\` "RSVP Hans feestje" — 412 events + 140 sessions (already merged into the real \`jasaandewilgen\` project)
- \`9f41d853\` "BugBarn GitHub Pages" — 6 events (still in place, awaiting decision)
- \`f3cd1743\` (UUID as name) — 1 event from places.wiebe.xyz (still in place, awaiting decision)

## Fix

\`EnsureProject\` now:
- If the slug looks like a UUID **and** a project with that exact ID exists → returns that project (typo correction).
- If the slug looks like a UUID **and** no matching project exists → refuses to auto-create. A UUID is never a meaningful slug.
- Any non-UUID slug auto-creates as before.

\`looksLikeUUID\` checks the canonical 8-4-4-4-12 hex layout, not strict RFC4122 — we want to catch "this is a UUID someone pasted in", not validate variant bits.

## Test plan

- [x] \`go test ./internal/repository/ -run TestEnsureProject\` — 4 new tests cover both new branches plus the existing happy path:
  - \`TestEnsureProject_UUIDSlug_RoutesToExistingProjectByID\`
  - \`TestEnsureProject_UUIDSlug_NoMatchingProject_Refuses\`
  - \`TestEnsureProject_NormalSlugAutoCreates\` (regression guard for non-UUID slugs)
- [ ] After deploy: confirm no new UUID-named projects appear in the picker over the next 24h.