### PR TITLE
feat: serve testing+staging at funnelbarn.{test,staging}.wiebe.xyz

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -235,7 +235,7 @@ jobs:
 
       - name: Run E2E tests
         env:
-          E2E_BASE_URL: https://funnelbarn-test.nijmegen.wiebe.xyz
+          E2E_BASE_URL: https://funnelbarn.test.wiebe.xyz
           # k3s cluster private IP — reachable from the Mac Mini runner
           E2E_CLUSTER_IP: 192.168.4.108
         run: npx playwright test --reporter=list,html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,8 @@
 ## Environments
 
 - **Production**: `funnelbarn.wiebe.xyz` (Cloudflare → k3s)
-- **Testing**: `funnelbarn-test.nijmegen.wiebe.xyz` (Caddy @ 192.168.4.111 → k3s)
-- **Staging**: `funnelbarn-staging.nijmegen.wiebe.xyz` (Caddy @ 192.168.4.111 → k3s)
+- **Testing**: `funnelbarn.test.wiebe.xyz` (legacy alias: `funnelbarn-test.nijmegen.wiebe.xyz`, still served)
+- **Staging**: `funnelbarn.staging.wiebe.xyz` (legacy alias: `funnelbarn-staging.nijmegen.wiebe.xyz`, still served)
 - Non-production uses `*.nijmegen.wiebe.xyz` wildcard — Caddy handles TLS, no Cloudflare free-tier limits
 
 ## Workflow

--- a/deploy/k8s/staging/deployment.yaml
+++ b/deploy/k8s/staging/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - name: FUNNELBARN_ADDR
               value: :8080
             - name: FUNNELBARN_PUBLIC_URL
-              value: https://funnelbarn-staging.nijmegen.wiebe.xyz
+              value: https://funnelbarn.staging.wiebe.xyz
             - name: FUNNELBARN_SPOOL_DIR
               value: /var/lib/funnelbarn/spool
             - name: FUNNELBARN_DB_PATH

--- a/deploy/k8s/staging/ingress.yaml
+++ b/deploy/k8s/staging/ingress.yaml
@@ -9,6 +9,26 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
+    - host: funnelbarn.staging.wiebe.xyz
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: funnelbarn
+                port:
+                  name: http
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: funnelbarn-web
+                port:
+                  name: http
+    # Legacy host — kept during the migration so existing consumers keep
+    # working until they roll out with the new URL. Drop once everything
+    # has moved over.
     - host: funnelbarn-staging.nijmegen.wiebe.xyz
       http:
         paths:
@@ -28,4 +48,5 @@ spec:
                   name: http
   tls:
     - hosts:
+        - funnelbarn.staging.wiebe.xyz
         - funnelbarn-staging.nijmegen.wiebe.xyz

--- a/deploy/k8s/testing/deployment.yaml
+++ b/deploy/k8s/testing/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - name: FUNNELBARN_ADDR
               value: :8080
             - name: FUNNELBARN_PUBLIC_URL
-              value: https://funnelbarn-test.nijmegen.wiebe.xyz
+              value: https://funnelbarn.test.wiebe.xyz
             - name: FUNNELBARN_LOGIN_RATE_PER_MINUTE
               value: "1000"
             - name: FUNNELBARN_LOGIN_RATE_BURST

--- a/deploy/k8s/testing/ingress.yaml
+++ b/deploy/k8s/testing/ingress.yaml
@@ -9,6 +9,26 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
+    - host: funnelbarn.test.wiebe.xyz
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: funnelbarn
+                port:
+                  name: http
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: funnelbarn-web
+                port:
+                  name: http
+    # Legacy host — kept during the migration so existing consumers keep
+    # working until they roll out with the new URL. Drop once everything
+    # has moved over.
     - host: funnelbarn-test.nijmegen.wiebe.xyz
       http:
         paths:
@@ -28,4 +48,5 @@ spec:
                   name: http
   tls:
     - hosts:
+        - funnelbarn.test.wiebe.xyz
         - funnelbarn-test.nijmegen.wiebe.xyz


### PR DESCRIPTION
## Summary

Move funnelbarn's non-prod public hostnames onto the canonical \`*.{test,staging}.wiebe.xyz\` wildcard the rest of the barns already use (bugbarn, iambarn, geobarn). The legacy \`funnelbarn-{test,staging}.nijmegen.wiebe.xyz\` hosts stay on the ingress so existing consumers keep working until they roll out the new URL; a follow-up will drop the legacy entries.

### Changes

- \`deploy/k8s/{testing,staging}/ingress.yaml\` — add the new host (with TLS via the existing Let's Encrypt resolver, both names in the cert SAN list)
- \`deploy/k8s/{testing,staging}/deployment.yaml\` — \`FUNNELBARN_PUBLIC_URL\` → the canonical name so setup pages, SDK links, and OAuth callbacks render the new URL by default
- \`CLAUDE.md\` — docs
- \`.github/workflows/build-and-test.yml\` — \`E2E_BASE_URL\`

## Test plan

- [ ] CI green; e2e suite passes against the new URL
- [ ] \`curl https://funnelbarn.test.wiebe.xyz/api/v1/client-config\` returns 200 with the funnelbarn block
- [ ] \`curl https://funnelbarn-test.nijmegen.wiebe.xyz/api/v1/client-config\` still returns 200 (legacy alias)