### PR TITLE
fix: silence deploy-rollout 503s, network blips, and stale 404s in BugBarn

### DIFF
--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -249,3 +249,50 @@ describe('api.getEventPropertyValues', () => {
     expect(url).toContain('property=button%20name')
   })
 })
+
+describe('api — transient 5xx retry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function mockFetchSequence(...responses: Array<{ status: number; body?: unknown }>) {
+    const fn = vi.fn()
+    for (const r of responses) {
+      const body = r.body ?? {}
+      fn.mockResolvedValueOnce({
+        status: r.status,
+        ok: r.status >= 200 && r.status < 300,
+        text: () => Promise.resolve(JSON.stringify(body)),
+        json: () => Promise.resolve(body),
+        headers: new Headers(),
+      })
+    }
+    globalThis.fetch = fn
+    return fn
+  }
+
+  it('retries a GET once on 503 and succeeds on second attempt', async () => {
+    const fetchFn = mockFetchSequence({ status: 503 }, { status: 200, body: { ok: true } })
+    const promise = api.me()
+    await vi.advanceTimersByTimeAsync(800)
+    const result = await promise
+    expect(result).toEqual({ ok: true })
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not retry POST on 503 (mutation might have partially applied)', async () => {
+    const fetchFn = mockFetchSequence({ status: 503, body: { error: 'unavailable' } })
+    await expect(api.login({ username: 'a', password: 'b' })).rejects.toMatchObject({
+      status: 503,
+    })
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws ApiError(0) when fetch itself rejects (network failure)', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+    await expect(api.me()).rejects.toMatchObject({ status: 0 })
+  })
+})

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -13,6 +13,10 @@ function getCookie(name: string): string | undefined {
   return match ? decodeURIComponent(match[1]) : undefined
 }
 
+// Transient statuses we'll retry once. 502/503/504 are almost always a
+// k8s rollout in flight (pod cycling) — they recover in a couple of seconds.
+const TRANSIENT_STATUSES = new Set([502, 503, 504])
+
 async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json', ...options.headers as Record<string, string> }
 
@@ -24,11 +28,29 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
     }
   }
 
-  const res = await fetch(path, {
-    ...options,
-    headers,
-    credentials: 'include',
-  })
+  const doFetch = () => fetch(path, { ...options, headers, credentials: 'include' })
+
+  let res: Response
+  try {
+    res = await doFetch()
+  } catch (e) {
+    // TypeError: Failed to fetch — browser-level network failure. Don't
+    // report (it's the user's network, not our code). Surface as an
+    // ApiError so callers can render a "lost connection" state if they want.
+    throw new ApiError(0, e instanceof Error ? e.message : 'network error')
+  }
+
+  // One-shot retry on transient 5xx after a short delay. Don't retry mutating
+  // methods — the request may have already partially applied server-side.
+  if (TRANSIENT_STATUSES.has(res.status) && method === 'GET') {
+    await new Promise((r) => setTimeout(r, 800))
+    try {
+      res = await doFetch()
+    } catch {
+      // Same network-failure rationale as above.
+      throw new ApiError(0, 'network error after retry')
+    }
+  }
 
   if (res.status === 401) {
     // Redirect to login unless we're already there or on the landing page
@@ -47,8 +69,11 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
       // ignore parse errors
     }
     const apiErr = new ApiError(res.status, msg)
