### PR TITLE
fix(login): defer to legacy IAMBarn button when both flows are enabled

### DIFF
--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -28,11 +28,12 @@ export default function Login() {
   useEffect(() => {
     api.getClientConfig().then((cfg) => {
       setIambarnEnabled(cfg.iambarn_enabled)
-      // If the bugbarn-style confidential OIDC flow is configured server-side,
-      // auto-redirect to the OIDC login URL instead of showing the local form.
-      // The local form is still wired up for the zero-config case.
+      // If the bugbarn-style confidential OIDC flow is configured server-side
+      // AND the legacy IAMBarn PKCE flow is not enabled, auto-redirect to the
+      // OIDC login URL. When both are configured the legacy button-driven flow
+      // takes priority; consolidation is a follow-up.
       const oc = cfg.oidc
-      if (oc?.enabled && oc.loginURL) {
+      if (!cfg.iambarn_enabled && oc?.enabled && oc.loginURL) {
         window.location.assign(oc.loginURL)
       }
     }).catch(() => {


### PR DESCRIPTION
## Summary
- When \`FUNNELBARN_IAMBARN_ENABLED\` resolves true (current default for Chrome UA on funnelbarn-testing), the legacy PKCE-based \"Continue with IAMBarn\" button flow takes priority.
- The bugbarn-pattern auto-redirect added in #123 was short-circuiting that, breaking the existing E2E tests at \`e2e/iambarn.spec.ts\` (they expect to find the button on \`/login\`, but were redirected away before they could click).
- One-line guard: only auto-redirect when the legacy flag is off.

## Test plan
- [ ] E2E tests pass (no \"Continue with IAMBarn\" timeout)
- [ ] funnelbarn-testing still shows the IAMBarn button for Chrome users
- [ ] When FUNNELBARN_IAMBARN_ENABLED is later disabled, the auto-redirect kicks in