### PR TITLE
fix: build full SDK before web in binary-release workflow

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -118,10 +118,10 @@ jobs:
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 
-      - name: Install SDK dependencies and build IIFE bundle
+      - name: Install SDK dependencies and build
         run: |
           npm ci --prefix sdks/js
-          npm run build:iife --prefix sdks/js
+          npm run build --prefix sdks/js
           mkdir -p web/public/sdk
           cp sdks/js/dist/iife/funnelbarn.js web/public/sdk/funnelbarn.js
 


### PR DESCRIPTION
## Summary

The `upload-source-maps` job was running `build:iife` which only produces the IIFE bundle, skipping the ESM build and TypeScript declarations. The web app imports `@funnelbarn/js` as a workspace package and needs those outputs to compile. Changed to `build` which runs clean → ESM → CJS → IIFE.

Same fix as was applied to `ci.yml` in 92ca40a.