### PR TITLE
feat(secrets): point per-env FUNNELBARN_SPANBARN_* at matching spanbarn

### DIFF
--- a/deploy/k8s/staging/secret.yaml
+++ b/deploy/k8s/staging/secret.yaml
@@ -11,14 +11,18 @@ stringData:
     FUNNELBARN_SELF_API_KEY: ENC[AES256_GCM,data:6SDD45inIY+XyDxgk/hScUsEqVIdgvzEOJCYRLOM416ziRBbO575hw==,iv:6GWUt/qUo+fAHlVuY6EqePi8s3hZ+yJ7QHYU8n5fY1E=,tag:n/ZG++TXkLAho2hxAQ6uVA==,type:str]
     FUNNELBARN_SELF_ENDPOINT: ENC[AES256_GCM,data:5RKknfDnB89r15Q3ySsQW2fiNjkXNB9X8Q==,iv:nhmYMiwSNULzu3Jzl6sPk6YeYryD1EdCvyGsJBCVIoo=,tag:UKSbnHfXJKAOfK5K8E30ow==,type:str]
     FUNNELBARN_SESSION_SECRET: ENC[AES256_GCM,data:IkDl0LhwOcWYZTbXM5HuW4JvjskUHBhhg03cLhnf9HFnPDhKyKcEuLePFRT8LDjtGaNGtBUzqBN0MEyJc7wZCA==,iv:wjgWWucSu7Bp1c3GABv34prrs2NwBD+J+GACVA+Jqy0=,tag:kfVEjCaNpyD4VvgX756Owg==,type:str]
-    FUNNELBARN_SPANBARN_ENDPOINT: ENC[AES256_GCM,data:gyAazBuN33p/Y9viLopRzdue5B4NDiu6br+PaCPWDwLt6x4J,iv:vssQzVzpMoXTIMjjbAkRoaTq2ODMqFvjiKvkyo4vqck=,tag:hk1x1SD5b0OOmvKD5FjZNg==,type:str]
-    FUNNELBARN_SPANBARN_API_KEY: ENC[AES256_GCM,data:G/qWkw45IHZhifp9X7Kxg72GL7C7Afn/RRDmAF4jrtDoy0lsCwsMWw==,iv:AKNuOGHlTL7B8DZ+ute5fjhyqaffrQt0Rk2tvvC+jZQ=,tag:s6/GmAUimaIQvMDs5aouPg==,type:str]
+    FUNNELBARN_SPANBARN_ENDPOINT: ENC[AES256_GCM,data:7lZHOW+vXQj0x1wjbG7lUUpzWlS/4HiDpyC+TMS0OFrYkHilv1DUVY7i4ioFUahdzNamWWw=,iv:KOWo8p9k3ivITHFu/2rUwAeQYKQZAkd29MNQ5DNI8DM=,tag:tEyBbbyYi5gijTBHoZMS7A==,type:str]
+    FUNNELBARN_SPANBARN_API_KEY: ENC[AES256_GCM,data:EXxFyM84xXupz/DyuNA7GZge1GVLzMRz4o4E0Hjd2/5aX9wRfQirHg==,iv:mKl0T74Oi9oZKrpcZQGgVsyPhHLdMNx6egbxIQtjbrc=,tag:qR+E/sYYUkD+NzoZm6ehEg==,type:str]
     FUNNELBARN_IAMBARN_ENABLED: ENC[AES256_GCM,data:bp/EVxM=,iv:/ax6WW1SXry/qvxn1sVExgB5TPtoWH99rpoIzxSDPwA=,tag:eBdADL6xvnAGAUJ5UYdXWw==,type:str]
     FUNNELBARN_IAMBARN_CLIENT_ID: ENC[AES256_GCM,data:SnCchjkihlWUMd7alWDqssxznswh4lQBxbJlaNQ51gJyyPy5hWEUoeeEy+o=,iv:3o/QOHKxqv/on84oCoU5p1P4Fvq4Fd9onCvhcS69pRU=,tag:OZgKAdll9DRhEtS0PBkBzw==,type:str]
     GEOIPUPDATE_ACCOUNT_ID: ENC[AES256_GCM,data:xVEE+MCiYg==,iv:6CdJ3Ug9+MpnHBCGOR3KFIbAMUBpK+FJod/xMm1GPdE=,tag:HkM7sAdFuffQNeXLxXFWqw==,type:str]
     GEOIPUPDATE_LICENSE_KEY: ENC[AES256_GCM,data:/Ki4Bxr8AXwEwA5S0WFDldO1EQwQaNw1Vp7p4imNYMNbjujkP/Y4Ow==,iv:cXnbo9qNecWVNTP59Myb9hTbruA/tE/uzhCko3MaVpI=,tag:xr92k+SiZwpLSvkAW9Q6nA==,type:str]
 type: ENC[AES256_GCM,data:j3xiz+Or,iv:IZU6E2E7NRmJNESOX3/39faVk97fZEPreoVimwYeHR8=,tag:JM35xtiOm/wxdt30cZHCXQ==,type:str]
 sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
     age:
         - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
           enc: |
