### PR TITLE
feat(auth): add Edit IAMBarn profile link to user menu

### DIFF
--- a/internal/api/client_config.go
+++ b/internal/api/client_config.go
@@ -1,6 +1,9 @@
 package api
 
-import "net/http"
+import (
+	"net/http"
+	"strings"
+)
 
 // handleClientConfig returns public client-side configuration for the frontend.
 // No auth required — values are safe to expose (ingest keys are public by design).
@@ -9,15 +12,19 @@ func (s *Server) handleClientConfig(w http.ResponseWriter, r *http.Request) {
 		Enabled  bool   `json:"enabled"`
 		LoginURL string `json:"loginURL,omitempty"`
 	}
+	type iambarnOut struct {
+		ProfileURL string `json:"profile_url,omitempty"`
+	}
 	type response struct {
-		BugbarnEndpoint    string  `json:"bugbarn_endpoint"`
-		BugbarnIngestKey   string  `json:"bugbarn_ingest_key"`
-		BugbarnProject     string  `json:"bugbarn_project,omitempty"`
-		FunnelbarnEndpoint string  `json:"funnelbarn_endpoint,omitempty"`
-		FunnelbarnAPIKey   string  `json:"funnelbarn_api_key,omitempty"`
-		FunnelbarnProject  string  `json:"funnelbarn_project,omitempty"`
-		IAMBarnEnabled     bool    `json:"iambarn_enabled"`
-		OIDC               oidcOut `json:"oidc"`
+		BugbarnEndpoint    string     `json:"bugbarn_endpoint"`
+		BugbarnIngestKey   string     `json:"bugbarn_ingest_key"`
+		BugbarnProject     string     `json:"bugbarn_project,omitempty"`
+		FunnelbarnEndpoint string     `json:"funnelbarn_endpoint,omitempty"`
+		FunnelbarnAPIKey   string     `json:"funnelbarn_api_key,omitempty"`
+		FunnelbarnProject  string     `json:"funnelbarn_project,omitempty"`
+		IAMBarnEnabled     bool       `json:"iambarn_enabled"`
+		IAMBarn            iambarnOut `json:"iambarn,omitempty"`
+		OIDC               oidcOut    `json:"oidc"`
 	}
 	resp := response{
 		BugbarnEndpoint:    s.bugbarnEndpoint,
@@ -31,5 +38,23 @@ func (s *Server) handleClientConfig(w http.ResponseWriter, r *http.Request) {
 	if s.oidc != nil {
 		resp.OIDC = oidcOut{Enabled: true, LoginURL: "/api/v1/oidc/login"}
 	}
+	if issuer := s.iambarnIssuer(); issuer != "" {
+		resp.IAMBarn.ProfileURL = strings.TrimRight(issuer, "/") + "/admin"
+	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// iambarnIssuer returns the configured iambarn issuer URL from either the
+// new confidential-client OIDC config or the legacy IAMBarn PKCE provider.
+// Returns "" when neither path is configured.
+func (s *Server) iambarnIssuer() string {
+	if s.oidc != nil {
+		if iss := s.oidc.Config().Issuer; iss != "" {
+			return iss
+		}
+	}
+	if s.iambarnProvider != nil {
+		return s.iambarnProvider.Issuer()
+	}
+	return ""
 }

--- a/internal/api/client_config_test.go
+++ b/internal/api/client_config_test.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wiebe-xyz/funnelbarn/internal/auth"
+	"github.com/wiebe-xyz/funnelbarn/internal/iambarn"
+)
+
+type clientConfigResp struct {
+	IAMBarnEnabled bool `json:"iambarn_enabled"`
+	IAMBarn        struct {
+		ProfileURL string `json:"profile_url,omitempty"`
+	} `json:"iambarn,omitempty"`
+	OIDC struct {
+		Enabled  bool   `json:"enabled"`
+		LoginURL string `json:"loginURL,omitempty"`
+	} `json:"oidc"`
+}
+
+func getClientConfig(t *testing.T, srv *Server) clientConfigResp {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/client-config", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var out clientConfigResp
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, w.Body.String())
+	}
+	return out
+}
+
+func TestClientConfig_NoIAMBarnConfigured(t *testing.T) {
+	srv, _ := newTestServer(t)
+	got := getClientConfig(t, srv)
+	if got.IAMBarn.ProfileURL != "" {
+		t.Errorf("expected empty profile_url, got %q", got.IAMBarn.ProfileURL)
+	}
+}
+
+func TestClientConfig_LegacyIAMBarnProviderSetsProfileURL(t *testing.T) {
+	srv, _ := newTestServer(t)
+	srv.iambarnProvider = iambarn.New("https://iam.test.wiebe.xyz/", "test-client", "https://funnelbarn.test/cb")
+	got := getClientConfig(t, srv)
+	want := "https://iam.test.wiebe.xyz/admin"
+	if got.IAMBarn.ProfileURL != want {
+		t.Errorf("profile_url: got %q, want %q", got.IAMBarn.ProfileURL, want)
+	}
+}
+
+func TestClientConfig_ConfidentialOIDCSetsProfileURL(t *testing.T) {
+	srv, _ := newTestServer(t)
+	srv.oidc = auth.NewOIDCClient(auth.OIDCConfig{
+		Issuer:       "https://iam.staging.wiebe.xyz",
+		ClientID:     "fb",
+		ClientSecret: "secret",
+		RedirectURL:  "https://funnelbarn.staging/cb",
+	})
+	got := getClientConfig(t, srv)
+	want := "https://iam.staging.wiebe.xyz/admin"
+	if got.IAMBarn.ProfileURL != want {
+		t.Errorf("profile_url: got %q, want %q", got.IAMBarn.ProfileURL, want)
+	}
+	if !got.OIDC.Enabled {
+		t.Errorf("expected oidc.enabled = true")
+	}
+}

