### PR TITLE
docs: document FUNNELBARN_SPANBARN_* env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,3 +65,10 @@ FUNNELBARN_SELF_ENDPOINT=https://bugbarn.wiebe.xyz
 # Project slug in BugBarn that errors are routed to (default: funnelbarn)
 # FUNNELBARN_SELF_PROJECT=funnelbarn
 FUNNELBARN_ENVIRONMENT=production
+
+# ── Distributed tracing via SpanBarn (optional) ──────────────────────────────
+#
+# When both vars are set, the server exports OTLP/HTTP traces to SpanBarn.
+# Get your project key from: https://spanbarn.wiebe.xyz/api/v1/setup/funnelbarn
+# FUNNELBARN_SPANBARN_ENDPOINT=https://spanbarn.wiebe.xyz/v1/traces
+# FUNNELBARN_SPANBARN_API_KEY=<set via SOPS secret>


### PR DESCRIPTION
## Summary

Tracing init in \`cmd/funnelbarn/main.go:163-165\` already consumes \`cfg.SpanBarnEndpoint\` / \`cfg.SpanBarnAPIKey\`, but the variables were undiscoverable from \`.env.example\`. Add them as a commented block next to the existing \`SELF_*\` (bugbarn) section so the spanbarn integration is operator-visible.

No code change — pure documentation.

## Test plan

- [ ] CI green
- [ ] After deploy + setting the vars in SOPS, confirm spans appear in spanbarn under the \`funnelbarn\` project slug