### PR TITLE
chore(secrets): seed funnelbarn-testing iambarn OIDC client

### DIFF
--- a/deploy/k8s/testing/secret.yaml
+++ b/deploy/k8s/testing/secret.yaml
@@ -18,8 +18,8 @@ stringData:
     GEOIPUPDATE_ACCOUNT_ID: ENC[AES256_GCM,data:kNSVQrpkZA==,iv:wOCAo3IgiMofoW1AGK7I5KFD2xUF6T6w97kucywfvLk=,tag:A8JikXgrx54BR+HHJHML7Q==,type:str]
     GEOIPUPDATE_LICENSE_KEY: ENC[AES256_GCM,data:fX32wEEfx9+3KidaV5YVuBIgzzVuM8CuifDSSueEMsmwznUULAFJcA==,iv:AYSd0F6/yfYfhgTOyzschE8VFzHcPx2+XS7bJ1QaWmU=,tag:2wD68QWVomhhwE94eEqwxg==,type:str]
     FUNNELBARN_OIDC_ISSUER: ENC[AES256_GCM,data:nrSUb7WZqsawzJF2IidyDfhiM52axYUF7DQ=,iv:EGyKq4V4VGDrri+gnx+CY1/hETBwaQJylP1baLStdLc=,tag:E98lsBk4aC0ONqu4DR/QGg==,type:str]
-    FUNNELBARN_OIDC_CLIENT_ID: ENC[AES256_GCM,data:mUotE2zlPwowyG2P03SgalhJ,iv:rEjZbi0Sk2TxrAZCTPTCWBM3XxYEKBFquYGqVyVYgWg=,tag:mE9zpi/4OB/3IlWdm6PTRA==,type:str]
-    FUNNELBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:bKK27M7UFTprMhUQaJP3/ZKs1zKlnYk+3/KBAELInGNCdiCFK9/O0Rirng==,iv:77XxAEvQDfZupsTTGJwgjtnzuDWzZCwJqL2vkVpyeF4=,tag:bBZtMRB7fkH3uRTVgieT1w==,type:str]
+    FUNNELBARN_OIDC_CLIENT_ID: ENC[AES256_GCM,data:KVSiwftvM1NyARARxVuoadB0,iv:cND9ZgjYgZst9UM9ekATd4Cs9hx7UV9TyMHTdQXDaXE=,tag:UF2lrw9OZ8HbtHRaKNx/BQ==,type:str]
+    FUNNELBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:G8Wb3GT4hOctfDac39Auk9hlKPhdmPkWrGjHSLWIvBrzI+OP9Ntx+raKNw==,iv:s6utrBmi5uQS7OPc9l9VT0wc+qStkYUORy3a18o+0C0=,tag:7LZWJT11LmHBaAsJP04vEA==,type:str]
     FUNNELBARN_OIDC_REDIRECT_URL: ENC[AES256_GCM,data:JHyCBMzVUtOdkapSqqqP9/+UASQl/fmTq/Qyj2wZyvJgFGqdBUAg95KH6/Us1A2MeFEp69nm,iv:Q84jA1VNlFyqWlSaKhP20/PLjEAuAk5t6PV2NTuG7TM=,tag:9DZd3/zMoT1C3q2bz/4zJQ==,type:str]
 type: ENC[AES256_GCM,data:ETH/E3ZO,iv:FKQE873C2MNTWi9dJ8gk3tJj0mVfsWnb98CRttHkUCI=,tag:TthlSQPFdD1TZkjo5ri+HA==,type:str]
 sops:
@@ -37,8 +37,8 @@ sops:
             YVRMZnBPamJLSEV0bHYzaXpnbWQ0VWMKQtcZclj7MlV8sg2Jo5buKYxtkn5Ww15U
             sTAHou/EFRgHbnpEjf2jjjUZshqOwjv6unN5Wyeq+XGsTqNuV/pHPQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-18T19:54:30Z"
-    mac: ENC[AES256_GCM,data:3+iHNxfFE/igkTs8kISKm0IqCGKKIM935d3spsszArgdFb9oixyiGR7GEcAvgNWx9FAA0s3ZqKv7uhckYENokpeH+oIV21AWBZ+zzodTcJNe+c2nVYqhNM8nSl6DyIFXqhw32z5QtCQvdf7ZPgoIiG4AXbYEhIZOiADWE3vQgjk=,iv:VPamevIn03WY6VVGk8RfGWiQHtt+F3b6CvcqhilNxOY=,tag:7iDPnKDJ1Xs+Sz6LhsLJdA==,type:str]
+    lastmodified: "2026-05-20T13:12:05Z"
+    mac: ENC[AES256_GCM,data:Hw6K7ozVkA+23LkGeNaxN23JDdgwqPFXYlFWa8hSn/yPce4vffVpPr016ZgJdVMortnOeWgcSYM8Q/t1sJf/EDKMmbpmO0EqXwpgQ2gJGzkxwQI27VjJ/12IJhj8qFrn3xKL3Tdmd/+GepcaaknGHr+xMtZgANyd9Hc4P/O/FzM=,iv:dF0bL6pOq7u/c/DGalYMnclX5TX4upjgoCIr6Bp3FHs=,tag:xd/swbnN+6hPzWKacARI/A==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
Provisioned a confidential OIDC client for **funnelbarn** in **iambarn-testing** and written the credentials into `deploy/k8s/testing/secret.yaml`.

- Client id: `ibc_aoaGWvuu…`
- Redirect URI: `https://funnelbarn.test.wiebe.xyz/api/v1/oidc/callback`
- Organization id: `org_h5yxfpj72k5c7cpa`

Next deploy of funnelbarn-testing picks up the new credentials.

Provisioned via `/srv/projects/seed-iambarn-clients.sh`.