### PR TITLE
feat(secrets): wire FUNNELBARN_OIDC_* for staging

### DIFF
--- a/deploy/k8s/staging/secret.yaml
+++ b/deploy/k8s/staging/secret.yaml
@@ -17,6 +17,10 @@ stringData:
     FUNNELBARN_IAMBARN_CLIENT_ID: ENC[AES256_GCM,data:SnCchjkihlWUMd7alWDqssxznswh4lQBxbJlaNQ51gJyyPy5hWEUoeeEy+o=,iv:3o/QOHKxqv/on84oCoU5p1P4Fvq4Fd9onCvhcS69pRU=,tag:OZgKAdll9DRhEtS0PBkBzw==,type:str]
     GEOIPUPDATE_ACCOUNT_ID: ENC[AES256_GCM,data:xVEE+MCiYg==,iv:6CdJ3Ug9+MpnHBCGOR3KFIbAMUBpK+FJod/xMm1GPdE=,tag:HkM7sAdFuffQNeXLxXFWqw==,type:str]
     GEOIPUPDATE_LICENSE_KEY: ENC[AES256_GCM,data:/Ki4Bxr8AXwEwA5S0WFDldO1EQwQaNw1Vp7p4imNYMNbjujkP/Y4Ow==,iv:cXnbo9qNecWVNTP59Myb9hTbruA/tE/uzhCko3MaVpI=,tag:xr92k+SiZwpLSvkAW9Q6nA==,type:str]
+    FUNNELBARN_OIDC_ISSUER: ENC[AES256_GCM,data:ZPjMWKKN/X1gitTtoOWV9sY3mEdcPc89MH+bTlw=,iv:Z+3PPt5PXHPKDt3iVaFTR7LC7a5yMTagbSbtjR4xt0o=,tag:I2wiEi9oXo0RRLgr1GBEww==,type:str]
+    FUNNELBARN_OIDC_CLIENT_ID: ENC[AES256_GCM,data:nWVFFDQgbmFd1IGieDL3ka1D,iv:fRWroo/85qhWdXFFEqJiQKBp6qYZKpJWw8C0LnLieUE=,tag:DCqxTNwVBY0AK1Bf6ZZD6g==,type:str]
+    FUNNELBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:BaDFlddvvwhMgfYjpJNUck8y7PKPmgCw4v1H5Voi7w3MF7aaySJrA0FUeg==,iv:+Pps63PbY1W84w1/rtYW5zLV5vJfN18o64uDveYC5dQ=,tag:kq3jK6+mgiVqnldgjzuu3A==,type:str]
+    FUNNELBARN_OIDC_REDIRECT_URL: ENC[AES256_GCM,data:d9YhornCLqvtg67XSFx0W3pzmHo5Ap77mHon+9W6FD3VvgD5pyfpTOwfQOcjkTp+Elwe7j/qYfGn,iv:1GyUFdx80bes0tTURiI4ZTgfd5oEjYK/F+nek6GA2iw=,tag:HjDQh5zR3f/Vfi08H3aF5A==,type:str]
 type: ENC[AES256_GCM,data:j3xiz+Or,iv:IZU6E2E7NRmJNESOX3/39faVk97fZEPreoVimwYeHR8=,tag:JM35xtiOm/wxdt30cZHCXQ==,type:str]
 sops:
     kms: []
@@ -33,8 +37,8 @@ sops:
             M1pZcUQrWmxCWlQzUldpcWZpTlF5Z2sKxvRXA7kLe7HoC+UJmtfQuzGOZ+1oaKvI
             anzLivgCzT7bxqYfSbAjDu3HY+wdVU4ezJeAgAnL7EXH5B8YCFNyJg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-18T16:32:52Z"
-    mac: ENC[AES256_GCM,data:TS8Xb5GRsxngVyvuwOS3cSrZpmEqmEVjkP8KO0Eg36u7pFeCVq4DX5iFWtVyd5492J/uXG+a2/4CbQp5gzjJ6nBzCdXYfYqhaE3hfqMlQz4kucTm2fK0fbD+A9fPpPpqv+qUoO39hRHWlS8HlALRgXcJcFHANbif2yiPyHQV0TQ=,iv:wd7iv5u/dzeu7qYnQiKix3BToMb15urIpcvKOkU0nCc=,tag:lC9R0c2NWBSVtEvuJFSTSg==,type:str]
+    lastmodified: "2026-05-19T09:57:03Z"
+    mac: ENC[AES256_GCM,data:g/azTtFXBFDG/pi2v5KYqVaP3fKCUg+73spBIG4bSshY5e/SC6Ue53wN9515yc87xz3FnEBQ9Jw3HQ7+7UdprzWjRNtZZQeQsVT7B5hmh3wBY1pov7QaM0PQF1zaOG21wfieI0ItMAoKmqrd8YmH6yrbFqvCuuEnk7+mE23wUew=,iv:BHbXbjMUbfuiyqT3bqmF5xeZVMKBgKsoDRg2gTdCz6M=,tag:iyrZ0pQyyZAxLc25dDUIkw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
Adds the bugbarn-pattern OIDC credentials to funnelbarn-staging. Coexists with the legacy IAMBarn PKCE button which still takes UX priority via the Chrome-UA gate.