### PR TITLE
fix(web): redirect authenticated users away from landing to dashboard

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -155,3 +155,110 @@ describe('DefaultProjectRoute', () => {
     expect(window.location.pathname).toBe('/dashboard/p2')
   })
 })
+
+// ---------------------------------------------------------------------------
+// RootRedirect tests — guard for the marketing landing route ("/")
+// ---------------------------------------------------------------------------
+
+describe('RootRedirect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the marketing Landing page for unauthenticated visitors', async () => {
+    mockUseAuth.mockReturnValue({ user: null, isLoading: false })
+    mockUseProjects.mockReturnValue({
+      projects: [],
+      isLoading: false,
+      defaultProjectId: null,
+      refetch: vi.fn(),
+      setDefaultProjectId: vi.fn(),
+    })
+
+    renderAt('/')
+
+    await waitFor(() =>
+      expect(screen.getByTestId('landing-page')).toBeInTheDocument(),
+    )
+    expect(window.location.pathname).toBe('/')
+  })
+
+  it('does not render Landing while auth is still loading', () => {
+    mockUseAuth.mockReturnValue({ user: null, isLoading: true })
+    mockUseProjects.mockReturnValue({
+      projects: [],
+      isLoading: false,
+      defaultProjectId: null,
+      refetch: vi.fn(),
+      setDefaultProjectId: vi.fn(),
+    })
+
+    renderAt('/')
+
+    expect(screen.queryByTestId('landing-page')).toBeNull()
+    expect(screen.queryByTestId('dashboard-page')).toBeNull()
+  })
+
+  it('redirects authenticated users to the default project dashboard', async () => {
+    mockUseAuth.mockReturnValue({ user: loggedInUser, isLoading: false })
+    mockUseProjects.mockReturnValue({
+      projects: [
+        { id: 'p1', name: 'Alpha', slug: 'alpha', status: 'active' },
+        { id: 'p2', name: 'Beta', slug: 'beta', status: 'active' },
+      ],
+      isLoading: false,
+      defaultProjectId: 'p2',
+      refetch: vi.fn(),
+      setDefaultProjectId: vi.fn(),
+    })
+
+    renderAt('/')
+
+    await waitFor(() =>
+      expect(screen.getByTestId('dashboard-page')).toBeInTheDocument(),
+    )
+    expect(window.location.pathname).toBe('/dashboard/p2')
+    // Landing must not render for authenticated users
+    expect(screen.queryByTestId('landing-page')).toBeNull()
+  })
+
+  it('redirects authenticated users to the first project when no default is stored', async () => {
+    mockUseAuth.mockReturnValue({ user: loggedInUser, isLoading: false })
+    mockUseProjects.mockReturnValue({
+      projects: [
+        { id: 'p1', name: 'Alpha', slug: 'alpha', status: 'active' },
+        { id: 'p2', name: 'Beta', slug: 'beta', status: 'active' },
+      ],
+      isLoading: false,
+      defaultProjectId: null,
+      refetch: vi.fn(),
+      setDefaultProjectId: vi.fn(),
+    })
+
+    renderAt('/')
+
+    await waitFor(() =>
+      expect(screen.getByTestId('dashboard-page')).toBeInTheDocument(),
+    )
+    expect(window.location.pathname).toBe('/dashboard/p1')
+    expect(screen.queryByTestId('landing-page')).toBeNull()
+  })
+
+  it('shows the Dashboard empty-state when an authenticated user has no projects', async () => {
+    mockUseAuth.mockReturnValue({ user: loggedInUser, isLoading: false })
+    mockUseProjects.mockReturnValue({
+      projects: [],
+      isLoading: false,
+      defaultProjectId: null,
+      refetch: vi.fn(),
+      setDefaultProjectId: vi.fn(),
+    })
+
+    renderAt('/')
+
+    await waitFor(() =>
+      expect(screen.getByTestId('dashboard-page')).toBeInTheDocument(),
+    )
+    expect(screen.queryByTestId('landing-page')).toBeNull()
+  })
+})

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -71,8 +71,12 @@ function RootRedirect() {
     )
   }
 
+  // Authenticated users skip the marketing landing and go straight to their
+  // dashboard. Reuse DefaultProjectRoute so they land on /dashboard/<projectId>
+  // when a default/last-visited project is known, rather than bouncing through
+  // a generic /dashboard hop.
   if (user) {
-    return <Navigate to="/dashboard" replace />
+    return <DefaultProjectRoute base="/dashboard" />
   }
 
   return <Landing />


### PR DESCRIPTION
## Summary
- Authenticated visits to `/` now skip the marketing landing entirely. `RootRedirect` reuses `DefaultProjectRoute` instead of bouncing through `/dashboard`, so users go straight to `/dashboard/<projectId>` when a default/last-visited project is known (via the existing `funnelbarn_default_project` localStorage key, surfaced through `useProjects`).
- Unauthenticated visitors keep seeing `Landing.tsx` exactly as before; auth-loading still shows the spinner so we never flash the marketing page in front of a returning user.
- Authenticated users with no projects fall through to the Dashboard empty-state (which already handles the create-project flow).

## How the destination was chosen
The task asked to prefer `/dashboard/<projectId>` over generic `/dashboard` when project context exists. `DefaultProjectRoute` in `App.tsx` already encodes "use the stored default project if it's still valid, else first project, else render Dashboard for the empty-state". Rendering it directly from `RootRedirect` reuses that logic and removes the intermediate `/dashboard` hop.

## Test plan
- [x] `npm test --run` in `web/` — 137 passed
- [x] `npm run lint` (tsc --noEmit) clean
- [x] `npm run lint:eslint` no new errors/warnings
- [x] Added `RootRedirect` test suite covering: unauthenticated (Landing renders, path stays `/`), auth-loading (neither Landing nor Dashboard renders), authenticated with stored default project (`/dashboard/p2`), authenticated with no stored default (`/dashboard/p1` — first project), authenticated with no projects (Dashboard empty-state, no Landing flash).