### PR TITLE
feat: serve /.well-known/iambarn-theme.json

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -200,6 +200,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/v1/health", s.handleHealth)
 	s.mux.Handle("GET /api/v1/setup/{slug}", s.setupLimiter.middleware(http.HandlerFunc(s.handleSetup)))
 	s.mux.HandleFunc("GET /api/v1/client-config", s.handleClientConfig)
+	s.mux.HandleFunc("GET /.well-known/iambarn-theme.json", s.handleThemeManifest)
 
 	// Ingest (API key required)
 	s.mux.Handle("POST /api/v1/events", s.eventsLimiter.middleware(s.ingest))

--- a/internal/api/theme.go
+++ b/internal/api/theme.go
@@ -1,0 +1,36 @@
+package api
+
+import "net/http"
+
+// themeManifest mirrors the iambarn relying-party theme manifest schema.
+// See: https://iam.wiebe.xyz/.well-known/iambarn-theme.json
+type themeManifest struct {
+	Name            string `json:"name"`
+	LogoURL         string `json:"logo_url"`
+	PrimaryColor    string `json:"primary_color"`
+	BackgroundColor string `json:"background_color"`
+	CardColor       string `json:"card_color"`
+	BodyTextColor   string `json:"body_text_color"`
+	SupportURL      string `json:"support_url"`
+	Locale          string `json:"locale"`
+}
+
+// funnelbarnThemeManifest reflects the FunnelBarn brand as defined in
+// web/src/index.css and web/src/components/shell/Shell.tsx (bg, surface,
+// amber, text) and web/public/icons.
+var funnelbarnThemeManifest = themeManifest{
+	Name:            "FunnelBarn",
+	LogoURL:         "https://funnelbarn.wiebe.xyz/icons/icon-512.png",
+	PrimaryColor:    "#f59e0b",
+	BackgroundColor: "#0f1117",
+	CardColor:       "#1a1d27",
+	BodyTextColor:   "#e2e8f0",
+	SupportURL:      "https://funnelbarn.wiebe.xyz/",
+	Locale:          "en",
+}
+
+// handleThemeManifest serves the iambarn relying-party theme manifest used by
+// iambarn to skin its login page when a user is redirected here for OIDC.
+func (s *Server) handleThemeManifest(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, funnelbarnThemeManifest)
+}

--- a/internal/api/theme_test.go
+++ b/internal/api/theme_test.go
@@ -1,0 +1,43 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestThemeManifest(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/iambarn-theme.json", nil)
+	req.Header.Set("Accept", "application/json")
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want %d (body=%q)", w.Code, http.StatusOK, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Fatalf("content-type: got %q want it to contain application/json", ct)
+	}
+
+	type manifest struct {
+		Name            string `json:"name"`
+		LogoURL         string `json:"logo_url"`
+		PrimaryColor    string `json:"primary_color"`
+		BackgroundColor string `json:"background_color"`
+		CardColor       string `json:"card_color"`
+		BodyTextColor   string `json:"body_text_color"`
+		SupportURL      string `json:"support_url"`
+		Locale          string `json:"locale"`
+	}
+	var m manifest
+	if err := json.NewDecoder(w.Body).Decode(&m); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+	if m.Name == "" {
+		t.Errorf("name should be populated, got empty")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `GET /.well-known/iambarn-theme.json` returning the iambarn theme manifest (8 fields) so iambarn can skin its login page with the FunnelBarn brand during OIDC.
- Theme values mirror the existing dark/amber palette from `web/src/index.css` and `web/src/components/shell/Shell.tsx` (primary `#f59e0b`, background `#0f1117`, card `#1a1d27`, body text `#e2e8f0`). Logo and support URL point at `https://funnelbarn.wiebe.xyz`.
- New unit test asserts 200, `application/json` Content-Type, decodable manifest, and a populated `name`.

## Test plan
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `staticcheck ./...` clean
- [x] `go test -race -count=1 ./...` green
- [ ] CI passes on PR