@@ -29,7 +33,8 @@ sops:
             M1pZcUQrWmxCWlQzUldpcWZpTlF5Z2sKxvRXA7kLe7HoC+UJmtfQuzGOZ+1oaKvI
             anzLivgCzT7bxqYfSbAjDu3HY+wdVU4ezJeAgAnL7EXH5B8YCFNyJg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-17T09:15:06Z"
-    mac: ENC[AES256_GCM,data:OxF9U/OLJxLWM/bXaFbVE8iMWkQa7P+9ajrP3tY9D52E2FAq1zfnaLs8jC99BOfHeRV13IhSsO7zU32iq/WmdOS1aJ720oovSkqugi9YrlNWkg+lVJYo5AA0F678Nv3bMnfAd1J2lRv2177rBnhxskQDzgJmLVAeu46s0OIJ8hE=,iv:aXSwpX7RoG054EjScRzya0IfTaveDTbh156tAy8RD74=,tag:EFJHBskfAYX1LU6bcJU7fg==,type:str]
+    lastmodified: "2026-05-18T15:09:45Z"
+    mac: ENC[AES256_GCM,data:v9hdcMQQqUsc7TvT+Bfb/tBgc3eOS27f7BRBbKdBhhzFg4a6nAfliUhg/C+/Jd/3usFrBFDHZ0fb3VeKZIqgpjrWejdXIj2EWtQSmC8bx7zHsGSUkxm1MgmsV/i4yViaAibDtP5e57PH62IKPhLFPZbaQMy29dEhbsbtAm9BZz4=,iv:U9D6v2jym9PrCTXwrXfADlUCGZqcxuF7iOVrHeCyUIU=,tag:sZN0N3SVHXSL0dCXwrueeg==,type:str]
+    pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/deploy/k8s/testing/secret.yaml
+++ b/deploy/k8s/testing/secret.yaml
@@ -11,14 +11,18 @@ stringData:
     FUNNELBARN_SELF_API_KEY: ENC[AES256_GCM,data:VnNVDRC9VlPWVrn+AfVTsmS6+4pnmREzW5CsCxIPcRSr5CCBjL7JmA==,iv:lYwQRC1zgbq16W7iaL81kUnuxc1I82QwdZZnmpyduXs=,tag:r4uMI14dybu6m8S6fthtMg==,type:str]
     FUNNELBARN_SELF_ENDPOINT: ENC[AES256_GCM,data:bHphSc24+xzpLwffZNLjaq3rsTjSmuLBtA==,iv:p7zInON3d7g1GN78IQX107xyaik8CnTvr++ZRZR/jF4=,tag:NRUGyQ0hBJpI52SUiuFXmg==,type:str]
     FUNNELBARN_SESSION_SECRET: ENC[AES256_GCM,data:Ka+WUlLPusWDisSUDIoL3Vji6q+WUG8GsBkuyax4htSfbk6eoy3uSJQSUvH2p/PG+1+0EeiTdgANseN0WfafwA==,iv:V218Ak+t1c29NizuhpjStfKTlPOgNqxbyvlzyjzig/U=,tag:S0jGV0pbv5pejaiaWKxpNg==,type:str]
