### PR TITLE
fix(deploy): bind FUNNELBARN_OIDC_* env vars into the container

### DIFF
--- a/deploy/k8s/production/deployment.yaml
+++ b/deploy/k8s/production/deployment.yaml
@@ -131,6 +131,30 @@ spec:
                   name: funnelbarn-secrets
                   key: FUNNELBARN_IAMBARN_CLIENT_ID
                   optional: true
+            - name: FUNNELBARN_OIDC_ISSUER
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_OIDC_ISSUER
+                  optional: true
+            - name: FUNNELBARN_OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_OIDC_CLIENT_ID
+                  optional: true
+            - name: FUNNELBARN_OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_OIDC_CLIENT_SECRET
+                  optional: true
+            - name: FUNNELBARN_OIDC_REDIRECT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_OIDC_REDIRECT_URL
+                  optional: true
             - name: FUNNELBARN_GEOIP_CITY_DB
               value: /var/lib/funnelbarn/geoip/GeoLite2-City.mmdb
             - name: FUNNELBARN_GEOIP_ASN_DB

--- a/deploy/k8s/staging/deployment.yaml
+++ b/deploy/k8s/staging/deployment.yaml
@@ -125,6 +125,30 @@ spec:
                   name: funnelbarn-secrets
                   key: FUNNELBARN_IAMBARN_CLIENT_ID
                   optional: true
+            - name: FUNNELBARN_OIDC_ISSUER
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_OIDC_ISSUER
+                  optional: true
+            - name: FUNNELBARN_OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_OIDC_CLIENT_ID
+                  optional: true
+            - name: FUNNELBARN_OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_OIDC_CLIENT_SECRET
+                  optional: true
+            - name: FUNNELBARN_OIDC_REDIRECT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_OIDC_REDIRECT_URL
+                  optional: true
             - name: FUNNELBARN_GEOIP_CITY_DB
               value: /var/lib/funnelbarn/geoip/GeoLite2-City.mmdb
             - name: FUNNELBARN_GEOIP_ASN_DB

--- a/deploy/k8s/testing/deployment.yaml
+++ b/deploy/k8s/testing/deployment.yaml
@@ -119,6 +119,30 @@ spec:
                   name: funnelbarn-secrets
                   key: FUNNELBARN_IAMBARN_CLIENT_ID
                   optional: true
+            - name: FUNNELBARN_OIDC_ISSUER
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_OIDC_ISSUER
+                  optional: true
+            - name: FUNNELBARN_OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_OIDC_CLIENT_ID
+                  optional: true
+            - name: FUNNELBARN_OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_OIDC_CLIENT_SECRET
+                  optional: true
+            - name: FUNNELBARN_OIDC_REDIRECT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_OIDC_REDIRECT_URL
+                  optional: true
             - name: FUNNELBARN_GEOIP_CITY_DB
               value: /var/lib/funnelbarn/geoip/GeoLite2-City.mmdb
             - name: FUNNELBARN_GEOIP_ASN_DB

--- a/deploy/k8s/testing/secret.yaml
+++ b/deploy/k8s/testing/secret.yaml
@@ -17,6 +17,10 @@ stringData:
     FUNNELBARN_IAMBARN_CLIENT_ID: ENC[AES256_GCM,data:Dc0MyNyzEfFAIX2DfDvdudQcLe2AwhMXi3tL3GRLsoWoYbZ9g5060t7q9r0=,iv:jNaV+Jzc9wjblaaqb1PDNhBxPfNP6OmY7OgTrNMMEP4=,tag:4/DNEMJFLOX4yXpiHdOZxw==,type:str]
     GEOIPUPDATE_ACCOUNT_ID: ENC[AES256_GCM,data:kNSVQrpkZA==,iv:wOCAo3IgiMofoW1AGK7I5KFD2xUF6T6w97kucywfvLk=,tag:A8JikXgrx54BR+HHJHML7Q==,type:str]
     GEOIPUPDATE_LICENSE_KEY: ENC[AES256_GCM,data:fX32wEEfx9+3KidaV5YVuBIgzzVuM8CuifDSSueEMsmwznUULAFJcA==,iv:AYSd0F6/yfYfhgTOyzschE8VFzHcPx2+XS7bJ1QaWmU=,tag:2wD68QWVomhhwE94eEqwxg==,type:str]
