### PR TITLE
fix(staging): correct FUNNELBARN_SPANBARN_API_KEY for spanbarn-staging

### DIFF
--- a/deploy/k8s/staging/secret.yaml
+++ b/deploy/k8s/staging/secret.yaml
@@ -12,7 +12,7 @@ stringData:
     FUNNELBARN_SELF_ENDPOINT: ENC[AES256_GCM,data:YHzIzK7orQRstScf7EJed5o6zYAJTZJq7Sg6nzHm7oj8,iv:CUTQ3T2C8A3TdR1U0HNYqG/+aLXULWFWVW+S6L4cuvU=,tag:bnoL4Drqi9dotWgYHVIm8A==,type:str]
     FUNNELBARN_SESSION_SECRET: ENC[AES256_GCM,data:IkDl0LhwOcWYZTbXM5HuW4JvjskUHBhhg03cLhnf9HFnPDhKyKcEuLePFRT8LDjtGaNGtBUzqBN0MEyJc7wZCA==,iv:wjgWWucSu7Bp1c3GABv34prrs2NwBD+J+GACVA+Jqy0=,tag:kfVEjCaNpyD4VvgX756Owg==,type:str]
     FUNNELBARN_SPANBARN_ENDPOINT: ENC[AES256_GCM,data:7lZHOW+vXQj0x1wjbG7lUUpzWlS/4HiDpyC+TMS0OFrYkHilv1DUVY7i4ioFUahdzNamWWw=,iv:KOWo8p9k3ivITHFu/2rUwAeQYKQZAkd29MNQ5DNI8DM=,tag:tEyBbbyYi5gijTBHoZMS7A==,type:str]
-    FUNNELBARN_SPANBARN_API_KEY: ENC[AES256_GCM,data:EXxFyM84xXupz/DyuNA7GZge1GVLzMRz4o4E0Hjd2/5aX9wRfQirHg==,iv:mKl0T74Oi9oZKrpcZQGgVsyPhHLdMNx6egbxIQtjbrc=,tag:qR+E/sYYUkD+NzoZm6ehEg==,type:str]
+    FUNNELBARN_SPANBARN_API_KEY: ENC[AES256_GCM,data:ZFFbuYwEgZ2mVhDiTK9Un9nFgCqFUGs1kNmrdqxRcOGQShX4lyYGbg==,iv:Ojbm6mugWyrgp0GkP0Eulh/v4A15jHFIiCT1yRtsnTU=,tag:qW22zvaDqKyYoehG9zvRIA==,type:str]
     FUNNELBARN_IAMBARN_ENABLED: ENC[AES256_GCM,data:bp/EVxM=,iv:/ax6WW1SXry/qvxn1sVExgB5TPtoWH99rpoIzxSDPwA=,tag:eBdADL6xvnAGAUJ5UYdXWw==,type:str]
     FUNNELBARN_IAMBARN_CLIENT_ID: ENC[AES256_GCM,data:SnCchjkihlWUMd7alWDqssxznswh4lQBxbJlaNQ51gJyyPy5hWEUoeeEy+o=,iv:3o/QOHKxqv/on84oCoU5p1P4Fvq4Fd9onCvhcS69pRU=,tag:OZgKAdll9DRhEtS0PBkBzw==,type:str]
     GEOIPUPDATE_ACCOUNT_ID: ENC[AES256_GCM,data:xVEE+MCiYg==,iv:6CdJ3Ug9+MpnHBCGOR3KFIbAMUBpK+FJod/xMm1GPdE=,tag:HkM7sAdFuffQNeXLxXFWqw==,type:str]
@@ -33,8 +33,8 @@ sops:
             M1pZcUQrWmxCWlQzUldpcWZpTlF5Z2sKxvRXA7kLe7HoC+UJmtfQuzGOZ+1oaKvI
             anzLivgCzT7bxqYfSbAjDu3HY+wdVU4ezJeAgAnL7EXH5B8YCFNyJg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-18T15:48:35Z"
-    mac: ENC[AES256_GCM,data:TvuhZMeczB/s/X0c1DRlKDYUGAXnKPWmjo8LZBzn2e0gdEhr/jyvwoPyKm8DRNgg4boAYcsk1FJSj3X7G+hzdynkn+8IEaiEhFQOJMoTH4aGBOF6Y2zSL2FA2Ebk0Np/WsotoLan/mweZMKZZBCcjeiqmME129MHJiy68wuk5mk=,iv:JLLGSXcMo+Se0Hz4A9vHHItsxfQI7W1RJKJjpwpoMTc=,tag:l9t3aihdCQ8Oh5v4dWQo9w==,type:str]
+    lastmodified: "2026-05-18T16:12:50Z"
+    mac: ENC[AES256_GCM,data:jgIV9ehqMWdj6rkAWnBSh4WYgf+nMZ0zz7jDfEWY4Y7izwZOVyn/Ro+lKs//Gv0KPh6dQ3Suw/dZ9Y5pmY9w19Wpysq93fM1unNXI2S8y8UdQSysb8PZQvhKWKVg8yS/F1kZnH7c+c1Pkrn84PIWYpu0uPC71BIydQVWA7O4zcM=,iv:wELc7H4sKM63FlKI5YSEtrAfHlYDGhfGuOJHjXQJij8=,tag:iN0r/8zHLvztswTiNeFvuA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Summary

PR #118 copied the wrong key into staging — I'd grabbed it from the first round of provisioning that hit \`spanbarn.wiebe.xyz/api/v1/setup/funnelbarn-staging\` (prod spanbarn, project-slug-includes-env), then mixed it up with the per-env-instance round that uses slug \`funnelbarn\` on the \`spanbarn-staging\` instance. Live probe of \`POST /v1/traces\` returned \`401 invalid API key\`.

Replace with the deterministic key from \`spanbarn-staging.nijmegen.wiebe.xyz/api/v1/setup/funnelbarn\`. Re-probed → \`200\`.

## Test plan

- [ ] CI deploy succeeds
- [ ] funnelbarn-staging traces appear in spanbarn-staging