### PR TITLE
Restrict IAMBarn profile link to OIDC sessions

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -73,6 +73,15 @@ func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
 	secure := r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
 	http.SetCookie(w, auth.ClearSessionCookie(secure))
 	http.SetCookie(w, auth.ClearCSRFCookie(secure))
+	// Clear the auth-method hint set by the OIDC callbacks.
+	http.SetCookie(w, &http.Cookie{
+		Name:     "funnelbarn_auth_method",
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	})
 	writeJSON(w, http.StatusOK, map[string]string{"status": "logged out"})
 }
 

--- a/internal/api/client_config.go
+++ b/internal/api/client_config.go
@@ -39,7 +39,7 @@ func (s *Server) handleClientConfig(w http.ResponseWriter, r *http.Request) {
 		resp.OIDC = oidcOut{Enabled: true, LoginURL: "/api/v1/oidc/login"}
 	}
 	if issuer := s.iambarnIssuer(); issuer != "" {
-		resp.IAMBarn.ProfileURL = strings.TrimRight(issuer, "/") + "/admin"
+		resp.IAMBarn.ProfileURL = strings.TrimRight(issuer, "/") + "/admin#profile"
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/api/client_config_test.go
+++ b/internal/api/client_config_test.go
@@ -48,7 +48,7 @@ func TestClientConfig_LegacyIAMBarnProviderSetsProfileURL(t *testing.T) {
 	srv, _ := newTestServer(t)
 	srv.iambarnProvider = iambarn.New("https://iam.test.wiebe.xyz/", "test-client", "https://funnelbarn.test/cb")
 	got := getClientConfig(t, srv)
-	want := "https://iam.test.wiebe.xyz/admin"
+	want := "https://iam.test.wiebe.xyz/admin#profile"
 	if got.IAMBarn.ProfileURL != want {
 		t.Errorf("profile_url: got %q, want %q", got.IAMBarn.ProfileURL, want)
 	}
@@ -63,7 +63,7 @@ func TestClientConfig_ConfidentialOIDCSetsProfileURL(t *testing.T) {
 		RedirectURL:  "https://funnelbarn.staging/cb",
 	})
 	got := getClientConfig(t, srv)
-	want := "https://iam.staging.wiebe.xyz/admin"
+	want := "https://iam.staging.wiebe.xyz/admin#profile"
 	if got.IAMBarn.ProfileURL != want {
 		t.Errorf("profile_url: got %q, want %q", got.IAMBarn.ProfileURL, want)
 	}

--- a/internal/api/oidc.go
+++ b/internal/api/oidc.go
@@ -141,6 +141,17 @@ func (s *Server) handleOIDCCallback(w http.ResponseWriter, r *http.Request) {
 
 	http.SetCookie(w, auth.SessionCookie(token, expires, secure))
 	http.SetCookie(w, auth.CSRFCookie(token, expires, secure))
+	// Non-HttpOnly hint so the SPA can show OIDC-specific UI (e.g. the
+	// IAMBarn profile link) only for sessions that actually came from
+	// iambarn. Same expiry as the session.
+	http.SetCookie(w, &http.Cookie{
+		Name:     "funnelbarn_auth_method",
+		Value:    "oidc",
+		Path:     "/",
+		Expires:  expires,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	})
 
 	slog.InfoContext(r.Context(), "oidc login", "sub", claims.Sub, "display", claims.DisplayName())
 	http.Redirect(w, r, "/dashboard", http.StatusFound)

--- a/internal/api/oidc_confidential.go
+++ b/internal/api/oidc_confidential.go
@@ -94,6 +94,17 @@ func (s *Server) handleOIDCConfidentialCallback(w http.ResponseWriter, r *http.R
 	secure := r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
 	http.SetCookie(w, auth.SessionCookie(token, expires, secure))
 	http.SetCookie(w, auth.CSRFCookie(token, expires, secure))
+	// Non-HttpOnly hint so the SPA can show OIDC-specific UI (e.g. the
+	// IAMBarn profile link) only for sessions that actually came from
+	// iambarn. Same expiry as the session.
+	http.SetCookie(w, &http.Cookie{
+		Name:     "funnelbarn_auth_method",
+		Value:    "oidc",
+		Path:     "/",
+		Expires:  expires,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	})
 	// Clear the short-lived state/nonce cookies.
 	http.SetCookie(w, oidcConfShortLivedCookie(oidcConfStateCookie, "", secure))
 	http.SetCookie(w, oidcConfShortLivedCookie(oidcConfNonceCookie, "", secure))

--- a/web/src/components/shell/Shell.test.tsx
+++ b/web/src/components/shell/Shell.test.tsx
@@ -49,6 +49,8 @@ function renderShell(ui: ReactNode = <div>child content</div>, projectId?: strin
 describe('Shell', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Reset auth-method cookie between tests so we can opt in per case.
+    document.cookie = 'funnelbarn_auth_method=; path=/; max-age=0'
     mockGetClientConfig.mockResolvedValue({
       bugbarn_endpoint: '',
       bugbarn_ingest_key: '',
@@ -95,6 +97,7 @@ describe('Shell', () => {
   })
 
   it('does not show "Edit IAMBarn profile" link when iambarn profile_url is not configured', async () => {
+    document.cookie = 'funnelbarn_auth_method=oidc; path=/'
     renderShell()
     // Open the desktop user menu so the dropdown is visible.
     fireEvent.click(screen.getByText('testuser'))
@@ -103,20 +106,38 @@ describe('Shell', () => {
     expect(screen.queryByText('Edit IAMBarn profile')).not.toBeInTheDocument()
   })
 
-  it('shows "Edit IAMBarn profile" link in the user menu when iambarn profile_url is configured', async () => {
+  it('shows "Edit IAMBarn profile" link in the user menu when iambarn profile_url is configured and session is OIDC', async () => {
+    document.cookie = 'funnelbarn_auth_method=oidc; path=/'
     mockGetClientConfig.mockResolvedValue({
       bugbarn_endpoint: '',
       bugbarn_ingest_key: '',
       iambarn_enabled: false,
-      iambarn: { profile_url: 'https://iam.test.wiebe.xyz/admin' },
+      iambarn: { profile_url: 'https://iam.test.wiebe.xyz/admin#profile' },
     })
     renderShell()
     fireEvent.click(screen.getByText('testuser'))
     const link = await screen.findByText('Edit IAMBarn profile')
     const anchor = link.closest('a')
     expect(anchor).not.toBeNull()
-    expect(anchor!.getAttribute('href')).toBe('https://iam.test.wiebe.xyz/admin')
+    expect(anchor!.getAttribute('href')).toBe('https://iam.test.wiebe.xyz/admin#profile')
     expect(anchor!.getAttribute('target')).toBe('_blank')
     expect(anchor!.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+
+  it('does not show "Edit IAMBarn profile" link for local password sessions even when iambarn profile_url is configured', async () => {
+    // No funnelbarn_auth_method cookie — local password session.
+    mockGetClientConfig.mockResolvedValue({
+      bugbarn_endpoint: '',
+      bugbarn_ingest_key: '',
+      iambarn_enabled: false,
+      iambarn: { profile_url: 'https://iam.test.wiebe.xyz/admin#profile' },
+    })
+    renderShell()
+    fireEvent.click(screen.getByText('testuser'))
+    // Give the component effect time; getClientConfig should NOT be called
+    // because the OIDC cookie is absent.
+    await new Promise((r) => setTimeout(r, 0))
+    expect(mockGetClientConfig).not.toHaveBeenCalled()
+    expect(screen.queryByText('Edit IAMBarn profile')).not.toBeInTheDocument()
   })
 })

--- a/web/src/components/shell/Shell.tsx
+++ b/web/src/components/shell/Shell.tsx
@@ -33,6 +33,15 @@ export default function Shell({ children, projectId, projectName, projects: proj
   const [iambarnProfileURL, setIambarnProfileURL] = useState<string | null>(null)
 
   useEffect(() => {
+    // Only show the IAMBarn profile link when the session was actually
+    // minted by an OIDC callback — the callback sets a non-HttpOnly
+    // `funnelbarn_auth_method=oidc` cookie. Local password sessions
+    // don't have it, so the menu entry stays hidden for them.
+    const isOIDCSession = typeof document !== 'undefined' &&
+      document.cookie.split(';').some((c) => c.trim() === 'funnelbarn_auth_method=oidc')
+    if (!isOIDCSession) {
+      return
+    }
     let cancelled = false
     api.getClientConfig()
       .then((cfg) => {


### PR DESCRIPTION
## Summary
- Both OIDC callbacks (legacy PKCE on `/api/v1/auth/oidc/callback` and the new confidential flow on `/api/v1/oidc/callback`) now set a non-HttpOnly `funnelbarn_auth_method=oidc` cookie with the same expiry as the session.
- `handleLogout` clears that cookie alongside session/CSRF.
- Runtime client-config `iambarn.profile_url` now ends in `/admin#profile` so the link deep-links to the profile section.
- `Shell.tsx` only fetches client-config and renders the "Edit IAMBarn profile" menu entry when the cookie is present, so local password sessions no longer see an IAMBarn link that doesn't apply to them.

Mirrors the same fix already done in bugbarn (PR #90 there).

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (api package, including updated client_config tests for the new URL)
- [x] `npm --prefix web run build`
- [x] `npm --prefix web run lint`
- [x] `npm --prefix web test` (Shell.test.tsx: link hidden without cookie, shown with cookie + profile_url, URL ends in `#profile`)
- [ ] Manual: local password login -> no menu entry; OIDC login -> menu entry present, opens `<issuer>/admin#profile`; logout -> cookie cleared