--- a/internal/iambarn/iambarn.go
+++ b/internal/iambarn/iambarn.go
@@ -42,6 +42,11 @@ func New(issuer, clientID, redirectURI string) *Provider {
 	}
 }
 
+// Issuer returns the configured issuer URL (no trailing slash).
+func (p *Provider) Issuer() string {
+	return p.issuer
+}
+
 // GenerateVerifier generates a PKCE code_verifier (43 base64url chars from 32 random bytes).
 func GenerateVerifier() (string, error) {
 	b := make([]byte, 32)

--- a/web/src/components/shell/Shell.test.tsx
+++ b/web/src/components/shell/Shell.test.tsx
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Shell from './Shell'
 import type { ReactNode } from 'react'
 
 const mockLogout = vi.fn()
 const mockNavigate = vi.fn()
+const mockGetClientConfig = vi.fn()
 
 vi.mock('../../lib/auth', () => ({
   useAuth: () => ({
@@ -26,6 +27,12 @@ vi.mock('../../lib/projects', () => ({
   }),
 }))
 
+vi.mock('../../lib/api', () => ({
+  api: {
+    getClientConfig: (...args: unknown[]) => mockGetClientConfig(...args),
+  },
+}))
+
 vi.mock('react-router-dom', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react-router-dom')>()
   return { ...actual, useNavigate: () => mockNavigate }
@@ -40,7 +47,14 @@ function renderShell(ui: ReactNode = <div>child content</div>, projectId?: strin
 }
 
 describe('Shell', () => {
-  beforeEach(() => { vi.clearAllMocks() })
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetClientConfig.mockResolvedValue({
+      bugbarn_endpoint: '',
+      bugbarn_ingest_key: '',
+      iambarn_enabled: false,
+    })
+  })
 
   it('renders its children', () => {
     renderShell(<p>Hello world</p>)
@@ -78,5 +92,31 @@ describe('Shell', () => {
 
   it('renders without errors when no projectId is provided', () => {
     expect(() => renderShell()).not.toThrow()
+  })
+
+  it('does not show "Edit IAMBarn profile" link when iambarn profile_url is not configured', async () => {
+    renderShell()
+    // Open the desktop user menu so the dropdown is visible.
+    fireEvent.click(screen.getByText('testuser'))
+    // Give the effect a tick to resolve.
+    await waitFor(() => expect(mockGetClientConfig).toHaveBeenCalled())
+    expect(screen.queryByText('Edit IAMBarn profile')).not.toBeInTheDocument()
+  })
+
+  it('shows "Edit IAMBarn profile" link in the user menu when iambarn profile_url is configured', async () => {
+    mockGetClientConfig.mockResolvedValue({
+      bugbarn_endpoint: '',
+      bugbarn_ingest_key: '',
+      iambarn_enabled: false,
+      iambarn: { profile_url: 'https://iam.test.wiebe.xyz/admin' },
+    })
+    renderShell()
+    fireEvent.click(screen.getByText('testuser'))
+    const link = await screen.findByText('Edit IAMBarn profile')
+    const anchor = link.closest('a')
+    expect(anchor).not.toBeNull()
+    expect(anchor!.getAttribute('href')).toBe('https://iam.test.wiebe.xyz/admin')
+    expect(anchor!.getAttribute('target')).toBe('_blank')
+    expect(anchor!.getAttribute('rel')).toBe('noopener noreferrer')
   })
 })

--- a/web/src/components/shell/Shell.tsx
+++ b/web/src/components/shell/Shell.tsx
@@ -1,10 +1,10 @@
-import { ReactNode, useState } from 'react'
+import { ReactNode, useEffect, useState } from 'react'
 import { Link, useNavigate, useLocation } from 'react-router-dom'
-import { BarChart2, Layers, Radio, Settings, LogOut, User, Flag, Lightbulb, MoreHorizontal } from 'lucide-react'
+import { BarChart2, Layers, Radio, Settings, LogOut, User, Flag, Lightbulb, MoreHorizontal, ExternalLink } from 'lucide-react'
 import { useAuth } from '../../lib/auth'
 import { useProjects } from '../../lib/projects'
 import { ProjectPicker } from '../ui/ProjectPicker'
-import type { Project } from '../../lib/api'
+import { api, type Project } from '../../lib/api'
 
 const C = {
   bg: '#0f1117',
@@ -30,6 +30,19 @@ export default function Shell({ children, projectId, projectName, projects: proj
   const location = useLocation()
   const [userMenuOpen, setUserMenuOpen] = useState(false)
   const [moreSheetOpen, setMoreSheetOpen] = useState(false)
+  const [iambarnProfileURL, setIambarnProfileURL] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    api.getClientConfig()
+      .then((cfg) => {
+        if (!cancelled && cfg.iambarn?.profile_url) {
+          setIambarnProfileURL(cfg.iambarn.profile_url)
+        }
+      })
+      .catch(() => { /* non-fatal — menu item simply hidden */ })
+    return () => { cancelled = true }
+  }, [])
 
   const projects = projectsProp ?? ctxProjects
 
@@ -188,10 +201,37 @@ export default function Shell({ children, projectId, projectName, projects: proj
                 background: C.surface,
                 border: `1px solid ${C.border}`,
                 borderRadius: 8,
-                minWidth: 140,
+                minWidth: 200,
                 boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
                 zIndex: 200,
               }}>
+                {iambarnProfileURL && (
+                  <a
+                    href={iambarnProfileURL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={() => setUserMenuOpen(false)}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 8,
+                      width: '100%',
+                      textAlign: 'left',
+                      background: 'transparent',
+                      border: 'none',
+                      borderBottom: `1px solid ${C.border}`,
+                      color: C.text,
+                      padding: '0.6rem 1rem',
+                      cursor: 'pointer',
+                      fontSize: 14,
+                      textDecoration: 'none',
+                      boxSizing: 'border-box',
+                    }}
+                  >
+                    <ExternalLink size={14} />
+                    Edit IAMBarn profile
+                  </a>
+                )}
                 <button
                   onClick={handleLogout}
                   style={{
@@ -397,6 +437,30 @@ export default function Shell({ children, projectId, projectName, projects: proj
               <Settings size={18} color={C.muted} />
               Settings
             </Link>
+
+            {/* Edit IAMBarn profile — only when iambarn issuer is configured */}
+            {iambarnProfileURL && (
+              <a
+                href={iambarnProfileURL}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => setMoreSheetOpen(false)}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 12,
+                  padding: '0.75rem 0',
+                  textDecoration: 'none',
+                  color: C.text,
+                  fontSize: 15,
+                  fontWeight: 500,
+                  borderBottom: `1px solid ${C.border}`,
+                }}
+              >
+                <ExternalLink size={18} color={C.muted} />
+                Edit IAMBarn profile
+              </a>
+            )}
 
             {/* Logout */}
             <button

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -501,6 +501,9 @@ export interface ClientConfig {
   funnelbarn_api_key?: string
   funnelbarn_project?: string
   iambarn_enabled: boolean
+  iambarn?: {
+    profile_url?: string
+  }
   oidc?: {
     enabled?: boolean
     loginURL?: string

--- a/web/src/pages/Dashboard.test.tsx
+++ b/web/src/pages/Dashboard.test.tsx
@@ -32,6 +32,11 @@ const mockApi = vi.hoisted(() => ({
   createProject: vi.fn(),
   listFunnels: vi.fn(),
   getFunnelAnalysis: vi.fn(),
+  getClientConfig: vi.fn().mockResolvedValue({
+    bugbarn_endpoint: '',
+    bugbarn_ingest_key: '',
+    iambarn_enabled: false,
+  }),
 }))
 
 vi.mock('../lib/api', async (importOriginal) => {

--- a/web/src/pages/Settings.test.tsx
+++ b/web/src/pages/Settings.test.tsx
@@ -39,6 +39,11 @@ const mockApi = vi.hoisted(() => ({
   approveProject: vi.fn(),
   getInstanceSettings: vi.fn(),
   setInstanceSettings: vi.fn(),
+  getClientConfig: vi.fn().mockResolvedValue({
+    bugbarn_endpoint: '',
+    bugbarn_ingest_key: '',
+    iambarn_enabled: false,
+  }),
 }))
 
 vi.mock('../lib/api', async (importOriginal) => {


### PR DESCRIPTION
## Summary
- Extend `/api/v1/client-config` to include `iambarn.profile_url` ({issuer}/admin) whenever either OIDC path is configured: the new `FUNNELBARN_OIDC_*` confidential-client flow or the legacy `FUNNELBARN_IAMBARN_*` PKCE flow.
- Render an "Edit IAMBarn profile" link in the layout's user menu (desktop dropdown and mobile More sheet) that opens the profile URL in a new tab with `rel="noopener noreferrer"`.
- Add a small `Issuer()` accessor on `iambarn.Provider`; the confidential `OIDCClient` already exposes its issuer via `Config().Issuer`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — new `client_config_test.go` covers no-config, legacy IAMBarn provider, and confidential-OIDC paths
- [x] `npm --prefix web run build`
- [x] `npm --prefix web run lint`
- [x] `npm --prefix web test` — Shell tests cover absent and present `iambarn.profile_url`, asserting `target="_blank"` and `rel="noopener noreferrer"`
- [ ] Manual: log in via either OIDC path on `funnelbarn.test.wiebe.xyz` and verify the menu item appears and opens `iam.test.wiebe.xyz/admin`