### PR TITLE
test: extend IAMBarn e2e with callback errors and credential flow

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -15,8 +15,6 @@ on:
 permissions:
   contents: write
 
-env:
-
 jobs:
   tag:
     name: Create Release Tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ concurrency:
 permissions:
   contents: read
 
-env:
-
 jobs:
   go-quality:
     runs-on: ubuntu-latest

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -5,7 +5,7 @@ test.describe('auth', () => {
     await page.context().clearCookies()
     await page.goto('/')
     await expect(page.getByText('Own Your')).toBeVisible()
-    await expect(page.getByText('Analytics')).toBeVisible()
+    await expect(page.getByText('Analytics', { exact: true })).toBeVisible()
   })
 
   test('login and redirect to dashboard', async ({ page }) => {

--- a/e2e/iambarn.spec.ts
+++ b/e2e/iambarn.spec.ts
@@ -62,3 +62,106 @@ test.describe('iambarn login page', () => {
     expect(page.url()).toContain('client_id=ibc_')
   })
 })
+
+// ── OIDC callback error handling ─────────────────────────────────────────────
+
+test.describe('OIDC callback error handling', () => {
+  test('callback without state cookie → /login?error=auth_failed', async ({ page }) => {
+    await page.context().clearCookies()
+    await page.goto('/api/v1/auth/oidc/callback?code=fake&state=fake')
+    await expect(page).toHaveURL(/\/login\?error=auth_failed/, { timeout: 6000 })
+    await expect(page.getByText(/Login failed/i)).toBeVisible()
+  })
+
+  test('callback with mismatched state → /login?error=auth_failed', async ({ page }) => {
+    await page.context().clearCookies()
+    const baseURL = process.env.E2E_BASE_URL || 'http://localhost:5173'
+    const hostname = new URL(baseURL).hostname
+    await page.context().addCookies([{
+      name: 'oidc_state',
+      value: 'expected_state|some_verifier',
+      domain: hostname,
+      path: '/',
+    }])
+    await page.goto('/api/v1/auth/oidc/callback?code=fake&state=wrong_state')
+    await expect(page).toHaveURL(/\/login\?error=auth_failed/, { timeout: 6000 })
+  })
+
+  test('callback with error param → /login?error=auth_failed', async ({ page }) => {
+    await page.context().clearCookies()
+    const baseURL = process.env.E2E_BASE_URL || 'http://localhost:5173'
+    const hostname = new URL(baseURL).hostname
+    await page.context().addCookies([{
+      name: 'oidc_state',
+      value: 'real_state|some_verifier',
+      domain: hostname,
+      path: '/',
+    }])
+    await page.goto('/api/v1/auth/oidc/callback?error=access_denied&state=real_state')
+    await expect(page).toHaveURL(/\/login\?error=auth_failed/, { timeout: 6000 })
+  })
+})
+
+// ── Full credential flow ──────────────────────────────────────────────────────
+// Set E2E_IAMBARN_EMAIL + E2E_IAMBARN_PASSWORD to run these.
+
+test.describe('Full IAMBarn credential flow', () => {
+  const email = process.env.E2E_IAMBARN_EMAIL
+  const password = process.env.E2E_IAMBARN_PASSWORD
+
+  test.beforeEach(async () => {
+    if (!email || !password) {
+      test.skip(true, 'Set E2E_IAMBARN_EMAIL and E2E_IAMBARN_PASSWORD to run credential tests')
+    }
+  })
+
+  test('logs in via IAMBarn and lands on /dashboard', async ({ page }) => {
+    test.setTimeout(30_000)
+    await page.context().clearCookies()
+    await page.goto('/login')
+    await page.getByText('Continue with IAMBarn').click()
+
+    // Wait for IAMBarn login page.
+    await page.waitForURL(/iam\.wiebe\.xyz/, { waitUntil: 'commit', timeout: 10_000 })
+
+    // IAMBarn uses email + password form.
+    await page.locator('input[name="email"]').fill(email!)
+    await page.getByRole('button', { name: /continue|next/i }).first().click()
+
+    // Password step (IAMBarn may use a two-step flow).
+    await page.locator('input[type="password"]').fill(password!)
+    await page.locator('button[type="submit"]').click()
+
+    // Consent screen if present.
+    const allowBtn = page.getByRole('button', { name: /allow/i })
+    if (await allowBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await allowBtn.click()
+    }
+
+    // Should land back on FunnelBarn dashboard.
+    await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 })
+  })
+
+  test('IAMBarn session persists across page reload', async ({ page }) => {
+    test.setTimeout(30_000)
+    await page.context().clearCookies()
+    await page.goto('/login')
+    await page.getByText('Continue with IAMBarn').click()
+    await page.waitForURL(/iam\.wiebe\.xyz/, { waitUntil: 'commit', timeout: 10_000 })
+
+    await page.locator('input[name="email"]').fill(email!)
+    await page.getByRole('button', { name: /continue|next/i }).first().click()
+    await page.locator('input[type="password"]').fill(password!)
+    await page.locator('button[type="submit"]').click()
+
+    const allowBtn = page.getByRole('button', { name: /allow/i })
+    if (await allowBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await allowBtn.click()
+    }
+
+    await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 })
+
+    await page.reload()
+    await expect(page).toHaveURL(/\/dashboard/)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds OIDC callback error-handling tests: missing state cookie, state mismatch, and IAMBarn error param all redirect to `/login?error=auth_failed`
- Adds full credential flow tests (skipped unless `E2E_IAMBARN_EMAIL` + `E2E_IAMBARN_PASSWORD` are set): logs in via IAMBarn, verifies dashboard redirect, verifies session persistence across reload
- Existing flag-gating and redirect tests kept as-is

## Test plan

- [ ] Run `npm run e2e` against test env — callback error tests pass without credentials
- [ ] Set `E2E_IAMBARN_EMAIL` + `E2E_IAMBARN_PASSWORD` and run again to exercise the full login flow
- [ ] Feature flag tests pass once `iambarn-enabled` flag is set to `on` in the dogfood project