### PR TITLE
fix: flag detail header wraps gracefully on narrow viewports

### DIFF
--- a/web/src/pages/Flags.tsx
+++ b/web/src/pages/Flags.tsx
@@ -201,7 +201,10 @@ function FlagDetail({ flag, projectId, onUpdated, onDeleted }: {
             <DefaultToggle value={flag.default_variant === 'on'} onChange={toggleDefault} disabled={togglingDefault} />
           )}
           {statusBadge(flag.status)}
-          <button onClick={toggleStatus} disabled={toggling} title={flag.status === 'active' ? 'Pause' : 'Resume'}
+          <button onClick={toggleStatus} disabled={toggling}
+            title={flag.status === 'active'
+              ? 'Pause — every evaluation returns the default value, targeting rules and split are bypassed (reason: DISABLED)'
+              : 'Resume — re-enable targeting rules and split'}
             style={{ background: 'transparent', border: `1px solid ${C.border}`, borderRadius: 6, color: C.muted, cursor: 'pointer', padding: '4px 8px', display: 'flex', alignItems: 'center' }}>
             {flag.status === 'active' ? <Pause size={14} /> : <Play size={14} />}
           </button>

--- a/web/src/pages/Flags.tsx
+++ b/web/src/pages/Flags.tsx
@@ -178,14 +178,25 @@ function FlagDetail({ flag, projectId, onUpdated, onDeleted }: {
 
   return (
     <div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 16 }}>
-        <div>
-          <h2 style={{ fontSize: 20, fontWeight: 800, margin: '0 0 4px' }}>{flag.name}</h2>
-          <code style={{ fontSize: 13, color: C.amber, background: 'rgba(245,158,11,0.1)', padding: '2px 8px', borderRadius: 4 }}>
+      <div style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'flex-start',
+        gap: 12,
+        flexWrap: 'wrap',
+        marginBottom: 16,
+      }}>
+        <div style={{ flex: '1 1 200px', minWidth: 0 }}>
+          <h2 style={{ fontSize: 20, fontWeight: 800, margin: '0 0 4px', overflowWrap: 'anywhere' }}>{flag.name}</h2>
+          <code style={{
+            fontSize: 13, color: C.amber, background: 'rgba(245,158,11,0.1)',
+            padding: '2px 8px', borderRadius: 4,
+            display: 'inline-block', maxWidth: '100%', overflowWrap: 'anywhere',
+          }}>
             {flag.flag_key}
           </code>
         </div>
-        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap', flexShrink: 0 }}>
           {flag.flag_type === 'boolean' && (
             <DefaultToggle value={flag.default_variant === 'on'} onChange={toggleDefault} disabled={togglingDefault} />
           )}


### PR DESCRIPTION
## Summary

On mobile the flag detail header was unreadable: title was wrapping to 4 lines and the flag-key chip was rendering one character per line.

| before | after |
|---|---|
| Title wraps to 4 lines | Title gets full row when needed |
| Code chip stacks per character | Chip breaks at sensible points |
| Actions hog space next to a 100px-wide title | Actions drop below the title when there isn't room |

Cause: the header was \`display: flex; justify-content: space-between\` with no wrap allowed, so the action group (toggle, status badge, pause, edit, delete = ~230px wide) pinned itself opposite the title and squeezed the title block into whatever was left. \`<code>\` doesn't word-break inside hyphenated identifiers, so the chip's only fallback was per-character.

### Fix

- Parent row: \`flex-wrap: wrap\` so the action group drops below the title block when there's not room for both.
- Title block: \`flex: 1 1 200px\` + \`min-width: 0\` so the \`<h2>\` can actually shrink and wrap by words.
- Flag-key chip: \`display: inline-block\`, \`max-width: 100%\`, \`overflow-wrap: anywhere\` so it breaks at sensible spots.
- Action group keeps \`flex-shrink: 0\` (icons shouldn't compress) and gets \`flex-wrap\` of its own for very narrow screens.

## Test plan

- [x] \`vitest run\` + \`tsc --noEmit\` pass locally.
- [ ] Manual on a narrow viewport (≤360px): title takes one column, action group sits below or wraps cleanly.
- [ ] Manual on desktop: no visual regression — title and actions side by side.