-    FUNNELBARN_SPANBARN_ENDPOINT: ENC[AES256_GCM,data:jLPwmVWEqHx7StGfn+rUBUi5gxo9y1hqw0Mt9RZJq0eZNZDt,iv:DilahkbgqTSVXSOIA2KL2qVtswIDUpBzvVLCCTwgFdY=,tag:sKznY8Mo4QJr1qkyAKHByw==,type:str]
-    FUNNELBARN_SPANBARN_API_KEY: ENC[AES256_GCM,data:HsD+XspTd9nYabnPSeSeLS2smGV9AXJQHe35WDy4OLDjnxRAoP9TcQ==,iv:eI9DY9oXn2NBNrzRu/HvvSNecjnkB2eRH7Rwk+9bkOQ=,tag:HQtRylNW04SgtfWvYK58Uw==,type:str]
+    FUNNELBARN_SPANBARN_ENDPOINT: ENC[AES256_GCM,data:uLGfW5QrEkbvpo2PV/Xur5oKkorYdY8f9NpSfLunMlZRvv5FkHQ7Q6AxmiUQL0F9ufo=,iv:Ssy52JdJolqkuGDkdB/G8tONVD0Z9ZJnR46Y+6lwcqg=,tag:mZBsQRrK3C+UxJWl4IZATQ==,type:str]
+    FUNNELBARN_SPANBARN_API_KEY: ENC[AES256_GCM,data:NpH0Yj4vO2lck8MZg5IER0RXYKIRrhfal8ANWUc0wM+doVCh3KJvAA==,iv:yO7zV3F0/gYsdoGuHR7lhQmB5Ed5sGkJs/IHESz+EZk=,tag:rUO8xaYGZovODx6t5ZhNlg==,type:str]
     FUNNELBARN_IAMBARN_ENABLED: ENC[AES256_GCM,data:fs3mKLQ=,iv:kDtg7RyFR81QtYbro8nGv8jesLPYF9AOGBdHXK5p6to=,tag:BROc0N6J/Oo6d5G3tcxppg==,type:str]
     FUNNELBARN_IAMBARN_CLIENT_ID: ENC[AES256_GCM,data:Dc0MyNyzEfFAIX2DfDvdudQcLe2AwhMXi3tL3GRLsoWoYbZ9g5060t7q9r0=,iv:jNaV+Jzc9wjblaaqb1PDNhBxPfNP6OmY7OgTrNMMEP4=,tag:4/DNEMJFLOX4yXpiHdOZxw==,type:str]
     GEOIPUPDATE_ACCOUNT_ID: ENC[AES256_GCM,data:kNSVQrpkZA==,iv:wOCAo3IgiMofoW1AGK7I5KFD2xUF6T6w97kucywfvLk=,tag:A8JikXgrx54BR+HHJHML7Q==,type:str]
     GEOIPUPDATE_LICENSE_KEY: ENC[AES256_GCM,data:fX32wEEfx9+3KidaV5YVuBIgzzVuM8CuifDSSueEMsmwznUULAFJcA==,iv:AYSd0F6/yfYfhgTOyzschE8VFzHcPx2+XS7bJ1QaWmU=,tag:2wD68QWVomhhwE94eEqwxg==,type:str]
 type: ENC[AES256_GCM,data:ETH/E3ZO,iv:FKQE873C2MNTWi9dJ8gk3tJj0mVfsWnb98CRttHkUCI=,tag:TthlSQPFdD1TZkjo5ri+HA==,type:str]
 sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
     age:
         - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
           enc: |
@@ -29,7 +33,8 @@ sops:
             YVRMZnBPamJLSEV0bHYzaXpnbWQ0VWMKQtcZclj7MlV8sg2Jo5buKYxtkn5Ww15U
             sTAHou/EFRgHbnpEjf2jjjUZshqOwjv6unN5Wyeq+XGsTqNuV/pHPQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-17T09:15:10Z"
-    mac: ENC[AES256_GCM,data:Ytrz5b3KFtylbHTxcd9ChaCCYlmDj6N7CyOYYHzd6kpnuSJNQP5njfMRKZvQsUzqnfLfHgidwqj5ol3Fb/qRK46yWnALzHn5LGFXVOJvvBzPGQNRT2GxO4NIeynmitQ4/jJgmeZ9grqVyxMlJYqLTzKrh1jbEiMGuDH+8OBTtbs=,iv:lc1GbZADrP6P7udDof+1S/FYlA2e09PlVODWdbycTys=,tag:s72GN/s2jm+ysoAQOHkEFg==,type:str]
+    lastmodified: "2026-05-18T15:09:45Z"
+    mac: ENC[AES256_GCM,data:J0slZWw9XoISDSiDY4Db23EQFF8hXjRH57O7r9e7aWx+vfJ/wY354HB5Z6+x2TVeZHPX/E7a3KFPuaYrAj1dpYIGeQvQ9IhvJDllJ4apUY8aAO1gvG5vvlaw2LfeCQ19WjswRLErdrCmptvytkFhDWuuW87k1+4fftazdjynwnc=,iv:NlprqGg8dXG4gsWNKJquCGjgt7xVd61yEAc3yKUuYa4=,tag:NhGioHGHXEnBanRP3jXCRg==,type:str]
+    pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Summary

testing and staging were both reporting traces to production spanbarn (\`spanbarn.wiebe.xyz\`). Dogfood per-env instead:

- testing → \`spanbarn-test.nijmegen.wiebe.xyz/v1/traces\`
- staging → \`spanbarn-staging.nijmegen.wiebe.xyz/v1/traces\`
- production → unchanged (\`spanbarn.wiebe.xyz/v1/traces\`)

Keys provisioned via \`spanbarn-{env}.nijmegen.wiebe.xyz/api/v1/setup/funnelbarn\` (deterministic per project slug). Deployment bindings were already in place.

## Test plan

- [ ] CI deploys cleanly to testing
- [ ] Traces for the test funnelbarn pod show up in spanbarn-test, not spanbarn-prod
- [ ] Same for staging