### PR TITLE
feat: pass user_agent to iambarn-enabled flag eval context

### DIFF
--- a/internal/api/client_config.go
+++ b/internal/api/client_config.go
@@ -21,6 +21,6 @@ func (s *Server) handleClientConfig(w http.ResponseWriter, r *http.Request) {
 		FunnelbarnEndpoint: s.publicURL,
 		FunnelbarnAPIKey:   s.dogfoodAPIKey,
 		FunnelbarnProject:  s.dogfoodProject,
-		IAMBarnEnabled:     s.iambarnFlagEnabled(r.Context()),
+		IAMBarnEnabled:     s.iambarnFlagEnabled(r.Context(), map[string]any{"user_agent": r.Header.Get("User-Agent")}),
 	})
 }

--- a/internal/api/oidc.go
+++ b/internal/api/oidc.go
@@ -28,7 +28,7 @@ const (
 // handleOIDCLogin starts the authorization code + PKCE flow.
 // GET /api/v1/auth/oidc/login
 func (s *Server) handleOIDCLogin(w http.ResponseWriter, r *http.Request) {
-	if !s.iambarnFlagEnabled(r.Context()) {
+	if !s.iambarnFlagEnabled(r.Context(), map[string]any{"user_agent": r.Header.Get("User-Agent")}) {
 		jsonError(w, "not found", http.StatusNotFound)
 		return
 	}
@@ -66,7 +66,7 @@ func (s *Server) handleOIDCLogin(w http.ResponseWriter, r *http.Request) {
 // handleOIDCCallback completes the PKCE flow and issues a FunnelBarn session.
 // GET /api/v1/auth/oidc/callback
 func (s *Server) handleOIDCCallback(w http.ResponseWriter, r *http.Request) {
-	if !s.iambarnFlagEnabled(r.Context()) {
+	if !s.iambarnFlagEnabled(r.Context(), map[string]any{"user_agent": r.Header.Get("User-Agent")}) {
 		jsonError(w, "not found", http.StatusNotFound)
 		return
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -365,9 +365,9 @@ func (s *Server) requireSession(next http.HandlerFunc) http.HandlerFunc {
 }
 
 // iambarnFlagEnabled evaluates the "iambarn-enabled" feature flag in the
-// dogfood project. Returns false if the provider is unconfigured, the project
-// doesn't exist, or the flag is absent / off.
-func (s *Server) iambarnFlagEnabled(ctx context.Context) bool {
+// dogfood project. evalCtx is passed as-is to the flag evaluator so that
+// targeting rules (e.g. user_agent contains "Chrome") can act on request data.
+func (s *Server) iambarnFlagEnabled(ctx context.Context, evalCtx map[string]any) bool {
 	if s.iambarnProvider == nil || s.iambarnFlagProject == "" {
 		return false
 	}
@@ -375,7 +375,7 @@ func (s *Server) iambarnFlagEnabled(ctx context.Context) bool {
 	if err != nil {
 		return false
 	}
-	result, err := s.flags.EvaluateFlag(ctx, proj.ID, "iambarn-enabled", map[string]any{})
+	result, err := s.flags.EvaluateFlag(ctx, proj.ID, "iambarn-enabled", evalCtx)
 	if err != nil {
 		return false
 	}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -53,8 +53,8 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   }
 
   if (res.status === 401) {
-    // Redirect to login unless we're already there or on the landing page
-    if (!window.location.pathname.includes('/login')) {
+    const { pathname } = window.location
+    if (pathname !== '/' && !pathname.startsWith('/login')) {
       window.location.href = '/login'
     }
     throw new ApiError(401, 'Unauthorized')


### PR DESCRIPTION
## Summary

- `iambarnFlagEnabled` previously evaluated with an empty context, making targeting rules useless for this flag
- Now threads `user_agent` from the request into the eval context
- Enables browser-based targeting rules (e.g. `user_agent contains Chrome`)

Flag config already updated on all three environments via API: targeting rule `user_agent contains Chrome → on`, default `off`.