### PR TITLE
chore(secrets): seed funnelbarn-production iambarn OIDC client

### DIFF
--- a/deploy/k8s/production/secret.yaml
+++ b/deploy/k8s/production/secret.yaml
@@ -21,8 +21,8 @@ stringData:
     GEOIPUPDATE_ACCOUNT_ID: ENC[AES256_GCM,data:eBEUPDgPSw==,iv:R0uDw3DewL0egpypcfEDufnuFoOismc46x+/hWVzVDs=,tag:hXN8mjXTuOGoQ37LWjDSqw==,type:str]
     GEOIPUPDATE_LICENSE_KEY: ENC[AES256_GCM,data:/rsXyPrr1GDiuFPnxzc+hpCdI0fmd+npWnFXUK2uoS6iiMUzH4ld5A==,iv:/a6TTcCxZuKFeDlsw7ylKOE68sUf2WDCUZjKjkxUEk8=,tag:M5QxsXdH/AnFNg0Aef1tcA==,type:str]
     FUNNELBARN_OIDC_ISSUER: ENC[AES256_GCM,data:yZA7EeFd46GMd887ArwdsUSMGN9z,iv:Z3dWY/qc/5s/mJVjCMmleTm7nMliv34rDUtya6nbeWo=,tag:Zm/9msyjjiCMhZQK7cA4lw==,type:str]
-    FUNNELBARN_OIDC_CLIENT_ID: ENC[AES256_GCM,data:wkbJkO7ca5vlgok6XyHAlAuG,iv:wtq7Zfn2eWynQ+/zvkRGoYVWY6kWesUZ3k8jlpeYS8E=,tag:fpN6L7EeuGKMmmXvyxEvyQ==,type:str]
-    FUNNELBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:GhpJL2JYKRBju5SLg9xSb1fd3kjVX3gAUudja7k6zBhFQCjoPD5KArHjdw==,iv:z6cU/+ti2IkakS/vSuQe/vWr/0LLCiWQZO2TzFugIsw=,tag:W2Whc4WI/8b1GttfT8U/Uw==,type:str]
+    FUNNELBARN_OIDC_CLIENT_ID: ENC[AES256_GCM,data:7FRdd11Mb8YhvBmpWz/EQozj,iv:j8dniz0nNA09hBIuLJxsNZrMOHOQmEOkYlWL0Xsm85k=,tag:KypSXLX6oxj73+BKqF/Zfg==,type:str]
+    FUNNELBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:0u5cwqClMA91X+RvVKLoUAzxg7zptn5AD/wISEuEb+1CfgLEIasP/ds2kQ==,iv:nIBi1U0qG1U6KCSFy5WwBg8TxERTdDbAHTkjO/rOZwk=,tag:Yo8zI6Wk0qsopK+RP6y49w==,type:str]
     FUNNELBARN_OIDC_REDIRECT_URL: ENC[AES256_GCM,data:KdBAxPHNoQOtR8rZ5wq/Wbh/gKAqhWMpCHo7K7GRGr64ikD0SOXwoKLIC/si+lBXIg==,iv:qhvDwSpC7XLn7BbeplB0poLHt5ExtVf34u5DN/DL+XA=,tag:aD/UrEKxRTj/7Z74BSosaA==,type:str]
 type: ENC[AES256_GCM,data:F2dhX/7h,iv:+TR+FJeT3eT15f6U4M90H1HDaE4yXLZwJhGR5xWNgvs=,tag:YOm3cnRAsgL4iCm4PS59DA==,type:str]
 sops:
@@ -40,8 +40,8 @@ sops:
             K3VwblNzQWFySkR6K1UzbVp6Yy9JaW8KgZXWEOPfza3zvi0Lb0J3H7K4ah090rJt
             sVw/YeVeR3nKT+cEQpKjAXXZkZzGqlalRuxl1fB3r2G9LGIyjkUahw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-19T10:47:31Z"
-    mac: ENC[AES256_GCM,data:ct/uRW31FbVPALqJj+lfjNxTCORRGlevZWXIHfedh/HAjUmDoH8G3jMQ/1O4cN8gdyIBn8RousG3Q0EuCnNb8omgMhkhyX9EUDIhvuZyOhebfWoR15EihkFw7S9jP7i/kiGLXMXtmDgggeNnEospIgpy1NWYXn55IbNlCRxKong=,iv:m6lnAOV4MEeJ0ShqyRfrJs9NJQll30iSreDZcRN8jm8=,tag:1pTUQamLDkJGRbQCaOBVGw==,type:str]
+    lastmodified: "2026-05-20T13:12:19Z"
+    mac: ENC[AES256_GCM,data:hkn/EMfQe5/W9scT/qiDTv9BvssYN+uaVKADXtvyjYbtonSLADjXyJ8wg0l6e3thSyIGwNLcNMNYdX/q1p9eAfD9jsVigdRIWlkRyO5vTX5XqbRBJRSmX+A7yIaS4Pq7Kcr6ZuIWM6maTphI4dHmDnDXcKxWxgpJOTCJJYp2Bzw=,iv:+1RPbUvOCNSsrK0WHKLNc4ds1B+2HWq/KoHYjU2h7uo=,tag:LWIUz6ynPA+A4GOP8BHf4g==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
Provisioned a confidential OIDC client for **funnelbarn** in **iambarn-production** and written the credentials into `deploy/k8s/production/secret.yaml`.

- Client id: `ibc_g3ykv92x…`
- Redirect URI: `https://funnelbarn.wiebe.xyz/api/v1/oidc/callback`
- Organization id: `org_qbwyqure4p2lm2hg`

Next deploy of funnelbarn-production picks up the new credentials.

Provisioned via `/srv/projects/seed-iambarn-clients.sh`.