### PR TITLE
chore(ci): bump setup-python off Node 20

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -92,7 +92,7 @@ jobs:
         working-directory: sdks/python
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - run: pip install build twine


### PR DESCRIPTION
## Summary

`actions/setup-python@v5` runs on Node 20, which GitHub has deprecated. Bump to `v6` (Node 24) to clear the deprecation warning in `binary-release.yml`.

All other actions in `.github/workflows/` are already on current majors (`checkout@v6`, `setup-go@v6`, `setup-node@v6`, `upload-artifact@v7`, `download-artifact@v8`, `deploy-pages@v4`, `upload-pages-artifact@v5`, `docker/setup-buildx-action@v4`) — no further bumps needed.

## Test plan

- [ ] CI passes on this PR
- [ ] Next release run picks up `setup-python@v6` without warnings