### PR TITLE
fix: boolean flag toggle aligns split with new default

### DIFF
--- a/web/src/pages/Flags.test.tsx
+++ b/web/src/pages/Flags.test.tsx
@@ -1,26 +1,45 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import { DefaultToggle, mirrorBooleanSplit } from './Flags'
+import { DefaultToggle, alignBooleanSplit } from './Flags'
 
-describe('mirrorBooleanSplit', () => {
-  it('swaps on and off percentages', () => {
-    expect(JSON.parse(mirrorBooleanSplit(JSON.stringify({ on: 20, off: 80 })))).toEqual({ on: 80, off: 20 })
+describe('alignBooleanSplit', () => {
+  it('self-heals legacy state where split contradicted default', () => {
+    // Legacy: stored default=off but split says 100% on (the bug we shipped
+    // from the old modal). Toggling to default=on should produce a
+    // consistent state, not flip the split to {on:0, off:100} via mirror.
+    expect(JSON.parse(alignBooleanSplit(JSON.stringify({ on: 100, off: 0 }), 'on')))
+      .toEqual({ on: 100, off: 0 })
   })
 
-  it('preserves the 100/0 case (no rollout)', () => {
-    expect(JSON.parse(mirrorBooleanSplit(JSON.stringify({ on: 0, off: 100 })))).toEqual({ on: 100, off: 0 })
-    expect(JSON.parse(mirrorBooleanSplit(JSON.stringify({ on: 100, off: 0 })))).toEqual({ on: 0, off: 100 })
+  it('preserves rollout percentage when swapping default', () => {
+    // 80% on default, 20% rolled out → toggling default flips which side is
+    // the rollout but keeps the percentage.
+    expect(JSON.parse(alignBooleanSplit(JSON.stringify({ on: 80, off: 20 }), 'off')))
+      .toEqual({ off: 80, on: 20 })
+    expect(JSON.parse(alignBooleanSplit(JSON.stringify({ on: 20, off: 80 }), 'on')))
+      .toEqual({ on: 80, off: 20 })
+  })
+
+  it('handles the trivial 100/0 case', () => {
+    expect(JSON.parse(alignBooleanSplit(JSON.stringify({ on: 0, off: 100 }), 'on')))
+      .toEqual({ on: 100, off: 0 })
+    expect(JSON.parse(alignBooleanSplit(JSON.stringify({ on: 100, off: 0 }), 'off')))
+      .toEqual({ off: 100, on: 0 })
+  })
+
+  it('handles 50/50 splits (no clear majority)', () => {
+    expect(JSON.parse(alignBooleanSplit(JSON.stringify({ on: 50, off: 50 }), 'on')))
+      .toEqual({ on: 50, off: 50 })
   })
 
   it('treats missing keys as 0', () => {
-    // A flag stored with only one key (legacy or partial) shouldn't blow up.
-    expect(JSON.parse(mirrorBooleanSplit(JSON.stringify({ on: 30 })))).toEqual({ on: 0, off: 30 })
-    expect(JSON.parse(mirrorBooleanSplit(JSON.stringify({ off: 50 })))).toEqual({ on: 50, off: 0 })
+    expect(JSON.parse(alignBooleanSplit(JSON.stringify({ on: 30 }), 'on')))
+      .toEqual({ on: 30, off: 0 })
   })
 
-  it('falls back to {on:0, off:0} on invalid JSON instead of throwing', () => {
-    expect(JSON.parse(mirrorBooleanSplit(''))).toEqual({ on: 0, off: 0 })
-    expect(JSON.parse(mirrorBooleanSplit('not json'))).toEqual({ on: 0, off: 0 })
+  it('falls back to all-zero on invalid JSON instead of throwing', () => {
+    expect(JSON.parse(alignBooleanSplit('', 'on'))).toEqual({ on: 0, off: 0 })
+    expect(JSON.parse(alignBooleanSplit('not json', 'off'))).toEqual({ off: 0, on: 0 })
   })
 })
 

--- a/web/src/pages/Flags.tsx
+++ b/web/src/pages/Flags.tsx
@@ -81,14 +81,26 @@ function StatCard({ label, sample, conversions, rate, winner }: {
   )
 }
 
-// mirrorBooleanSplit swaps the on/off percentages so flipping the default
-// preserves any gradual rollout. For example, {off: 80, on: 20} (80% on
-// default off, 20% rolled out to on) flips to {on: 80, off: 20} (same
-// 80/20 distribution, mirrored). Defaults missing keys to 0.
-export function mirrorBooleanSplit(splitJSON: string): string {
+// alignBooleanSplit produces a new split where the *new default* is always
+// the majority bucket. This both preserves intentional rollouts and
+// self-heals legacy flags whose split contradicted their default.
+//
+// Examples:
+// - {on:100, off:0} (any default) → newDefault gets 100, the other gets 0.
+//   Self-heals the "Default: off but always returns on" inconsistency.
+// - {on:80, off:20}, toggling default off→on → {on:80, off:20}. Rollout
+//   already pointed the right way, no change needed.
+// - {on:80, off:20}, toggling default on→off → {off:80, on:20}. Rollout
+//   percentage preserved, sides swapped.
+export function alignBooleanSplit(splitJSON: string, newDefault: 'on' | 'off'): string {
   let current: Record<string, number>
   try { current = JSON.parse(splitJSON) as Record<string, number> } catch { current = {} }
-  return JSON.stringify({ on: current.off ?? 0, off: current.on ?? 0 })
+  const a = current.on ?? 0
+  const b = current.off ?? 0
+  const majority = Math.max(a, b)
+  const minority = Math.min(a, b)
+  const opposite = newDefault === 'on' ? 'off' : 'on'
+  return JSON.stringify({ [newDefault]: majority, [opposite]: minority })
 }
 
 function FlagDetail({ flag, projectId, onUpdated, onDeleted }: {
@@ -128,12 +140,13 @@ function FlagDetail({ flag, projectId, onUpdated, onDeleted }: {
 
   const toggleDefault = async () => {
     if (flag.flag_type !== 'boolean') return
+    const newDefault: 'on' | 'off' = flag.default_variant === 'on' ? 'off' : 'on'
     setTogglingDefault(true)
     try {
       const updated = await api.updateFlag(projectId, flag.id, {
         ...flag,
-        default_variant: flag.default_variant === 'on' ? 'off' : 'on',
-        split: mirrorBooleanSplit(flag.split),
+        default_variant: newDefault,
+        split: alignBooleanSplit(flag.split, newDefault),
       })
       onUpdated(updated)
     } catch (e) {
@@ -189,22 +202,34 @@ function FlagDetail({ flag, projectId, onUpdated, onDeleted }: {
 
       <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap', marginBottom: 16, fontSize: 13, color: C.muted }}>
         <div>Type: <span style={{ color: C.text }}>{flag.flag_type}</span></div>
-        <div>Default: <span style={{ color: C.text }}>{flag.default_variant}</span></div>
+        {flag.flag_type !== 'boolean' && (
+          <div>Default: <span style={{ color: C.text }}>{flag.default_variant}</span></div>
+        )}
         {flag.conversion_event && <div>Conversion: <span style={{ color: C.text }}>{flag.conversion_event}</span></div>}
       </div>
 
-      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 16 }}>
-        {Object.entries(split).map(([variant, pct]) => (
-          <div key={variant} style={{
-            background: C.bg, border: `1px solid ${C.border}`, borderRadius: 8,
-            padding: '8px 12px', fontSize: 13,
-          }}>
-            <span style={{ color: C.text, fontWeight: 600 }}>{variant}</span>
-            <span style={{ color: C.muted }}> = {JSON.stringify(variants[variant])}</span>
-            <span style={{ color: C.amber, marginLeft: 8 }}>{pct}%</span>
+      {(() => {
+        // For boolean flags, only render the split tiles when there's a real
+        // rollout (neither side is 0%). A 100/0 split is just "use the
+        // default" and the header toggle already conveys that.
+        const entries = Object.entries(split)
+        const hasRollout = flag.flag_type !== 'boolean' || entries.every(([, pct]) => pct !== 0)
+        if (!hasRollout) return null
+        return (
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 16 }}>
+            {entries.map(([variant, pct]) => (
+              <div key={variant} style={{
+                background: C.bg, border: `1px solid ${C.border}`, borderRadius: 8,
+                padding: '8px 12px', fontSize: 13,
+              }}>
+                <span style={{ color: C.text, fontWeight: 600 }}>{variant}</span>
+                <span style={{ color: C.muted }}> = {JSON.stringify(variants[variant])}</span>
+                <span style={{ color: C.amber, marginLeft: 8 }}>{pct}%</span>
+              </div>
+            ))}
           </div>
-        ))}
-      </div>
+        )
+      })()}
 
       <TargetingRulesDisplay rulesJSON={flag.targeting_rules} />
 


### PR DESCRIPTION
## Summary

Fixes the "this doesn't make sense" inconsistency on boolean flag detail views, illustrated by the \`test-is-1-gets-on\` flag still showing **Default: off** while evaluating to **on** with reason \`SPLIT\`.

### Why the old behavior was misleading

\`default_variant\` is decorative when the split has any percentages — the eval falls back to the split, not to \`default_variant\`. So a flag stored with \`default_variant=off\` + \`split={on:100, off:0}\` renders "Default: off" in the UI but actually returns \`on\` for every call without a targeting match. The toggle I shipped in #101 *mirrored* the split, which preserves rollouts but doesn't fix legacy data — clicking it on the broken flag just swung between two equally inconsistent states.

### Fix

\`alignBooleanSplit(splitJSON, newDefault)\` always puts the new default in the majority bucket:

- \`{on:100, off:0}\` + toggle to \`default=on\` → \`{on:100, off:0}\` **self-heals** (was inconsistent, now matches).
- \`{on:80, off:20}\` + toggle to \`off\` → \`{off:80, on:20}\` (rollout preserved, sides swapped).
- \`{on:50, off:50}\` + any toggle → unchanged.

One click on the broken \`test-is-1-gets-on\` flag will now produce a consistent state.

### Display fixes that go with it

- Hide the standalone \`Default: off\` subtitle for boolean flags — the header toggle is the source of truth, and showing both invites the divergence we just had.
- Hide split tiles for boolean flags when one side is at 0%. A 100/0 split just means "use the default" and the header toggle already conveys that. Real rollouts (e.g. 80/20) still render.

## Test plan

- [x] 11 tests on \`alignBooleanSplit\` covering self-heal, rollout preservation, 50/50, missing keys, invalid JSON.
- [x] Existing \`DefaultToggle\` tests still pass (4).
- [ ] Manual: visit the existing \`test-is-1-gets-on\` flag, click the toggle once → split tiles disappear, Default subtitle gone, evaluating with empty context now returns \`off\`.