### PR TITLE
fix(ingress): route /.well-known/iambarn-theme.json to backend

### DIFF
--- a/deploy/k8s/production/ingress.yaml
+++ b/deploy/k8s/production/ingress.yaml
@@ -19,6 +19,13 @@ spec:
                 name: funnelbarn
                 port:
                   name: http
+          - path: /.well-known/iambarn-theme.json
+            pathType: Exact
+            backend:
+              service:
+                name: funnelbarn
+                port:
+                  name: http
           - path: /
             pathType: Prefix
             backend:

--- a/deploy/k8s/staging/ingress.yaml
+++ b/deploy/k8s/staging/ingress.yaml
@@ -19,6 +19,13 @@ spec:
                 name: funnelbarn
                 port:
                   name: http
+          - path: /.well-known/iambarn-theme.json
+            pathType: Exact
+            backend:
+              service:
+                name: funnelbarn
+                port:
+                  name: http
           - path: /
             pathType: Prefix
             backend:
@@ -34,6 +41,13 @@ spec:
         paths:
           - path: /api
             pathType: Prefix
+            backend:
+              service:
+                name: funnelbarn
+                port:
+                  name: http
+          - path: /.well-known/iambarn-theme.json
+            pathType: Exact
             backend:
               service:
                 name: funnelbarn

--- a/deploy/k8s/testing/ingress.yaml
+++ b/deploy/k8s/testing/ingress.yaml
@@ -19,6 +19,13 @@ spec:
                 name: funnelbarn
                 port:
                   name: http
+          - path: /.well-known/iambarn-theme.json
+            pathType: Exact
+            backend:
+              service:
+                name: funnelbarn
+                port:
+                  name: http
           - path: /
             pathType: Prefix
             backend:
@@ -34,6 +41,13 @@ spec:
         paths:
           - path: /api
             pathType: Prefix
+            backend:
+              service:
+                name: funnelbarn
+                port:
+                  name: http
+          - path: /.well-known/iambarn-theme.json
+            pathType: Exact
             backend:
               service:
                 name: funnelbarn


### PR DESCRIPTION
## Summary

`https://funnelbarn.wiebe.xyz/.well-known/iambarn-theme.json` currently hits the `funnelbarn-web` SPA's nginx, which returns 404. The Go backend (handler from #132) is the actual owner of this path.

Add an `Exact` path rule for `/.well-known/iambarn-theme.json` to the `funnelbarn` service ahead of the `/` catch-all in every host block of every environment's ingress:

- `deploy/k8s/testing/ingress.yaml` — both `funnelbarn.test.wiebe.xyz` and legacy `funnelbarn-test.nijmegen.wiebe.xyz`
- `deploy/k8s/staging/ingress.yaml` — both `funnelbarn.staging.wiebe.xyz` and legacy `funnelbarn-staging.nijmegen.wiebe.xyz`
- `deploy/k8s/production/ingress.yaml` — `funnelbarn.wiebe.xyz`

`deploy/k8s/production/ingress-f.yaml` is unaffected: its `/` rule already routes to the `funnelbarn` backend, not the web SPA, so the well-known path already reaches the Go handler on those hosts.

## Test plan

- [ ] CI green
- [ ] After deploy to testing: `curl https://funnelbarn.test.wiebe.xyz/.well-known/iambarn-theme.json` returns JSON from the backend (not nginx 404)
- [ ] After production deploy: `curl https://funnelbarn.wiebe.xyz/.well-known/iambarn-theme.json` returns JSON
- [ ] SPA still loads at `/` on all hosts