### PR TITLE
chore(secrets): seed funnelbarn-staging iambarn OIDC client

### DIFF
--- a/deploy/k8s/staging/secret.yaml
+++ b/deploy/k8s/staging/secret.yaml
@@ -18,8 +18,8 @@ stringData:
     GEOIPUPDATE_ACCOUNT_ID: ENC[AES256_GCM,data:xVEE+MCiYg==,iv:6CdJ3Ug9+MpnHBCGOR3KFIbAMUBpK+FJod/xMm1GPdE=,tag:HkM7sAdFuffQNeXLxXFWqw==,type:str]
     GEOIPUPDATE_LICENSE_KEY: ENC[AES256_GCM,data:/Ki4Bxr8AXwEwA5S0WFDldO1EQwQaNw1Vp7p4imNYMNbjujkP/Y4Ow==,iv:cXnbo9qNecWVNTP59Myb9hTbruA/tE/uzhCko3MaVpI=,tag:xr92k+SiZwpLSvkAW9Q6nA==,type:str]
     FUNNELBARN_OIDC_ISSUER: ENC[AES256_GCM,data:ZPjMWKKN/X1gitTtoOWV9sY3mEdcPc89MH+bTlw=,iv:Z+3PPt5PXHPKDt3iVaFTR7LC7a5yMTagbSbtjR4xt0o=,tag:I2wiEi9oXo0RRLgr1GBEww==,type:str]
-    FUNNELBARN_OIDC_CLIENT_ID: ENC[AES256_GCM,data:nWVFFDQgbmFd1IGieDL3ka1D,iv:fRWroo/85qhWdXFFEqJiQKBp6qYZKpJWw8C0LnLieUE=,tag:DCqxTNwVBY0AK1Bf6ZZD6g==,type:str]
-    FUNNELBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:BaDFlddvvwhMgfYjpJNUck8y7PKPmgCw4v1H5Voi7w3MF7aaySJrA0FUeg==,iv:+Pps63PbY1W84w1/rtYW5zLV5vJfN18o64uDveYC5dQ=,tag:kq3jK6+mgiVqnldgjzuu3A==,type:str]
+    FUNNELBARN_OIDC_CLIENT_ID: ENC[AES256_GCM,data:5izKpXB1/fcMot+ctrCHG31j,iv:qVayUOwipTCspJeFkbo8NUeifqXFR4PTI7aY9iLx6T0=,tag:cPVGTjP+inl3oVLasBFJOQ==,type:str]
+    FUNNELBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:g38LzANyYxQkhuyLX5AZq4r9c5RtaPdEJF+NEnld12m/aShQK4ie2Wur3Q==,iv:th+bn49bXMrNZe/Fz0iOlarOmn+ryGzBglBmkO4UheA=,tag:mXduxlD1xOSt6X5pyjIkNg==,type:str]
     FUNNELBARN_OIDC_REDIRECT_URL: ENC[AES256_GCM,data:d9YhornCLqvtg67XSFx0W3pzmHo5Ap77mHon+9W6FD3VvgD5pyfpTOwfQOcjkTp+Elwe7j/qYfGn,iv:1GyUFdx80bes0tTURiI4ZTgfd5oEjYK/F+nek6GA2iw=,tag:HjDQh5zR3f/Vfi08H3aF5A==,type:str]
 type: ENC[AES256_GCM,data:j3xiz+Or,iv:IZU6E2E7NRmJNESOX3/39faVk97fZEPreoVimwYeHR8=,tag:JM35xtiOm/wxdt30cZHCXQ==,type:str]
 sops:
@@ -37,8 +37,8 @@ sops:
             M1pZcUQrWmxCWlQzUldpcWZpTlF5Z2sKxvRXA7kLe7HoC+UJmtfQuzGOZ+1oaKvI
             anzLivgCzT7bxqYfSbAjDu3HY+wdVU4ezJeAgAnL7EXH5B8YCFNyJg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-19T09:57:03Z"
-    mac: ENC[AES256_GCM,data:g/azTtFXBFDG/pi2v5KYqVaP3fKCUg+73spBIG4bSshY5e/SC6Ue53wN9515yc87xz3FnEBQ9Jw3HQ7+7UdprzWjRNtZZQeQsVT7B5hmh3wBY1pov7QaM0PQF1zaOG21wfieI0ItMAoKmqrd8YmH6yrbFqvCuuEnk7+mE23wUew=,iv:BHbXbjMUbfuiyqT3bqmF5xeZVMKBgKsoDRg2gTdCz6M=,tag:iyrZ0pQyyZAxLc25dDUIkw==,type:str]
+    lastmodified: "2026-05-20T13:12:13Z"
+    mac: ENC[AES256_GCM,data:UuUlYiaWSm8pMvdQt1YhJ2sL4wlO/+/mvAckt0gtJGZM3xZ/L32aanJXhXv9bk2j3VI+eF842iKqNPZrD7HNAbMbHrIxcXOfo6jH4HWgwO8pj1SSau9KvMZT5AbZsLcPAzyogPSGySaWDkSVKOVTP005KOGbnw0QN4lXVPV+PIY=,iv:t4+Up9c8hP7IobETtrnfW2S5u7gk0giaCXbJhXp/T88=,tag:EEzx6UQSKXgBXMLcxa3sNA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
Provisioned a confidential OIDC client for **funnelbarn** in **iambarn-staging** and written the credentials into `deploy/k8s/staging/secret.yaml`.

- Client id: `ibc_Eeq-KWh6…`
- Redirect URI: `https://funnelbarn.staging.wiebe.xyz/api/v1/oidc/callback`
- Organization id: `org_g4cl3dgbyqcjhgct`

Next deploy of funnelbarn-staging picks up the new credentials.

Provisioned via `/srv/projects/seed-iambarn-clients.sh`.