### PR TITLE
feat(secrets): wire FUNNELBARN_OIDC_* for testing

### DIFF
--- a/deploy/k8s/testing/secret.yaml
+++ b/deploy/k8s/testing/secret.yaml
@@ -17,6 +17,10 @@ stringData:
     FUNNELBARN_IAMBARN_CLIENT_ID: ENC[AES256_GCM,data:Dc0MyNyzEfFAIX2DfDvdudQcLe2AwhMXi3tL3GRLsoWoYbZ9g5060t7q9r0=,iv:jNaV+Jzc9wjblaaqb1PDNhBxPfNP6OmY7OgTrNMMEP4=,tag:4/DNEMJFLOX4yXpiHdOZxw==,type:str]
     GEOIPUPDATE_ACCOUNT_ID: ENC[AES256_GCM,data:kNSVQrpkZA==,iv:wOCAo3IgiMofoW1AGK7I5KFD2xUF6T6w97kucywfvLk=,tag:A8JikXgrx54BR+HHJHML7Q==,type:str]
     GEOIPUPDATE_LICENSE_KEY: ENC[AES256_GCM,data:fX32wEEfx9+3KidaV5YVuBIgzzVuM8CuifDSSueEMsmwznUULAFJcA==,iv:AYSd0F6/yfYfhgTOyzschE8VFzHcPx2+XS7bJ1QaWmU=,tag:2wD68QWVomhhwE94eEqwxg==,type:str]
+    FUNNELBARN_OIDC_ISSUER: ENC[AES256_GCM,data:nrSUb7WZqsawzJF2IidyDfhiM52axYUF7DQ=,iv:EGyKq4V4VGDrri+gnx+CY1/hETBwaQJylP1baLStdLc=,tag:E98lsBk4aC0ONqu4DR/QGg==,type:str]
+    FUNNELBARN_OIDC_CLIENT_ID: ENC[AES256_GCM,data:mUotE2zlPwowyG2P03SgalhJ,iv:rEjZbi0Sk2TxrAZCTPTCWBM3XxYEKBFquYGqVyVYgWg=,tag:mE9zpi/4OB/3IlWdm6PTRA==,type:str]
+    FUNNELBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:bKK27M7UFTprMhUQaJP3/ZKs1zKlnYk+3/KBAELInGNCdiCFK9/O0Rirng==,iv:77XxAEvQDfZupsTTGJwgjtnzuDWzZCwJqL2vkVpyeF4=,tag:bBZtMRB7fkH3uRTVgieT1w==,type:str]
+    FUNNELBARN_OIDC_REDIRECT_URL: ENC[AES256_GCM,data:JHyCBMzVUtOdkapSqqqP9/+UASQl/fmTq/Qyj2wZyvJgFGqdBUAg95KH6/Us1A2MeFEp69nm,iv:Q84jA1VNlFyqWlSaKhP20/PLjEAuAk5t6PV2NTuG7TM=,tag:9DZd3/zMoT1C3q2bz/4zJQ==,type:str]
 type: ENC[AES256_GCM,data:ETH/E3ZO,iv:FKQE873C2MNTWi9dJ8gk3tJj0mVfsWnb98CRttHkUCI=,tag:TthlSQPFdD1TZkjo5ri+HA==,type:str]
 sops:
     kms: []
@@ -33,8 +37,8 @@ sops:
             YVRMZnBPamJLSEV0bHYzaXpnbWQ0VWMKQtcZclj7MlV8sg2Jo5buKYxtkn5Ww15U
             sTAHou/EFRgHbnpEjf2jjjUZshqOwjv6unN5Wyeq+XGsTqNuV/pHPQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-18T16:32:52Z"
-    mac: ENC[AES256_GCM,data:yA3CztaT5PvXz8bKXc5xV+EIt2Nq5UgPuIiobi+Rgbk5gnrb1p3wUh6V2Q+YmrtDcS/Uv4C8E607QHLJeJKP1pkeWzzaGhy1WRIoFhPs6VyxRHNzP3VhUVGs9XFxx9eahOgWThyGBIXumJYAoPZMY4vFd67Prg4MkStbFEAP6A0=,iv:IpJOWxnPQ6QcbZN1VWGD/GThS+ve8NYP1eL4sc+THMg=,tag:cp1TiAlAMQu5jBMKCWZbZA==,type:str]
+    lastmodified: "2026-05-18T19:54:30Z"
+    mac: ENC[AES256_GCM,data:3+iHNxfFE/igkTs8kISKm0IqCGKKIM935d3spsszArgdFb9oixyiGR7GEcAvgNWx9FAA0s3ZqKv7uhckYENokpeH+oIV21AWBZ+zzodTcJNe+c2nVYqhNM8nSl6DyIFXqhw32z5QtCQvdf7ZPgoIiG4AXbYEhIZOiADWE3vQgjk=,iv:VPamevIn03WY6VVGk8RfGWiQHtt+F3b6CvcqhilNxOY=,tag:7iDPnKDJ1Xs+Sz6LhsLJdA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Summary
- Adds the iambarn OIDC credentials to funnelbarn-testing's SOPS secret.
- Client minted via \`iamctl client create --confidential\` on iambarn-testing (operator org).
- Note: funnelbarn already has a separate IAMBarn PKCE flow at \`/api/v1/auth/oidc/*\` gated by an in-app feature flag (from PR #111). This wires the bugbarn-pattern confidential flow added in #123 — the two coexist for now; consolidation is a follow-up.

## Test plan
- [ ] CI deploy lands the new keys
- [ ] \`curl https://funnelbarn.test.wiebe.xyz/api/v1/client-config\` reports \`oidc.enabled=true\` via the new flow
- [ ] \`curl -I https://funnelbarn.test.wiebe.xyz/api/v1/oidc/login\` returns 302 to iam.test.wiebe.xyz