### PR TITLE
fix(web): show project picker on Settings page (header consistency)

### DIFF
--- a/web/src/components/shell/Shell.tsx
+++ b/web/src/components/shell/Shell.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate, useLocation } from 'react-router-dom'
 import { BarChart2, Layers, Radio, Settings, LogOut, User, Flag, Lightbulb, MoreHorizontal, ExternalLink } from 'lucide-react'
 import { useAuth } from '../../lib/auth'
 import { useProjects } from '../../lib/projects'
-import { ProjectPicker } from '../ui/ProjectPicker'
+import { ProjectPicker, LAST_PROJECT_ID_KEY } from '../ui/ProjectPicker'
 import { api, type Project } from '../../lib/api'
 
 const C = {
@@ -31,6 +31,18 @@ export default function Shell({ children, projectId, projectName, projects: proj
   const [userMenuOpen, setUserMenuOpen] = useState(false)
   const [moreSheetOpen, setMoreSheetOpen] = useState(false)
   const [iambarnProfileURL, setIambarnProfileURL] = useState<string | null>(null)
+
+  // Remember the active project so that when the user lands on a
+  // non-project-scoped route (e.g. /settings), the picker can show their
+  // last choice instead of defaulting to the alphabetical first.
+  useEffect(() => {
+    if (!projectId) return
+    try {
+      window.localStorage.setItem(LAST_PROJECT_ID_KEY, projectId)
+    } catch {
+      /* ignore — quota / disabled storage */
+    }
+  }, [projectId])
 
   useEffect(() => {
     // Only show the IAMBarn profile link when the session was actually
@@ -113,12 +125,15 @@ export default function Shell({ children, projectId, projectName, projects: proj
         </Link>
 
 
-        {/* Project picker badge (desktop top nav) */}
-        {projects.length > 0 && projectId && (
+        {/* Project picker badge (desktop top nav) — shown on every page that
+            has projects, including non-project-scoped routes like Settings, so
+            the user can switch context from anywhere. */}
+        {projects.length > 0 && (
           <div style={{ marginRight: 8 }}>
             <ProjectPicker
               projects={projects}
               base={location.pathname.split('/')[1] || 'dashboard'}
+              projectId={projectId}
               variant="badge"
             />
           </div>
@@ -415,12 +430,14 @@ export default function Shell({ children, projectId, projectName, projects: proj
               </div>
             </div>
 
-            {/* Project picker — only when there are projects to switch between */}
-            {projects.length > 0 && projectId && (
+            {/* Project picker — show whenever there are projects to switch
+                between, even on non-project-scoped routes like Settings. */}
+            {projects.length > 0 && (
               <div style={{ marginBottom: '0.75rem' }}>
                 <ProjectPicker
                   projects={projects}
                   base={location.pathname.split('/')[1] || 'dashboard'}
+                  projectId={projectId}
                   variant="full"
                   onSelect={() => setMoreSheetOpen(false)}
                 />

--- a/web/src/components/ui/ProjectPicker.test.tsx
+++ b/web/src/components/ui/ProjectPicker.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
-import { ProjectPicker } from './ProjectPicker'
+import { ProjectPicker, LAST_PROJECT_ID_KEY } from './ProjectPicker'
 import type { Project } from '../../lib/api'
 
 // ---------------------------------------------------------------------------
@@ -136,5 +136,90 @@ describe('ProjectPicker — full variant', () => {
   it('renders nothing when the project list is empty', () => {
     const { container } = renderPicker('p1', 'full', [])
     expect(container.firstChild).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Non-project-scoped routes (e.g. /settings)
+// ---------------------------------------------------------------------------
+
+describe('ProjectPicker — non-project-scoped routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.localStorage.clear()
+  })
+
+  function renderSettings(base: string = 'settings') {
+    return render(
+      <MemoryRouter initialEntries={[`/${base}`]}>
+        <Routes>
+          <Route
+            path={`/${base}`}
+            element={<ProjectPicker projects={projects} base={base} variant="badge" />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    )
+  }
+
+  it('falls back to the first project when no projectId and nothing in localStorage', () => {
+    renderSettings()
+    // Sorted projects: Alpha, Beta, Gamma — first is Alpha
+    expect(screen.getByText('Alpha')).toBeInTheDocument()
+  })
+
+  it('uses the last-selected project from localStorage when no projectId is provided', () => {
+    window.localStorage.setItem(LAST_PROJECT_ID_KEY, 'p3')
+    renderSettings()
+    expect(screen.getByText('Gamma')).toBeInTheDocument()
+  })
+
+  it('navigates to /dashboard/<id> when picker is on a non-project-scoped route', () => {
+    renderSettings()
+    fireEvent.click(screen.getByRole('button', { name: /switch project/i }))
+    fireEvent.click(screen.getByText('Beta'))
+    expect(mockNavigate).toHaveBeenCalledWith('/dashboard/p2')
+  })
+
+  it('persists the selected project id to localStorage', () => {
+    renderSettings()
+    fireEvent.click(screen.getByRole('button', { name: /switch project/i }))
+    fireEvent.click(screen.getByText('Gamma'))
+    expect(window.localStorage.getItem(LAST_PROJECT_ID_KEY)).toBe('p3')
+  })
+
+  it('keeps inline navigation on project-scoped routes (regression)', () => {
+    // When base is one of the scoped routes (e.g. "insights"), selecting a
+    // project should land on /insights/<id> — not redirect to dashboard.
+    render(
+      <MemoryRouter initialEntries={['/insights/p1']}>
+        <Routes>
+          <Route
+            path="/insights/:projectId"
+            element={<ProjectPicker projects={projects} base="insights" variant="badge" />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /switch project/i }))
+    fireEvent.click(screen.getByText('Beta'))
+    expect(mockNavigate).toHaveBeenCalledWith('/insights/p2')
+  })
+
+  it('prefers the explicit projectId prop over the URL param', () => {
+    render(
+      <MemoryRouter initialEntries={['/dashboard/p1']}>
+        <Routes>
+          <Route
+            path="/dashboard/:projectId"
+            element={
+              <ProjectPicker projects={projects} base="dashboard" projectId="p3" variant="badge" />
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    )
+    // The explicit prop (p3 = Gamma) wins over the URL param (p1 = Alpha).
+    expect(screen.getByText('Gamma')).toBeInTheDocument()
   })
 })

--- a/web/src/components/ui/ProjectPicker.tsx
+++ b/web/src/components/ui/ProjectPicker.tsx
@@ -12,17 +12,51 @@ const C = {
   muted: '#94a3b8',
 }
 
+/** localStorage key used to remember the user's last-selected project across pages. */
+export const LAST_PROJECT_ID_KEY = 'funnelbarn:lastProjectId'
+
+/**
+ * Routes that take a `/:projectId` segment. When the picker fires on any other
+ * route (e.g. `/settings`), selecting a project lands the user on
+ * `/dashboard/<id>` — the canonical project-landing page.
+ */
+const PROJECT_SCOPED_BASES = new Set(['dashboard', 'funnels', 'flags', 'insights', 'live'])
+
+function readLastProjectId(): string | undefined {
+  if (typeof window === 'undefined') return undefined
+  try {
+    return window.localStorage.getItem(LAST_PROJECT_ID_KEY) ?? undefined
+  } catch {
+    return undefined
+  }
+}
+
+function writeLastProjectId(id: string) {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(LAST_PROJECT_ID_KEY, id)
+  } catch {
+    /* ignore — quota / disabled storage */
+  }
+}
+
 interface ProjectPickerProps {
   projects: Project[]
   /** The base path segment used for navigation, e.g. "dashboard" or "funnels". */
   base: string
+  /**
+   * The currently-active project id, when known. Pages that are not
+   * project-scoped (e.g. Settings) may omit this; the picker then falls back
+   * to the last-selected project from localStorage, then to the first project.
+   */
+  projectId?: string
   /** Callback invoked after a project is selected (e.g. to close a parent sheet). */
   onSelect?: () => void
   /** Compact mode — used in the top nav badge. Full mode — used in "More" sheet. */
   variant?: 'badge' | 'full'
 }
 
-export function ProjectPicker({ projects, base, onSelect, variant = 'badge' }: ProjectPickerProps) {
+export function ProjectPicker({ projects, base, projectId, onSelect, variant = 'badge' }: ProjectPickerProps) {
   const navigate = useNavigate()
   const { projectId: urlProjectId } = useParams<{ projectId?: string }>()
   const [open, setOpen] = useState(false)
@@ -30,7 +64,9 @@ export function ProjectPicker({ projects, base, onSelect, variant = 'badge' }: P
 
   const sortedProjects = [...projects].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }))
 
-  const currentProject = projects.find((p) => p.id === urlProjectId) ?? projects[0]
+  // Resolve the "current" project: explicit prop > URL param > remembered id > first project.
+  const effectiveProjectId = projectId ?? urlProjectId ?? readLastProjectId()
+  const currentProject = projects.find((p) => p.id === effectiveProjectId) ?? projects[0]
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -47,7 +83,12 @@ export function ProjectPicker({ projects, base, onSelect, variant = 'badge' }: P
   const handleSelect = (project: Project) => {
     setOpen(false)
     onSelect?.()
-    navigate(`/${base}/${project.id}`)
+    writeLastProjectId(project.id)
+    // On project-scoped routes, swap the id inline. Anywhere else (e.g.
+    // /settings) take the user to the project's dashboard, which is the
+    // canonical landing page for a project context.
+    const target = PROJECT_SCOPED_BASES.has(base) ? base : 'dashboard'
+    navigate(`/${target}/${project.id}`)
   }
 
   if (projects.length === 0) return null


### PR DESCRIPTION
## Summary

The header on the Settings page was missing the project-picker badge that every other page shows. `Shell.tsx` gated the picker on `projects.length > 0 && projectId`, and Settings is the only route without a `:projectId` URL param — so the conditional collapsed and the picker hid.

## Approach (chose A)

Keep Settings global; show the picker for project switching from anywhere. Approach B (`/settings/:projectId`) would have been awkward — Settings primarily holds org-level + user-level content (API keys, project CRUD, user profile), and per-project URL scoping doesn't fit that content model.

## What changed

- **`Shell.tsx`**: Relax the picker conditional from `projects.length > 0 && projectId` to `projects.length > 0`. Forward the (possibly undefined) `projectId` to `ProjectPicker`. Apply the same fix to the mobile More-sheet variant so behaviour is consistent on small screens. Persist the active project id to `localStorage` (key `funnelbarn:lastProjectId`) on every render that has one, so the picker has a sensible default when the user lands on `/settings` directly.
- **`ProjectPicker.tsx`**: New optional `projectId` prop. Resolution order for the displayed project is now: prop > URL param > last-selected from localStorage > first project alphabetically > "Select project" fallback. On select, persist the chosen id and navigate inline on project-scoped routes (`dashboard`/`funnels`/`flags`/`insights`/`live`); on any other route, land on `/dashboard/<id>` as the canonical project-landing page.
- **`ProjectPicker.test.tsx`**: Six new tests cover fallback-to-first-project, localStorage remembered project, navigation to `/dashboard/<id>` from non-project-scoped routes, persistence of the selected id, regression of inline navigation on scoped routes, and explicit `projectId` prop overriding URL params.

## Behaviour on Settings when no project has ever been visited

The picker renders showing the first project alphabetically (label like "Alpha"). The user can click it; selecting a project lands them on that project's dashboard and persists the choice. On subsequent visits to `/settings`, the picker reflects the last-selected project.

## Test plan

- [x] `npm run test` — 132 passed (17 in ProjectPicker.test.tsx, up from 11)
- [x] `npm run lint` (tsc --noEmit) — clean
- [x] `npm run lint:eslint` — clean on touched files (only pre-existing warnings elsewhere)
- [x] `npm run build` — clean
- [ ] Manual: load `/settings` in dev; picker should appear and switching project should land you on that project's dashboard
- [ ] Manual: load `/insights/<id>`; picker still works as before (inline swap)