### PR TITLE
fix(ci): use long-lived PAT for cluster GHCR pull secret

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -97,8 +97,8 @@ jobs:
           ssh -o StrictHostKeyChecking=no "${K3S_USER}@${K3S_HOST}" "
             kubectl create secret docker-registry ghcr-secret \
               --docker-server=ghcr.io \
-              --docker-username='${{ github.actor }}' \
-              --docker-password='${{ secrets.GITHUB_TOKEN }}' \
+              --docker-username='webwiebe' \
+              --docker-password='${{ secrets.GHCR_PULL_PAT }}' \
               --namespace=${NAMESPACE} \
               --dry-run=client -o yaml | kubectl apply -f -
           "
@@ -179,8 +179,8 @@ jobs:
           ssh -o StrictHostKeyChecking=no "${K3S_USER}@${K3S_HOST}" "
             kubectl create secret docker-registry ghcr-secret \
               --docker-server=ghcr.io \
-              --docker-username='${{ github.actor }}' \
-              --docker-password='${{ secrets.GITHUB_TOKEN }}' \
+              --docker-username='webwiebe' \
+              --docker-password='${{ secrets.GHCR_PULL_PAT }}' \
               --namespace=${NAMESPACE} \
               --dry-run=client -o yaml | kubectl apply -f -
           "

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -110,8 +110,8 @@ jobs:
           ssh -o StrictHostKeyChecking=no "${K3S_USER}@${K3S_HOST}" "
             kubectl create secret docker-registry ghcr-secret \
               --docker-server=ghcr.io \
-              --docker-username='${{ github.actor }}' \
-              --docker-password='${{ secrets.GITHUB_TOKEN }}' \
+              --docker-username='webwiebe' \
+              --docker-password='${{ secrets.GHCR_PULL_PAT }}' \
               --namespace=${NAMESPACE} \
               --dry-run=client -o yaml | kubectl apply -f -
           "


### PR DESCRIPTION
## Summary
- The cluster's `ghcr-secret` was being created with `secrets.GITHUB_TOKEN`, which is only valid for the duration of the workflow run. Any pod that needs to pull the image after the workflow ends (HPA scale-ups, node reboots, pod evictions) hit a 403.
- Switched the three `kubectl create secret docker-registry ghcr-secret` blocks (testing + staging in `build-and-test.yml`, production in `deploy-production.yml`) to use a long-lived `GHCR_PULL_PAT` repo secret with `webwiebe` as the username.
- Other uses of `secrets.GITHUB_TOKEN` (docker login during push, gh API calls) only need workflow-duration validity and are left untouched.

## Test plan
- [ ] CI green on this PR
- [ ] After merge: confirm `kubectl get secret ghcr-secret -n funnelbarn-testing -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d` contains the PAT, not the ephemeral token
- [ ] Trigger a pod restart (e.g. `kubectl rollout restart deploy/...`) some time after the workflow ends and verify the image pulls successfully