+    FUNNELBARN_OIDC_ISSUER: ENC[AES256_GCM,data:nrSUb7WZqsawzJF2IidyDfhiM52axYUF7DQ=,iv:EGyKq4V4VGDrri+gnx+CY1/hETBwaQJylP1baLStdLc=,tag:E98lsBk4aC0ONqu4DR/QGg==,type:str]
+    FUNNELBARN_OIDC_CLIENT_ID: ENC[AES256_GCM,data:mUotE2zlPwowyG2P03SgalhJ,iv:rEjZbi0Sk2TxrAZCTPTCWBM3XxYEKBFquYGqVyVYgWg=,tag:mE9zpi/4OB/3IlWdm6PTRA==,type:str]
+    FUNNELBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:bKK27M7UFTprMhUQaJP3/ZKs1zKlnYk+3/KBAELInGNCdiCFK9/O0Rirng==,iv:77XxAEvQDfZupsTTGJwgjtnzuDWzZCwJqL2vkVpyeF4=,tag:bBZtMRB7fkH3uRTVgieT1w==,type:str]
+    FUNNELBARN_OIDC_REDIRECT_URL: ENC[AES256_GCM,data:JHyCBMzVUtOdkapSqqqP9/+UASQl/fmTq/Qyj2wZyvJgFGqdBUAg95KH6/Us1A2MeFEp69nm,iv:Q84jA1VNlFyqWlSaKhP20/PLjEAuAk5t6PV2NTuG7TM=,tag:9DZd3/zMoT1C3q2bz/4zJQ==,type:str]
 type: ENC[AES256_GCM,data:ETH/E3ZO,iv:FKQE873C2MNTWi9dJ8gk3tJj0mVfsWnb98CRttHkUCI=,tag:TthlSQPFdD1TZkjo5ri+HA==,type:str]
 sops:
     kms: []
@@ -33,8 +37,8 @@ sops:
             YVRMZnBPamJLSEV0bHYzaXpnbWQ0VWMKQtcZclj7MlV8sg2Jo5buKYxtkn5Ww15U
             sTAHou/EFRgHbnpEjf2jjjUZshqOwjv6unN5Wyeq+XGsTqNuV/pHPQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-18T16:32:52Z"
-    mac: ENC[AES256_GCM,data:yA3CztaT5PvXz8bKXc5xV+EIt2Nq5UgPuIiobi+Rgbk5gnrb1p3wUh6V2Q+YmrtDcS/Uv4C8E607QHLJeJKP1pkeWzzaGhy1WRIoFhPs6VyxRHNzP3VhUVGs9XFxx9eahOgWThyGBIXumJYAoPZMY4vFd67Prg4MkStbFEAP6A0=,iv:IpJOWxnPQ6QcbZN1VWGD/GThS+ve8NYP1eL4sc+THMg=,tag:cp1TiAlAMQu5jBMKCWZbZA==,type:str]
+    lastmodified: "2026-05-18T19:54:30Z"
+    mac: ENC[AES256_GCM,data:3+iHNxfFE/igkTs8kISKm0IqCGKKIM935d3spsszArgdFb9oixyiGR7GEcAvgNWx9FAA0s3ZqKv7uhckYENokpeH+oIV21AWBZ+zzodTcJNe+c2nVYqhNM8nSl6DyIFXqhw32z5QtCQvdf7ZPgoIiG4AXbYEhIZOiADWE3vQgjk=,iv:VPamevIn03WY6VVGk8RfGWiQHtt+F3b6CvcqhilNxOY=,tag:7iDPnKDJ1Xs+Sz6LhsLJdA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Summary
- The OIDC PR (#123) wired \`FUNNELBARN_OIDC_*\` on the Go side but didn't add explicit \`secretKeyRef\` bindings to the deployment manifests.
- Without these, the secret values added in #124 never reach the container — \`runtime-config\` reports \`oidc.enabled=false\` and \`/api/v1/oidc/login\` stays unregistered.
- Adds four bindings (issuer, client_id, client_secret, redirect_url) to all three envs with \`optional: true\`, matching the existing \`FUNNELBARN_IAMBARN_CLIENT_ID\` pattern.

## Test plan
- [ ] After deploy: \`curl https://funnelbarn.test.wiebe.xyz/api/v1/client-config\` reports \`oidc.enabled=true\`
- [ ] \`curl -I https://funnelbarn.test.wiebe.xyz/api/v1/oidc/login\` returns 302 to iam.test.wiebe.xyz