### PR TITLE
feat: ingest-only f.* subdomain ingress with root redirect

### DIFF
--- a/deploy/k8s/production/ingress-f.yaml
+++ b/deploy/k8s/production/ingress-f.yaml
@@ -1,0 +1,46 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: funnelbarn-f
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.tls.certresolver: letsencrypt
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: f.pensioenfeest.nl
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: funnelbarn
+                port:
+                  name: http
+    - host: f.scanoo.nl
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: funnelbarn
+                port:
+                  name: http
+    - host: f.scanbarelinks.nl
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: funnelbarn
+                port:
+                  name: http
+  tls:
+    - hosts:
+        - f.pensioenfeest.nl
+        - f.scanoo.nl
+        - f.scanbarelinks.nl

--- a/deploy/k8s/production/kustomization.yaml
+++ b/deploy/k8s/production/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - service.yaml
   - web-service.yaml
   - ingress.yaml
+  - ingress-f.yaml
 images:
   - name: funnelbarn/service
     newName: ghcr.io/webwiebe/funnelbarn/service

--- a/internal/api/f_domain_test.go
+++ b/internal/api/f_domain_test.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFDomainRedirect(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	tests := []struct {
+		name     string
+		host     string
+		path     string
+		wantCode int
+		wantLoc  string
+	}{
+		{
+			name:     "redirects root to parent domain",
+			host:     "f.pensioenfeest.nl",
+			path:     "/",
+			wantCode: http.StatusMovedPermanently,
+			wantLoc:  "https://pensioenfeest.nl",
+		},
+		{
+			name:     "redirects other f-subdomains",
+			host:     "f.scanoo.nl",
+			path:     "/",
+			wantCode: http.StatusMovedPermanently,
+			wantLoc:  "https://scanoo.nl",
+		},
+		{
+			name:     "api path passes through on f-subdomain",
+			host:     "f.pensioenfeest.nl",
+			path:     "/api/v1/health",
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "non-f host root is not redirected",
+			host:     "funnelbarn.wiebe.xyz",
+			path:     "/",
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:     "host with port strips port before check",
+			host:     "f.example.com:8080",
+			path:     "/",
+			wantCode: http.StatusMovedPermanently,
+			wantLoc:  "https://example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "http://"+tt.host+tt.path, nil)
+			req.Host = tt.host
+			w := httptest.NewRecorder()
+			srv.ServeHTTP(w, req)
+
+			if w.Code != tt.wantCode {
+				t.Errorf("got status %d, want %d", w.Code, tt.wantCode)
+			}
+			if tt.wantLoc != "" {
+				loc := w.Header().Get("Location")
+				if loc != tt.wantLoc {
+					t.Errorf("Location: got %q, want %q", loc, tt.wantLoc)
+				}
+			}
+		})
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -290,6 +290,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
+	// Redirect GET / on f.* subdomains back to their root domain.
+	// e.g. f.example.com → https://example.com
+	if r.Method == http.MethodGet && r.URL.Path == "/" {
+		host := r.Host
+		if i := strings.IndexByte(host, ':'); i >= 0 {
+			host = host[:i]
+		}
+		if strings.HasPrefix(host, "f.") {
+			http.Redirect(w, r, "https://"+strings.TrimPrefix(host, "f."), http.StatusMovedPermanently)
+			return
+		}
+	}
 	// Apply a reasonable body limit to all routes (ingest has its own per-handler limit).
 	if r.Body != nil && r.URL.Path != "/api/v1/events" {
 		r.Body = http.MaxBytesReader(w, r.Body, 256<<10) // 256 KiB


### PR DESCRIPTION
## Summary

- New k8s ingress (`ingress-f.yaml`) routes `f.pensioenfeest.nl`, `f.scanoo.nl`, `f.scanbarelinks.nl` to the backend service — no web frontend exposed
- `GET /` on any `f.*` host returns a 301 to the root domain (e.g. `f.pensioenfeest.nl` → `pensioenfeest.nl`), keeping `funnelbarn.wiebe.xyz` out of sight
- All `/api/*` paths pass through normally for ingest, evaluate, and setup

## Test plan

- [x] Unit tests cover: root redirect, API path pass-through, non-f host not redirected, port stripping
- [ ] DNS verified — all three domains resolve through Cloudflare to the cluster; 404s confirm Traefik is receiving traffic, pending this deploy
- [ ] After merge: verify `https://f.pensioenfeest.nl/` redirects to `https://pensioenfeest.nl`
- [ ] After merge: verify `https://f.pensioenfeest.nl/api/v1/health` returns 200