-    // Report unexpected server errors (5xx) to BugBarn.
-    if (res.status >= 500) {
+    // Report unexpected server errors (5xx) to BugBarn — but skip the transient
+    // statuses we just retried. If we retried and still got 503, it's likely a
+    // longer rollout or real outage; we still don't want a BugBarn spam storm
+    // for either case, so suppress those too.
+    if (res.status >= 500 && !TRANSIENT_STATUSES.has(res.status)) {
       reportError(apiErr, {
         source: 'api.request',
         path,

--- a/web/src/lib/projects.tsx
+++ b/web/src/lib/projects.tsx
@@ -31,9 +31,11 @@ export function ProjectProvider({ children }: { children: ReactNode }) {
     api.listProjects()
       .then((d) => setProjects(d.projects || []))
       .catch((e) => {
-        // 401 is expected when the session has expired or the user isn't logged in yet;
-        // the API client already redirects to /login. Don't pollute BugBarn with it.
-        if (!(e instanceof ApiError && e.status === 401)) {
+        // Skip noise:
+        // - 401: expected when session expired / before login. api.request already redirects.
+        // - 0:   network failure (TypeError: Failed to fetch). User's network, not our code.
+        const isNoise = e instanceof ApiError && (e.status === 401 || e.status === 0)
+        if (!isNoise) {
           reportError(e, { source: 'ProjectProvider.listProjects' })
         }
         setProjects([])

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -18,12 +18,24 @@ window.onerror = (message, source, lineno, colno, error) => {
 
 // Global unhandled promise rejection handler.
 window.onunhandledrejection = (event: PromiseRejectionEvent) => {
-  // ServiceWorker registration failures (typically untrusted TLS in dev/test
-  // environments or sandboxed browsers) are not actionable from app code.
-  const msg = event.reason instanceof Error ? event.reason.message : String(event.reason)
-  if (msg.includes('Failed to register a ServiceWorker')) return
+  const reason = event.reason
+  const msg = reason instanceof Error ? reason.message : String(reason)
+  const stack = reason instanceof Error ? (reason.stack ?? '') : ''
 
-  reportError(event.reason, {
+  // Filters for things that aren't application bugs:
+  // - "Failed to register a ServiceWorker": untrusted TLS in dev/test envs.
+  // - registerSW.js / ServiceWorkerContainer.register: same root cause, but
+  //   the rejection sometimes surfaces with a generic message like "Rejected"
+  //   so we also match on the stack.
+  // - "Failed to fetch" (TypeError): browser-level network blip; the API
+  //   client already handles this as ApiError(0). Surfacing it as an
+  //   unhandled rejection here means a non-api call dropped — still not
+  //   actionable from app code.
+  if (msg.includes('Failed to register a ServiceWorker')) return
+  if (stack.includes('registerSW.js') || stack.includes('ServiceWorkerContainer.register')) return
+  if (reason instanceof TypeError && msg.includes('Failed to fetch')) return
+
+  reportError(reason, {
     source: 'window.onunhandledrejection',
   })
 }

--- a/web/src/pages/Funnels.tsx
+++ b/web/src/pages/Funnels.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useRef } from 'react'
 import { useParams } from 'react-router-dom'
 import { Plus, X, Layers, Pencil, Trash2, ChevronDown, ChevronRight } from 'lucide-react'
 import Shell from '../components/shell/Shell'
-import { api, Funnel, FunnelAnalysis, FunnelStepInput } from '../lib/api'
+import { api, ApiError, Funnel, FunnelAnalysis, FunnelStepInput } from '../lib/api'
 import { useProjects } from '../lib/projects'
 import { trackEvent } from '../lib/analytics'
 import { reportError } from '../lib/bugbarn'
@@ -1365,7 +1365,11 @@ export default function Funnels() {
       .then(setAnalysis)
       .catch((e) => {
         console.error(e)
-        reportError(e, { source: 'Funnels.getFunnelAnalysis' })
+        // 404 (deleted funnel / stale URL) and 0 (network blip) are not real
+        // bugs — the user just landed on a URL whose backing record is gone
+        // or their connection dropped. Surface in the UI, don't escalate.
+        const isNoise = e instanceof ApiError && (e.status === 404 || e.status === 0)
+        if (!isNoise) reportError(e, { source: 'Funnels.getFunnelAnalysis' })
         setAnalysisError(String(e))
       })
       .finally(() => setAnalysisLoading(false))


### PR DESCRIPTION
## Summary

All four open BugBarn issues against \`funnelbarn\` were infra/UX noise being escalated as if they were code bugs.

| issue | what it actually was | fix |
|---|---|---|
| **FUN-5** HTTP 503 (8 events) | All clustered at 23:37 on 2026-05-13 — exactly the v0.0.144 rollout. Pods cycling = brief 503s. | Retry GETs once on 502/503/504 after 800ms; suppress these statuses from BugBarn even after retry. |
| **FUN-6** "Failed to fetch" | \`TypeError\` from a browser-level network failure (user's wifi dropping, etc). Not actionable. | Catch fetch's own TypeError → \`ApiError(0)\` so callers can filter cleanly. \`ProjectProvider\` now skips status 0 alongside 401. |
| **FUN-4** "funnel not found" | 404 from \`getFunnelAnalysis\` because someone navigated to a URL whose funnel had been deleted. | \`Funnels.tsx\` skips 404 (and 0) in its catch — surfaces the error in the UI banner, doesn't escalate. |
| **FUN-3** "Rejected" | Another SW registerSW.js rejection that slipped past the earlier filter because the message text was just "Rejected". | Widened the SW filter in \`main.tsx\` to also match on stack mentions of \`registerSW.js\` / \`ServiceWorkerContainer.register\`. Also skips \`TypeError "Failed to fetch"\` from this handler. |

### Retry policy

- GETs retry once after 800ms on 502/503/504. Mutations (POST/PUT/DELETE/PATCH) **don't retry** — the request may have already partially applied server-side, and a retry could double-write. Caller still sees the original \`ApiError(50x)\` and renders whatever fallback it wants.
- 5xx that isn't 502/503/504 still reports to BugBarn — that's where real server bugs live (500, 507, etc).

### Tests

3 new tests on the retry + network-failure paths (123 total, up from 120):
- GET on 503 → retries, succeeds → caller gets the second response.
- POST on 503 → no retry, throws.
- fetch rejects with TypeError → \`ApiError(0)\`.

## Test plan

- [x] \`vitest run\` (123) + \`tsc --noEmit\` pass locally.
- [ ] After deploy: rolling out the next version shouldn't create a new FUN-5-style cluster in BugBarn.
- [ ] Manual: open a known-deleted funnel URL → UI shows the "funnel not found" banner but no BugBarn event is sent.
- [ ] Manual: dev tools → throttling: Offline → reload → no \`Failed to fetch\` event in BugBarn.