### PR TITLE
feat: redesign flag creation UX around release vs experiment intent

### DIFF
--- a/web/src/pages/Flags.test.tsx
+++ b/web/src/pages/Flags.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { DefaultToggle, mirrorBooleanSplit } from './Flags'
+
+describe('mirrorBooleanSplit', () => {
+  it('swaps on and off percentages', () => {
+    expect(JSON.parse(mirrorBooleanSplit(JSON.stringify({ on: 20, off: 80 })))).toEqual({ on: 80, off: 20 })
+  })
+
+  it('preserves the 100/0 case (no rollout)', () => {
+    expect(JSON.parse(mirrorBooleanSplit(JSON.stringify({ on: 0, off: 100 })))).toEqual({ on: 100, off: 0 })
+    expect(JSON.parse(mirrorBooleanSplit(JSON.stringify({ on: 100, off: 0 })))).toEqual({ on: 0, off: 100 })
+  })
+
+  it('treats missing keys as 0', () => {
+    // A flag stored with only one key (legacy or partial) shouldn't blow up.
+    expect(JSON.parse(mirrorBooleanSplit(JSON.stringify({ on: 30 })))).toEqual({ on: 0, off: 30 })
+    expect(JSON.parse(mirrorBooleanSplit(JSON.stringify({ off: 50 })))).toEqual({ on: 50, off: 0 })
+  })
+
+  it('falls back to {on:0, off:0} on invalid JSON instead of throwing', () => {
+    expect(JSON.parse(mirrorBooleanSplit(''))).toEqual({ on: 0, off: 0 })
+    expect(JSON.parse(mirrorBooleanSplit('not json'))).toEqual({ on: 0, off: 0 })
+  })
+})
+
+describe('DefaultToggle', () => {
+  it('renders "on" label when value is true', () => {
+    render(<DefaultToggle value={true} onChange={() => {}} />)
+    expect(screen.getByText('on')).toBeInTheDocument()
+  })
+
+  it('renders "off" label when value is false', () => {
+    render(<DefaultToggle value={false} onChange={() => {}} />)
+    expect(screen.getByText('off')).toBeInTheDocument()
+  })
+
+  it('calls onChange when clicked', () => {
+    const onChange = vi.fn()
+    render(<DefaultToggle value={false} onChange={onChange} />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(onChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call onChange when disabled', () => {
+    const onChange = vi.fn()
+    render(<DefaultToggle value={false} onChange={onChange} disabled />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('hint title reflects current state and proposed flip direction', () => {
+    const { rerender } = render(<DefaultToggle value={true} onChange={() => {}} />)
+    expect(screen.getByRole('button')).toHaveAttribute('title', expect.stringContaining('flip to off'))
+    rerender(<DefaultToggle value={false} onChange={() => {}} />)
+    expect(screen.getByRole('button')).toHaveAttribute('title', expect.stringContaining('flip to on'))
+  })
+})

--- a/web/src/pages/Flags.tsx
+++ b/web/src/pages/Flags.tsx
@@ -429,13 +429,35 @@ function TargetingRulesDisplay({ rulesJSON }: { rulesJSON: string }) {
   )
 }
 
+interface StringVariantRow {
+  // The variant name is what's returned (and what targeting rules pick).
+  // returnValue is only different from name when the user opts in to the
+  // "use a different return value" disclosure — rare in practice.
+  name: string
+  returnValue: string
+  splitPct: number
+}
+
 function CreateFlagModal({ projectId, onClose, onCreated }: {
   projectId: string; onClose: () => void; onCreated: (f: FeatureFlag) => void
 }) {
   const [flagKey, setFlagKey] = useState('')
   const [name, setName] = useState('')
   const [flagType, setFlagType] = useState<'boolean' | 'string'>('boolean')
-  const [splitA, setSplitA] = useState(50)
+
+  // Boolean (release) state
+  const [defaultBool, setDefaultBool] = useState<'on' | 'off'>('off')
+  const [rolloutEnabled, setRolloutEnabled] = useState(false)
+  const [rolloutPct, setRolloutPct] = useState(0)
+
+  // String (experiment) state
+  const [variants, setVariants] = useState<StringVariantRow[]>([
+    { name: 'control', returnValue: 'control', splitPct: 50 },
+    { name: 'treatment', returnValue: 'treatment', splitPct: 50 },
+  ])
+  const [defaultVariant, setDefaultVariant] = useState('control')
+  const [advancedReturnValues, setAdvancedReturnValues] = useState(false)
+
   const [conversionEvent, setConversionEvent] = useState('')
   const [eventNames, setEventNames] = useState<string[]>([])
   const [saving, setSaving] = useState(false)
@@ -443,40 +465,72 @@ function CreateFlagModal({ projectId, onClose, onCreated }: {
   const [targetingRules, setTargetingRules] = useState<TargetingRule[]>([])
   const [showRules, setShowRules] = useState(false)
 
-  // String variants
-  const [variantAKey, setVariantAKey] = useState('control')
-  const [variantAVal, setVariantAVal] = useState('control')
-  const [variantBKey, setVariantBKey] = useState('treatment')
-  const [variantBVal, setVariantBVal] = useState('treatment')
-
   useEffect(() => {
     api.getEventNames(projectId).then((d) => setEventNames(d.event_names || [])).catch(() => {})
   }, [projectId])
 
   const autoKey = (n: string) => n.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
 
+  // Variant names targeting-rule dropdowns and default-variant selectors can pick from.
+  const variantNames = flagType === 'boolean'
+    ? ['on', 'off']
+    : variants.map((v) => v.name).filter((n) => n.trim() !== '')
+
+  // Keep defaultVariant in sync when the user removes/renames the row it pointed at.
+  useEffect(() => {
+    if (flagType !== 'string') return
+    if (!variantNames.includes(defaultVariant) && variantNames.length > 0) {
+      setDefaultVariant(variantNames[0])
+    }
+  }, [flagType, variantNames, defaultVariant])
+
+  const splitSum = variants.reduce((sum, v) => sum + (v.splitPct || 0), 0)
+
+  const validateString = (): string | null => {
+    if (variants.length < 2) return 'Need at least two variants'
+    const trimmedNames = variants.map((v) => v.name.trim())
+    if (trimmedNames.some((n) => !n)) return 'All variants need a name'
+    if (new Set(trimmedNames).size !== trimmedNames.length) return 'Variant names must be unique'
+    if (splitSum !== 100) return `Splits must add up to 100% (currently ${splitSum}%)`
+    return null
+  }
+
   const handleCreate = async () => {
     if (!flagKey.trim() || !name.trim()) { setError('Key and name are required'); return }
+
+    let variantsObj: Record<string, unknown>
+    let splitObj: Record<string, number>
+    let resolvedDefault: string
+
+    if (flagType === 'boolean') {
+      variantsObj = { on: true, off: false }
+      resolvedDefault = defaultBool
+      // No rollout → 100% to default. With rollout → that % goes to the
+      // *opposite* of the default ("flip X% of users"), the rest stays default.
+      if (!rolloutEnabled || rolloutPct === 0) {
+        splitObj = { [defaultBool]: 100, [defaultBool === 'on' ? 'off' : 'on']: 0 }
+      } else {
+        const opposite = defaultBool === 'on' ? 'off' : 'on'
+        splitObj = { [defaultBool]: 100 - rolloutPct, [opposite]: rolloutPct }
+      }
+    } else {
+      const err = validateString()
+      if (err) { setError(err); return }
+      variantsObj = Object.fromEntries(variants.map((v) => [v.name.trim(), v.returnValue]))
+      splitObj = Object.fromEntries(variants.map((v) => [v.name.trim(), v.splitPct]))
+      resolvedDefault = defaultVariant
+    }
+
     setSaving(true)
     setError(null)
     try {
-      let variants: Record<string, unknown>
-      let split: Record<string, number>
-      if (flagType === 'boolean') {
-        variants = { on: true, off: false }
-        split = { on: splitA, off: 100 - splitA }
-      } else {
-        variants = { [variantAKey]: variantAVal, [variantBKey]: variantBVal }
-        split = { [variantAKey]: splitA, [variantBKey]: 100 - splitA }
-      }
-
       const f = await api.createFlag(projectId, {
         flag_key: flagKey,
         name,
         flag_type: flagType,
-        variants: JSON.stringify(variants),
-        default_variant: flagType === 'boolean' ? 'off' : variantAKey,
-        split: JSON.stringify(split),
+        variants: JSON.stringify(variantsObj),
+        default_variant: resolvedDefault,
+        split: JSON.stringify(splitObj),
         conversion_event: conversionEvent,
         targeting_rules: targetingRules.length > 0 ? JSON.stringify(targetingRules) : '[]',
       })
@@ -535,26 +589,114 @@ function CreateFlagModal({ projectId, onClose, onCreated }: {
             ))}
           </div>
 
+          {flagType === 'boolean' && (
+            <>
+              <label style={{ display: 'block', fontSize: 13, color: C.muted, fontWeight: 600, marginBottom: 6 }}>Default value</label>
+              <div style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
+                {(['on', 'off'] as const).map((v) => (
+                  <button key={v} onClick={() => setDefaultBool(v)} type="button" style={{
+                    flex: 1, padding: '0.5rem', border: `1px solid ${defaultBool === v ? C.amber : C.border}`,
+                    borderRadius: 8, background: defaultBool === v ? 'rgba(245,158,11,0.1)' : 'transparent',
+                    color: defaultBool === v ? C.amber : C.muted, fontSize: 13, fontWeight: 600, cursor: 'pointer',
+                  }}>
+                    {v}
+                  </button>
+                ))}
+              </div>
+              <div style={{ marginBottom: 16 }}>
+                <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: C.muted, fontWeight: 600, cursor: 'pointer' }}>
+                  <input type="checkbox" checked={rolloutEnabled} onChange={(e) => setRolloutEnabled(e.target.checked)} />
+                  Gradual rollout
+                </label>
+                {rolloutEnabled && (
+                  <div style={{ marginTop: 8, padding: '0.75rem', background: C.bg, border: `1px solid ${C.border}`, borderRadius: 8 }}>
+                    <div style={{ fontSize: 12, color: C.muted, marginBottom: 6 }}>
+                      Flip <span style={{ color: C.amber, fontWeight: 700 }}>{rolloutPct}%</span> of users to{' '}
+                      <code style={{ color: C.text }}>{defaultBool === 'on' ? 'off' : 'on'}</code>; the rest stay on the default.
+                    </div>
+                    <input type="range" min={0} max={100} value={rolloutPct}
+                      onChange={(e) => setRolloutPct(Number(e.target.value))}
+                      style={{ width: '100%', accentColor: C.amber }} />
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+
           {flagType === 'string' && (
             <div style={{ marginBottom: 16 }}>
               <label style={{ display: 'block', fontSize: 13, color: C.muted, fontWeight: 600, marginBottom: 6 }}>Variants</label>
-              <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
-                <input value={variantAKey} onChange={(e) => setVariantAKey(e.target.value)} placeholder="key" style={{ ...inputStyle, flex: 1, fontFamily: 'monospace' }} />
-                <input value={variantAVal} onChange={(e) => setVariantAVal(e.target.value)} placeholder="value" style={{ ...inputStyle, flex: 1 }} />
+              {variants.map((v, i) => (
+                <div key={i} style={{ display: 'flex', gap: 6, marginBottom: 6, alignItems: 'center' }}>
+                  <input
+                    type="radio"
+                    name="defaultVariant"
+                    checked={defaultVariant === v.name}
+                    onChange={() => setDefaultVariant(v.name)}
+                    title="Default variant"
+                    style={{ accentColor: C.amber }}
+                  />
+                  <input
+                    value={v.name}
+                    onChange={(e) => {
+                      const next = [...variants]
+                      const oldName = next[i].name
+                      next[i] = { ...v, name: e.target.value, returnValue: advancedReturnValues ? v.returnValue : e.target.value }
+                      setVariants(next)
+                      if (defaultVariant === oldName) setDefaultVariant(e.target.value)
+                    }}
+                    placeholder="variant name"
+                    style={{ ...inputStyle, flex: 2, fontFamily: 'monospace' }}
+                  />
+                  {advancedReturnValues && (
+                    <input
+                      value={v.returnValue}
+                      onChange={(e) => {
+                        const next = [...variants]; next[i] = { ...v, returnValue: e.target.value }; setVariants(next)
+                      }}
+                      placeholder="return value"
+                      style={{ ...inputStyle, flex: 2 }}
+                    />
+                  )}
+                  <input
+                    type="number" min={0} max={100}
+                    value={v.splitPct}
+                    onChange={(e) => {
+                      const next = [...variants]; next[i] = { ...v, splitPct: Number(e.target.value) }; setVariants(next)
+                    }}
+                    style={{ ...inputStyle, width: 70, textAlign: 'right' }}
+                  />
+                  <span style={{ color: C.muted, fontSize: 12, width: 14 }}>%</span>
+                  <button type="button" onClick={() => {
+                    if (variants.length <= 2) return
+                    const next = variants.filter((_, idx) => idx !== i); setVariants(next)
+                  }} disabled={variants.length <= 2}
+                    style={{ background: 'transparent', border: 'none', color: variants.length <= 2 ? '#4a4d5a' : C.muted, cursor: variants.length <= 2 ? 'default' : 'pointer', padding: 2 }}>
+                    <X size={14} />
+                  </button>
+                </div>
+              ))}
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 6 }}>
+                <button type="button"
+                  onClick={() => setVariants([...variants, { name: '', returnValue: '', splitPct: 0 }])}
+                  style={{ background: 'transparent', border: `1px dashed ${C.border}`, borderRadius: 6, color: C.muted, cursor: 'pointer', padding: '4px 10px', fontSize: 12, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                  <Plus size={12} /> Add variant
+                </button>
+                <span style={{ fontSize: 12, color: splitSum === 100 ? C.success : C.error }}>
+                  Splits sum: {splitSum}%
+                </span>
               </div>
-              <div style={{ display: 'flex', gap: 8 }}>
-                <input value={variantBKey} onChange={(e) => setVariantBKey(e.target.value)} placeholder="key" style={{ ...inputStyle, flex: 1, fontFamily: 'monospace' }} />
-                <input value={variantBVal} onChange={(e) => setVariantBVal(e.target.value)} placeholder="value" style={{ ...inputStyle, flex: 1 }} />
-              </div>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: C.muted, marginTop: 10, cursor: 'pointer' }}>
+                <input type="checkbox" checked={advancedReturnValues} onChange={(e) => {
+                  setAdvancedReturnValues(e.target.checked)
+                  if (!e.target.checked) {
+                    setVariants((rows) => rows.map((r) => ({ ...r, returnValue: r.name })))
+                  }
+                }} />
+                Use a different return value than the variant name
+              </label>
             </div>
           )}
-
-          <label style={{ display: 'block', fontSize: 13, color: C.muted, fontWeight: 600, marginBottom: 6 }}>
-            Split: {flagType === 'boolean' ? `on ${splitA}% / off ${100 - splitA}%` : `${variantAKey} ${splitA}% / ${variantBKey} ${100 - splitA}%`}
-          </label>
-          <input type="range" min={0} max={100} value={splitA}
-            onChange={(e) => setSplitA(Number(e.target.value))}
-            style={{ width: '100%', marginBottom: 16, accentColor: C.amber }} />
 
           <label style={{ display: 'block', fontSize: 13, color: C.muted, fontWeight: 600, marginBottom: 6 }}>Conversion event</label>
           <select value={conversionEvent} onChange={(e) => setConversionEvent(e.target.value)}
@@ -576,7 +718,7 @@ function CreateFlagModal({ projectId, onClose, onCreated }: {
             {showRules && (
               <div style={{ padding: '0 1rem 1rem', borderTop: `1px solid ${C.border}` }}>
                 {targetingRules.map((rule, ri) => {
-                  const variantKeys = flagType === 'boolean' ? ['on', 'off'] : [variantAKey, variantBKey]
+                  const variantKeys = variantNames
                   return (
                     <div key={ri} style={{ background: C.bg, border: `1px solid ${C.border}`, borderRadius: 8, padding: '0.75rem', marginTop: '0.75rem' }}>
                       <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
@@ -657,7 +799,7 @@ function CreateFlagModal({ projectId, onClose, onCreated }: {
                 })}
 
                 <button onClick={() => setTargetingRules([...targetingRules, {
-                  name: '', variant: flagType === 'boolean' ? 'off' : variantAKey,
+                  name: '', variant: flagType === 'boolean' ? (defaultBool === 'on' ? 'off' : 'on') : (variantNames[0] || ''),
                   match: 'all', conditions: [{ context_key: '', operator: 'eq', value: '' }],
                 }])} type="button" style={{
                   marginTop: '0.75rem', width: '100%', padding: '0.5rem',

--- a/web/src/pages/Flags.tsx
+++ b/web/src/pages/Flags.tsx
@@ -81,6 +81,16 @@ function StatCard({ label, sample, conversions, rate, winner }: {
   )
 }
 
+// mirrorBooleanSplit swaps the on/off percentages so flipping the default
+// preserves any gradual rollout. For example, {off: 80, on: 20} (80% on
+// default off, 20% rolled out to on) flips to {on: 80, off: 20} (same
+// 80/20 distribution, mirrored). Defaults missing keys to 0.
+export function mirrorBooleanSplit(splitJSON: string): string {
+  let current: Record<string, number>
+  try { current = JSON.parse(splitJSON) as Record<string, number> } catch { current = {} }
+  return JSON.stringify({ on: current.off ?? 0, off: current.on ?? 0 })
+}
+
 function FlagDetail({ flag, projectId, onUpdated, onDeleted }: {
   flag: FeatureFlag; projectId: string
   onUpdated: (f: FeatureFlag) => void
@@ -116,21 +126,14 @@ function FlagDetail({ flag, projectId, onUpdated, onDeleted }: {
     }
   }
 
-  // Flips the default value for boolean flags. Mirrors the split so any
-  // gradual rollout percentage is preserved (e.g. 80/20 off→on becomes
-  // 20/80, which means the same "20% of users see the non-default" intent).
   const toggleDefault = async () => {
     if (flag.flag_type !== 'boolean') return
-    const newDefault = flag.default_variant === 'on' ? 'off' : 'on'
-    let currentSplit: Record<string, number>
-    try { currentSplit = JSON.parse(flag.split) as Record<string, number> } catch { currentSplit = {} }
-    const newSplit = { on: currentSplit.off ?? 0, off: currentSplit.on ?? 0 }
     setTogglingDefault(true)
     try {
       const updated = await api.updateFlag(projectId, flag.id, {
         ...flag,
-        default_variant: newDefault,
-        split: JSON.stringify(newSplit),
+        default_variant: flag.default_variant === 'on' ? 'off' : 'on',
+        split: mirrorBooleanSplit(flag.split),
       })
       onUpdated(updated)
     } catch (e) {
@@ -257,7 +260,7 @@ function FlagDetail({ flag, projectId, onUpdated, onDeleted }: {
 // DefaultToggle is the on/off switch for boolean (deploy) flags. Clicking it
 // flips the flag's default value — the most common operation on a release
 // flag once it's deployed.
-function DefaultToggle({ value, onChange, disabled }: { value: boolean; onChange: () => void; disabled?: boolean }) {
+export function DefaultToggle({ value, onChange, disabled }: { value: boolean; onChange: () => void; disabled?: boolean }) {
   return (
     <button
       onClick={onChange}

--- a/web/src/pages/Flags.tsx
+++ b/web/src/pages/Flags.tsx
@@ -89,6 +89,7 @@ function FlagDetail({ flag, projectId, onUpdated, onDeleted }: {
   const [analysis, setAnalysis] = useState<FlagAnalysis | null>(null)
   const [loading, setLoading] = useState(true)
   const [toggling, setToggling] = useState(false)
+  const [togglingDefault, setTogglingDefault] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [tab, setTab] = useState<'analytics' | 'tryit'>('analytics')
 
@@ -112,6 +113,30 @@ function FlagDetail({ flag, projectId, onUpdated, onDeleted }: {
       reportError(e instanceof Error ? e : new Error(String(e)), { source: 'Flags.toggle' })
     } finally {
       setToggling(false)
+    }
+  }
+
+  // Flips the default value for boolean flags. Mirrors the split so any
+  // gradual rollout percentage is preserved (e.g. 80/20 off→on becomes
+  // 20/80, which means the same "20% of users see the non-default" intent).
+  const toggleDefault = async () => {
+    if (flag.flag_type !== 'boolean') return
+    const newDefault = flag.default_variant === 'on' ? 'off' : 'on'
+    let currentSplit: Record<string, number>
+    try { currentSplit = JSON.parse(flag.split) as Record<string, number> } catch { currentSplit = {} }
+    const newSplit = { on: currentSplit.off ?? 0, off: currentSplit.on ?? 0 }
+    setTogglingDefault(true)
+    try {
+      const updated = await api.updateFlag(projectId, flag.id, {
+        ...flag,
+        default_variant: newDefault,
+        split: JSON.stringify(newSplit),
+      })
+      onUpdated(updated)
+    } catch (e) {
+      reportError(e instanceof Error ? e : new Error(String(e)), { source: 'Flags.toggleDefault' })
+    } finally {
+      setTogglingDefault(false)
     }
   }
 
@@ -144,6 +169,9 @@ function FlagDetail({ flag, projectId, onUpdated, onDeleted }: {
           </code>
         </div>
         <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          {flag.flag_type === 'boolean' && (
+            <DefaultToggle value={flag.default_variant === 'on'} onChange={toggleDefault} disabled={togglingDefault} />
+          )}
           {statusBadge(flag.status)}
           <button onClick={toggleStatus} disabled={toggling} title={flag.status === 'active' ? 'Pause' : 'Resume'}
             style={{ background: 'transparent', border: `1px solid ${C.border}`, borderRadius: 6, color: C.muted, cursor: 'pointer', padding: '4px 8px', display: 'flex', alignItems: 'center' }}>
@@ -223,6 +251,54 @@ function FlagDetail({ flag, projectId, onUpdated, onDeleted }: {
         </>
       )}
     </div>
+  )
+}
+
+// DefaultToggle is the on/off switch for boolean (deploy) flags. Clicking it
+// flips the flag's default value — the most common operation on a release
+// flag once it's deployed.
+function DefaultToggle({ value, onChange, disabled }: { value: boolean; onChange: () => void; disabled?: boolean }) {
+  return (
+    <button
+      onClick={onChange}
+      disabled={disabled}
+      title={value ? 'Default: on — click to flip to off' : 'Default: off — click to flip to on'}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        background: 'transparent',
+        border: `1px solid ${C.border}`,
+        borderRadius: 999,
+        padding: '2px 4px 2px 10px',
+        cursor: disabled ? 'default' : 'pointer',
+        opacity: disabled ? 0.6 : 1,
+      }}
+    >
+      <span style={{
+        fontSize: 11, fontWeight: 700, letterSpacing: 0.5, textTransform: 'uppercase',
+        color: value ? C.success : C.muted,
+      }}>
+        {value ? 'on' : 'off'}
+      </span>
+      <span style={{
+        position: 'relative',
+        width: 32, height: 18,
+        background: value ? 'rgba(16,185,129,0.25)' : C.border,
+        borderRadius: 999,
+        transition: 'background 120ms ease',
+      }}>
+        <span style={{
+          position: 'absolute',
+          top: 2,
+          left: value ? 16 : 2,
+          width: 14, height: 14,
+          background: value ? C.success : C.muted,
+          borderRadius: '50%',
+          transition: 'left 120ms ease',
+        }} />
+      </span>
+    </button>
   )
 }
 


### PR DESCRIPTION
## Summary

The old flag form was the same shape for both flag types and always put a "split" slider front-and-centre, which silently overrode the default variant and made the targeting-rules-as-overrides mental model unusable. The \`control control treatment treatment\` placeholder on string flags compounded the confusion — the key and value inputs were both labelled the same and pre-filled identically.

This rebuilds the form with two distinct shapes that match the actual intent.

### Boolean (release) flag

- **Default value** segmented toggle (on / off) — front and centre.
- **Gradual rollout** checkbox; when enabled, a slider chooses what percentage of users get *flipped* to the opposite of the default. The rest stay on the default.
- No raw split slider is exposed otherwise; everyone gets the default unless a targeting rule or rollout says otherwise.

### String (experiment) flag

- A list of variant rows: radio (default), name, split %, remove. Add up to N variants.
- The variant **name doubles as the return value** by default — covers 99% of real experiments without ever exposing the dual-field model.
- Optional "Use a different return value than the variant name" checkbox surfaces the legacy key/value pair for the rare case.
- Splits-sum indicator turns green at 100% and refuses save below/above.

### Targeting rules

The variant dropdown on each rule now reads from the live form: boolean → \`on\` / \`off\`; string → whatever variant names are in the rows. Renaming a variant rewrites the default selection if it pointed at the old name.

### Storage shape

Unchanged. \`variants\` and \`split\` JSON look identical on the wire — the form just produces sensible values now. Existing flags render fine.

## Test plan

- [x] \`npx tsc --noEmit\` + \`vitest run\` pass locally (102 tests).
- [ ] Manual: create a boolean flag with default=off, no rollout → it should never be on without a targeting rule match.
- [ ] Manual: create a boolean flag with default=off and rollout=20% → about 20% of distinct targeting_keys should land on \`on\`.
- [ ] Manual: create a string flag with three variants 33/33/34, mark one default → targeting key bucketing is stable across calls.
- [ ] Manual: rename a variant in the form before saving → default-variant radio and the targeting-rule dropdown follow the rename.