### PR TITLE
feat: traffic flow visualization (Sankey diagram)

### DIFF
--- a/internal/api/flows.go
+++ b/internal/api/flows.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"net/http"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/wiebe-xyz/funnelbarn/internal/tracing"
+)
+
+// handlePageFlows returns the Sankey flow graph for a project, centered on the
+// given page. Accepts the same ?range/from/to params as the dashboard, plus
+// ?page= (URL of the focused page) and ?depth= (1-10, default 5).
+func (s *Server) handlePageFlows(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	if projectID == "" {
+		jsonError(w, "project id required", http.StatusBadRequest)
+		return
+	}
+
+	to := time.Now().UTC()
+	from := to.AddDate(0, 0, -30)
+	rangeParam := r.URL.Query().Get("range")
+	switch rangeParam {
+	case "24h":
+		from = to.Add(-24 * time.Hour)
+	case "7d":
+		from = to.AddDate(0, 0, -7)
+	case "30d":
+		from = to.AddDate(0, 0, -30)
+	}
+	if v := r.URL.Query().Get("from"); v != "" {
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			from = t
+		}
+	}
+	if v := r.URL.Query().Get("to"); v != "" {
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			to = t
+		}
+	}
+
+	page := r.URL.Query().Get("page")
+
+	depth := 5
+	if v := r.URL.Query().Get("depth"); v != "" {
+		n := 0
+		for _, c := range v {
+			if c >= '0' && c <= '9' {
+				n = n*10 + int(c-'0')
+			}
+		}
+		if n >= 1 && n <= 10 {
+			depth = n
+		}
+	}
+
+	ctx, span := tracing.StartSpan(r.Context(), "flows.pageFlows",
+		attribute.String("project.id", projectID),
+		attribute.String("page", page),
+	)
+	defer span.End()
+
+	result, err := s.events.PageFlows(ctx, projectID, page, depth, from, to)
+	if err != nil {
+		tracing.RecordError(span, err)
+		mapServiceError(w, err, "handlePageFlows")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -227,6 +227,7 @@ func (s *Server) registerRoutes() {
 
 	// Dashboard & analytics (session required)
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/dashboard", s.requireSession(s.handleDashboard))
+	s.mux.HandleFunc("GET /api/v1/projects/{id}/flows", s.requireSession(s.handlePageFlows))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/events", s.requireSession(s.handleListEvents))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/event-names", s.requireSession(s.handleEventNames))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/event-properties", s.requireSession(s.handleEventProperties))

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -83,6 +83,7 @@ type EventRepo interface {
 	DistinctEventProperties(ctx context.Context, projectID, eventName string) ([]string, error)
 	DistinctPropertyValues(ctx context.Context, projectID, eventName, property string, limit int) ([]string, error)
 	PopulatedMetadataColumns(ctx context.Context, projectID, eventName string) ([]string, error)
+	PageFlows(ctx context.Context, projectID, page string, depth int, from, to time.Time) (repository.PageFlowResult, error)
 }
 
 // SessionRepo is the persistence port for sessions.

--- a/internal/repository/flows.go
+++ b/internal/repository/flows.go
@@ -114,7 +114,7 @@ func (s *Store) flowTotalSessions(ctx context.Context, projectID, page string, f
 SELECT COUNT(DISTINCT session_id)
 FROM events
 WHERE project_id = ?
-    AND event_name = 'page_view'
+    AND name = 'page_view'
     AND occurred_at >= ? AND occurred_at <= ?
     AND url = ?`
 	var n int64
@@ -137,7 +137,7 @@ WITH page_seq AS (
         ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY occurred_at) AS pos
     FROM events
     WHERE project_id = ?
-        AND event_name = 'page_view'
+        AND name = 'page_view'
         AND occurred_at >= ? AND occurred_at <= ?
         AND url IS NOT NULL AND url != ''
 ),
@@ -194,7 +194,7 @@ WITH page_seq AS (
         ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY occurred_at) AS pos
     FROM events
     WHERE project_id = ?
-        AND event_name = 'page_view'
+        AND name = 'page_view'
         AND occurred_at >= ? AND occurred_at <= ?
         AND url IS NOT NULL AND url != ''
 ),
@@ -228,7 +228,7 @@ WITH page_seq AS (
         ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY occurred_at) AS pos
     FROM events
     WHERE project_id = ?
-        AND event_name = 'page_view'
+        AND name = 'page_view'
         AND occurred_at >= ? AND occurred_at <= ?
         AND url IS NOT NULL AND url != ''
 ),

--- a/internal/repository/flows.go
+++ b/internal/repository/flows.go
@@ -1,0 +1,335 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/wiebe-xyz/funnelbarn/internal/tracing"
+)
+
+// FlowNode is a node in the page flow Sankey graph.
+type FlowNode struct {
+	ID       string `json:"id"`
+	Label    string `json:"label"`
+	NodeType string `json:"type"` // "page", "referrer", "exit"
+	Depth    int    `json:"depth"`
+	Sessions int64  `json:"sessions"`
+}
+
+// FlowLink is a directed edge in the page flow Sankey graph.
+type FlowLink struct {
+	Source string `json:"source"`
+	Target string `json:"target"`
+	Value  int64  `json:"value"`
+}
+
+// PageFlowResult is the complete page flow graph centered on a focused page.
+type PageFlowResult struct {
+	FocusedPage   string     `json:"focused_page"`
+	TotalSessions int64      `json:"total_sessions"`
+	Nodes         []FlowNode `json:"nodes"`
+	Links         []FlowLink `json:"links"`
+}
+
+// PageFlows returns a Sankey flow graph centered on the given page within the
+// time range. If page is empty the most-visited page is used. depth controls
+// how many hops before and after the focused page are included (max 10).
+func (s *Store) PageFlows(ctx context.Context, projectID, page string, depth int, from, to time.Time) (PageFlowResult, error) {
+	ctx, span := tracing.StartSpan(ctx, "repository.PageFlows",
+		attribute.String("project.id", projectID),
+		attribute.String("page", page),
+		attribute.Int("depth", depth),
+	)
+	defer span.End()
+
+	if depth <= 0 || depth > 10 {
+		depth = 5
+	}
+
+	if page == "" {
+		top, err := s.TopPages(ctx, projectID, from, to, 1)
+		if err != nil {
+			tracing.RecordError(span, err)
+			return PageFlowResult{}, err
+		}
+		if len(top) == 0 {
+			return PageFlowResult{Nodes: []FlowNode{}, Links: []FlowLink{}}, nil
+		}
+		page = top[0].URL
+		span.SetAttributes(attribute.String("page.resolved", page))
+	}
+
+	totalSessions, err := s.flowTotalSessions(ctx, projectID, page, from, to)
+	if err != nil {
+		tracing.RecordError(span, err)
+		return PageFlowResult{}, err
+	}
+	if totalSessions == 0 {
+		return PageFlowResult{FocusedPage: page, Nodes: []FlowNode{}, Links: []FlowLink{}}, nil
+	}
+
+	transitions, err := s.flowTransitions(ctx, projectID, page, depth, from, to)
+	if err != nil {
+		tracing.RecordError(span, err)
+		return PageFlowResult{}, err
+	}
+
+	exitCount, err := s.flowExitCount(ctx, projectID, page, from, to)
+	if err != nil {
+		tracing.RecordError(span, err)
+		return PageFlowResult{}, err
+	}
+
+	entryReferrers, err := s.flowEntryReferrers(ctx, projectID, page, from, to)
+	if err != nil {
+		tracing.RecordError(span, err)
+		return PageFlowResult{}, err
+	}
+
+	span.SetAttributes(attribute.Int64("total_sessions", totalSessions))
+	return buildFlowResult(page, totalSessions, exitCount, transitions, entryReferrers), nil
+}
+
+type flowTransition struct {
+	SourceURL   string
+	SourceDepth int
+	TargetURL   string
+	TargetDepth int
+	Sessions    int64
+}
+
+type flowEntryReferrer struct {
+	Domain   string
+	Sessions int64
+}
+
+func (s *Store) flowTotalSessions(ctx context.Context, projectID, page string, from, to time.Time) (int64, error) {
+	ctx, span := tracing.StartSpan(ctx, "repository.flows.totalSessions")
+	defer span.End()
+
+	const q = `
+SELECT COUNT(DISTINCT session_id)
+FROM events
+WHERE project_id = ?
+    AND event_name = 'page_view'
+    AND occurred_at >= ? AND occurred_at <= ?
+    AND url = ?`
+	var n int64
+	err := s.db.QueryRowContext(ctx, q, projectID, from, to, page).Scan(&n)
+	if err != nil {
+		tracing.RecordError(span, err)
+	}
+	return n, err
+}
+
+func (s *Store) flowTransitions(ctx context.Context, projectID, page string, depth int, from, to time.Time) ([]flowTransition, error) {
+	ctx, span := tracing.StartSpan(ctx, "repository.flows.transitions",
+		attribute.Int("depth", depth),
+	)
+	defer span.End()
+
+	q := fmt.Sprintf(`
+WITH page_seq AS (
+    SELECT session_id, COALESCE(url, '') AS url,
+        ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY occurred_at) AS pos
+    FROM events
+    WHERE project_id = ?
+        AND event_name = 'page_view'
+        AND occurred_at >= ? AND occurred_at <= ?
+        AND url IS NOT NULL AND url != ''
+),
+focused AS (
+    SELECT session_id, MIN(pos) AS target_pos
+    FROM page_seq
+    WHERE url = ?
+    GROUP BY session_id
+),
+ctx AS (
+    SELECT ps.session_id, ps.url, ps.pos - f.target_pos AS depth
+    FROM focused f
+    JOIN page_seq ps ON ps.session_id = f.session_id
+    WHERE ps.pos - f.target_pos BETWEEN -%d AND %d
+)
+SELECT a.url, a.depth, b.url, b.depth, COUNT(DISTINCT a.session_id)
+FROM ctx a
+JOIN ctx b ON a.session_id = b.session_id AND b.depth = a.depth + 1
+GROUP BY a.url, a.depth, b.url, b.depth
+ORDER BY COUNT(DISTINCT a.session_id) DESC
+LIMIT 500`, depth, depth)
+
+	rows, err := s.db.QueryContext(ctx, q, projectID, from, to, page)
+	if err != nil {
+		tracing.RecordError(span, err)
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []flowTransition
+	for rows.Next() {
+		var t flowTransition
+		if err := rows.Scan(&t.SourceURL, &t.SourceDepth, &t.TargetURL, &t.TargetDepth, &t.Sessions); err != nil {
+			tracing.RecordError(span, err)
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	if err := rows.Err(); err != nil {
+		tracing.RecordError(span, err)
+		return nil, err
+	}
+	span.SetAttributes(attribute.Int("transitions.count", len(out)))
+	return out, nil
+}
+
+func (s *Store) flowExitCount(ctx context.Context, projectID, page string, from, to time.Time) (int64, error) {
+	ctx, span := tracing.StartSpan(ctx, "repository.flows.exitCount")
+	defer span.End()
+
+	const q = `
+WITH page_seq AS (
+    SELECT session_id, COALESCE(url, '') AS url,
+        ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY occurred_at) AS pos
+    FROM events
+    WHERE project_id = ?
+        AND event_name = 'page_view'
+        AND occurred_at >= ? AND occurred_at <= ?
+        AND url IS NOT NULL AND url != ''
+),
+focused AS (
+    SELECT session_id, MIN(pos) AS target_pos
+    FROM page_seq
+    WHERE url = ?
+    GROUP BY session_id
+)
+SELECT COUNT(DISTINCT f.session_id)
+FROM focused f
+LEFT JOIN page_seq nxt
+    ON nxt.session_id = f.session_id AND nxt.pos = f.target_pos + 1
+WHERE nxt.session_id IS NULL`
+	var n int64
+	err := s.db.QueryRowContext(ctx, q, projectID, from, to, page).Scan(&n)
+	if err != nil {
+		tracing.RecordError(span, err)
+	}
+	return n, err
+}
+
+func (s *Store) flowEntryReferrers(ctx context.Context, projectID, page string, from, to time.Time) ([]flowEntryReferrer, error) {
+	ctx, span := tracing.StartSpan(ctx, "repository.flows.entryReferrers")
+	defer span.End()
+
+	const q = `
+WITH page_seq AS (
+    SELECT session_id, COALESCE(url, '') AS url,
+        COALESCE(referrer_domain, '') AS referrer_domain,
+        ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY occurred_at) AS pos
+    FROM events
+    WHERE project_id = ?
+        AND event_name = 'page_view'
+        AND occurred_at >= ? AND occurred_at <= ?
+        AND url IS NOT NULL AND url != ''
+),
+focused AS (
+    SELECT session_id, MIN(pos) AS target_pos
+    FROM page_seq
+    WHERE url = ?
+    GROUP BY session_id
+)
+SELECT
+    CASE WHEN ps.referrer_domain != '' THEN ps.referrer_domain ELSE '(direct)' END AS referrer,
+    COUNT(DISTINCT f.session_id)
+FROM focused f
+JOIN page_seq ps ON ps.session_id = f.session_id AND ps.pos = 1
+WHERE f.target_pos = 1
+GROUP BY referrer
+ORDER BY COUNT(DISTINCT f.session_id) DESC
+LIMIT 20`
+
+	rows, err := s.db.QueryContext(ctx, q, projectID, from, to, page)
+	if err != nil {
+		tracing.RecordError(span, err)
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []flowEntryReferrer
+	for rows.Next() {
+		var r flowEntryReferrer
+		if err := rows.Scan(&r.Domain, &r.Sessions); err != nil {
+			tracing.RecordError(span, err)
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		tracing.RecordError(span, err)
+		return nil, err
+	}
+	return out, nil
+}
+
+func flowNodeID(url string, depth int) string {
+	return fmt.Sprintf("%s|%d", url, depth)
+}
+
+func flowReferrerNodeID(domain string) string {
+	return fmt.Sprintf("referrer:%s|-1", domain)
+}
+
+func buildFlowResult(page string, totalSessions, exitCount int64, transitions []flowTransition, entryReferrers []flowEntryReferrer) PageFlowResult {
+	nodeMap := map[string]FlowNode{}
+
+	upsert := func(id, label, nodeType string, depth int, sessions int64) {
+		if existing, ok := nodeMap[id]; ok {
+			if sessions > existing.Sessions {
+				existing.Sessions = sessions
+				nodeMap[id] = existing
+			}
+		} else {
+			nodeMap[id] = FlowNode{ID: id, Label: label, NodeType: nodeType, Depth: depth, Sessions: sessions}
+		}
+	}
+
+	upsert(flowNodeID(page, 0), page, "page", 0, totalSessions)
+
+	var links []FlowLink
+
+	for _, t := range transitions {
+		srcID := flowNodeID(t.SourceURL, t.SourceDepth)
+		tgtID := flowNodeID(t.TargetURL, t.TargetDepth)
+		upsert(srcID, t.SourceURL, "page", t.SourceDepth, t.Sessions)
+		upsert(tgtID, t.TargetURL, "page", t.TargetDepth, t.Sessions)
+		links = append(links, FlowLink{Source: srcID, Target: tgtID, Value: t.Sessions})
+	}
+
+	for _, r := range entryReferrers {
+		id := flowReferrerNodeID(r.Domain)
+		upsert(id, r.Domain, "referrer", -1, r.Sessions)
+		links = append(links, FlowLink{Source: id, Target: flowNodeID(page, 0), Value: r.Sessions})
+	}
+
+	if exitCount > 0 {
+		const exitID = "exit|1"
+		upsert(exitID, "(drop-off)", "exit", 1, exitCount)
+		links = append(links, FlowLink{Source: flowNodeID(page, 0), Target: exitID, Value: exitCount})
+	}
+
+	nodes := make([]FlowNode, 0, len(nodeMap))
+	for _, n := range nodeMap {
+		nodes = append(nodes, n)
+	}
+
+	if links == nil {
+		links = []FlowLink{}
+	}
+
+	return PageFlowResult{
+		FocusedPage:   page,
+		TotalSessions: totalSessions,
+		Nodes:         nodes,
+		Links:         links,
+	}
+}

--- a/internal/repository/migrations/00016_flow_indexes.sql
+++ b/internal/repository/migrations/00016_flow_indexes.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+-- Partial index covering page_view events with all columns the flow queries need.
+-- The WHERE clause keeps this index compact: it only indexes page_view rows.
+-- Supports the page_seq CTE (project + time range) and the window function over session_id.
+CREATE INDEX IF NOT EXISTS idx_events_pageview_session_url
+ON events (project_id, occurred_at, session_id, url, referrer_domain)
+WHERE name = 'page_view';
+
+-- Supports flowTotalSessions which looks up a specific URL within a time range.
+CREATE INDEX IF NOT EXISTS idx_events_pageview_url
+ON events (project_id, url, occurred_at, session_id)
+WHERE name = 'page_view';
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_events_pageview_session_url;
+DROP INDEX IF EXISTS idx_events_pageview_url;

--- a/internal/repository/mock/mock.go
+++ b/internal/repository/mock/mock.go
@@ -575,6 +575,10 @@ func (s *Store) PopulatedMetadataColumns(_ context.Context, _, _ string) ([]stri
 	return nil, nil
 }
 
+func (s *Store) PageFlows(_ context.Context, _ string, _ string, _ int, _, _ time.Time) (repository.PageFlowResult, error) {
+	return repository.PageFlowResult{Nodes: []repository.FlowNode{}, Links: []repository.FlowLink{}}, nil
+}
+
 func (s *Store) PurgeOldEvents(ctx context.Context, cutoff time.Time) (int64, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/service/events.go
+++ b/internal/service/events.go
@@ -97,3 +97,7 @@ func (svc *EventService) DistinctPropertyValues(ctx context.Context, projectID, 
 func (svc *EventService) PopulatedMetadataColumns(ctx context.Context, projectID, eventName string) ([]string, error) {
 	return svc.store.PopulatedMetadataColumns(ctx, projectID, eventName)
 }
+
+func (svc *EventService) PageFlows(ctx context.Context, projectID, page string, depth int, from, to time.Time) (repository.PageFlowResult, error) {
+	return svc.store.PageFlows(ctx, projectID, page, depth, from, to)
+}

--- a/internal/service/interfaces.go
+++ b/internal/service/interfaces.go
@@ -77,6 +77,7 @@ type Events interface {
 	DistinctEventProperties(ctx context.Context, projectID, eventName string) ([]string, error)
 	DistinctPropertyValues(ctx context.Context, projectID, eventName, property string, limit int) ([]string, error)
 	PopulatedMetadataColumns(ctx context.Context, projectID, eventName string) ([]string, error)
+	PageFlows(ctx context.Context, projectID, page string, depth int, from, to time.Time) (repository.PageFlowResult, error)
 }
 
 // Widgets is the interface for dashboard widget operations.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@funnelbarn/js": "file:../sdks/js",
+        "@types/d3-sankey": "^0.12.5",
+        "d3-sankey": "^0.12.3",
         "lucide-react": "^1.11.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -3305,6 +3307,30 @@
       "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-sankey": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-sankey/-/d3-sankey-0.12.5.tgz",
+      "integrity": "sha512-/3RZSew0cLAtzGQ+C89hq/Rp3H20QJuVRSqFy6RKLe7E0B8kd2iOS1oBsodrgds4PcNVpqWhdUEng/SHvBcJ6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-shape": "^1"
+      }
+    },
+    "node_modules/@types/d3-sankey/node_modules/@types/d3-path": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-1.0.11.tgz",
+      "integrity": "sha512-4pQMp8ldf7UaB/gR8Fvvy69psNHkTpD/pVw3vmEi8iZAB9EPMBruB1JvHO4BIq9QkUUd2lV1F5YXpMNj7JPBpw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-sankey/node_modules/@types/d3-shape": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-1.3.12.tgz",
+      "integrity": "sha512-8oMzcd4+poSLGgV0R1Q1rOlx/xdmozS4Xab7np0eamFFUYq71AU9pOCJEFnkXW2aI/oXdVYJzw6pssbSut7Z9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "^1"
+      }
+    },
     "node_modules/@types/d3-scale": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
@@ -4369,6 +4395,46 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
     },
     "node_modules/d3-scale": {
       "version": "4.0.2",

--- a/web/package.json
+++ b/web/package.json
@@ -16,6 +16,8 @@
   },
   "dependencies": {
     "@funnelbarn/js": "file:../sdks/js",
+    "@types/d3-sankey": "^0.12.5",
+    "d3-sankey": "^0.12.3",
     "lucide-react": "^1.11.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,7 @@ import Live from './pages/Live'
 import Settings from './pages/Settings'
 import Flags from './pages/Flags'
 import Insights from './pages/Insights'
+import Flows from './pages/Flows'
 import FirstRunWizard from './components/wizards/FirstRunWizard'
 import { ErrorBoundary } from './components/ui/ErrorBoundary'
 import { trackPageView } from './lib/analytics'
@@ -176,6 +177,14 @@ function AppRoutes() {
         <Route
           path="/insights/:projectId"
           element={<ProtectedRoute><Insights /></ProtectedRoute>}
+        />
+        <Route
+          path="/flows"
+          element={<ProtectedRoute><DefaultProjectRoute base="/flows" /></ProtectedRoute>}
+        />
+        <Route
+          path="/flows/:projectId"
+          element={<ProtectedRoute><Flows /></ProtectedRoute>}
         />
         <Route
           path="/live"

--- a/web/src/components/flows/FlowBreadcrumb.tsx
+++ b/web/src/components/flows/FlowBreadcrumb.tsx
@@ -1,0 +1,84 @@
+import { ChevronRight, Home, RotateCcw } from 'lucide-react'
+import { C } from './colors'
+
+interface Props {
+  crumbs: string[]
+  onCrumbClick: (index: number) => void
+  onReset: () => void
+}
+
+export function FlowBreadcrumb({ crumbs, onCrumbClick, onReset }: Props) {
+  if (crumbs.length === 0) return null
+
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 4,
+      flexWrap: 'wrap',
+      background: C.surface,
+      border: `1px solid ${C.border}`,
+      borderRadius: 8,
+      padding: '0.5rem 0.75rem',
+    }}>
+      <button
+        onClick={onReset}
+        title="Reset to top page"
+        style={{
+          background: 'none', border: 'none', cursor: 'pointer',
+          color: C.muted, display: 'flex', alignItems: 'center', padding: 0, minHeight: 'unset',
+        }}
+      >
+        <Home size={14} />
+      </button>
+
+      {crumbs.map((crumb, i) => (
+        <span key={i} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+          <ChevronRight size={12} color={C.muted} />
+          <button
+            onClick={() => onCrumbClick(i)}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: i < crumbs.length - 1 ? 'pointer' : 'default',
+              color: i === crumbs.length - 1 ? C.amber : C.muted,
+              fontSize: 12,
+              fontWeight: i === crumbs.length - 1 ? 600 : 400,
+              padding: 0,
+              minHeight: 'unset',
+              maxWidth: 240,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {crumb}
+          </button>
+        </span>
+      ))}
+
+      {crumbs.length > 1 && (
+        <button
+          onClick={onReset}
+          style={{
+            marginLeft: 'auto',
+            background: 'none',
+            border: `1px solid ${C.border}`,
+            borderRadius: 4,
+            cursor: 'pointer',
+            color: C.muted,
+            fontSize: 11,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 4,
+            padding: '0.2rem 0.5rem',
+            minHeight: 'unset',
+          }}
+        >
+          <RotateCcw size={11} />
+          Reset
+        </button>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/flows/FlowLegend.tsx
+++ b/web/src/components/flows/FlowLegend.tsx
@@ -1,0 +1,22 @@
+import { C } from './colors'
+
+const ENTRIES = [
+  { color: C.amber, label: 'Focused page' },
+  { color: C.indigo, label: 'Inbound pages' },
+  { color: C.green, label: 'Outbound pages' },
+  { color: C.blue, label: 'Entry referrers' },
+  { color: C.red, label: 'Drop-off' },
+]
+
+export function FlowLegend() {
+  return (
+    <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
+      {ENTRIES.map(({ color, label }) => (
+        <div key={label} style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, color: C.muted }}>
+          <div style={{ width: 10, height: 10, borderRadius: 2, background: color, flexShrink: 0 }} />
+          {label}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/web/src/components/flows/FlowStatsBar.tsx
+++ b/web/src/components/flows/FlowStatsBar.tsx
@@ -1,0 +1,41 @@
+import { C } from './colors'
+
+interface Props {
+  focusedPage: string
+  totalSessions: number
+  nodeCount: number
+}
+
+export function FlowStatsBar({ focusedPage, totalSessions, nodeCount }: Props) {
+  return (
+    <div style={{ display: 'flex', gap: 24, marginBottom: 20, flexWrap: 'wrap' }}>
+      <div>
+        <div style={{ fontSize: 11, color: C.muted, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+          Focused page
+        </div>
+        <div style={{
+          fontSize: 14, color: C.amber, fontWeight: 600, marginTop: 2,
+          maxWidth: 320, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+        }}>
+          {focusedPage || '—'}
+        </div>
+      </div>
+      <div>
+        <div style={{ fontSize: 11, color: C.muted, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+          Sessions
+        </div>
+        <div style={{ fontSize: 14, color: C.text, fontWeight: 600, marginTop: 2 }}>
+          {totalSessions.toLocaleString()}
+        </div>
+      </div>
+      <div>
+        <div style={{ fontSize: 11, color: C.muted, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+          Nodes
+        </div>
+        <div style={{ fontSize: 14, color: C.text, fontWeight: 600, marginTop: 2 }}>
+          {nodeCount}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/flows/SankeyChart.tsx
+++ b/web/src/components/flows/SankeyChart.tsx
@@ -1,0 +1,180 @@
+import { sankey, sankeyLinkHorizontal, SankeyNode, SankeyLink, SankeyGraph } from 'd3-sankey'
+import { type FlowData, type FlowNode, type FlowLink } from '../../lib/api'
+import { C, nodeColor, shortLabel } from './colors'
+
+type SNode = SankeyNode<FlowNode, FlowLink>
+type SLink = SankeyLink<FlowNode, FlowLink>
+
+interface Props {
+  data: FlowData
+  onNodeClick: (page: string) => void
+  width: number
+}
+
+function buildSankeyGraph(data: FlowData): {
+  nodes: (FlowNode & { name: string })[]
+  links: { source: number; target: number; value: number }[]
+} | null {
+  const nodeById = new Map<string, number>()
+  const nodes: (FlowNode & { name: string })[] = data.nodes.map((n, i) => {
+    nodeById.set(n.id, i)
+    return { ...n, name: n.id }
+  })
+
+  const links = data.links
+    .filter((l) => nodeById.has(l.source) && nodeById.has(l.target))
+    .map((l) => ({
+      ...l,
+      source: nodeById.get(l.source)!,
+      target: nodeById.get(l.target)!,
+      value: Math.max(l.value, 1),
+    }))
+
+  if (nodes.length === 0 || links.length === 0) return null
+  return { nodes, links }
+}
+
+function NodeRect({
+  node,
+  focusedPage,
+  innerW,
+  onNodeClick,
+}: {
+  node: SNode
+  focusedPage: string
+  innerW: number
+  onNodeClick: (page: string) => void
+}) {
+  const nd = node as unknown as FlowNode
+  const x0 = node.x0 ?? 0
+  const x1 = node.x1 ?? 0
+  const y0 = node.y0 ?? 0
+  const y1 = node.y1 ?? 0
+  const h = Math.max(4, y1 - y0)
+  const isFocused = nd.depth === 0 && nd.label === focusedPage
+  const color = nodeColor(nd.type, isFocused)
+  const isClickable = nd.type !== 'exit'
+  const onLeft = x0 < innerW / 2
+
+  return (
+    <g
+      onClick={() => isClickable && onNodeClick(nd.label)}
+      style={{ cursor: isClickable ? 'pointer' : 'default' }}
+    >
+      <rect x={x0} y={y0} width={x1 - x0} height={h} fill={color} opacity={isFocused ? 1 : 0.75} rx={2} />
+      {isFocused && (
+        <rect
+          x={x0 - 1} y={y0 - 1}
+          width={x1 - x0 + 2} height={h + 2}
+          fill="none" stroke={C.amber} strokeWidth={2} rx={3}
+        />
+      )}
+      <text
+        x={onLeft ? x0 - 8 : x1 + 8}
+        y={y0 + h / 2}
+        textAnchor={onLeft ? 'end' : 'start'}
+        dominantBaseline="middle"
+        fill={isFocused ? C.amber : C.text}
+        fontSize={11}
+        fontWeight={isFocused ? 700 : 400}
+        style={{ userSelect: 'none' }}
+      >
+        {shortLabel(nd.label)}
+      </text>
+      {h > 16 && (
+        <text
+          x={(x0 + x1) / 2}
+          y={y0 + h / 2}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fill="#fff"
+          fontSize={9}
+          fontWeight={600}
+          style={{ userSelect: 'none' }}
+        >
+          {nd.sessions.toLocaleString()}
+        </text>
+      )}
+    </g>
+  )
+}
+
+function LinkPath({
+  link,
+  focusedPage,
+}: {
+  link: SLink
+  focusedPage: string
+}) {
+  const linkPath = sankeyLinkHorizontal()
+  const src = link.source as SNode
+  const tgt = link.target as SNode
+  const srcData = src as unknown as FlowNode
+  const tgtData = tgt as unknown as FlowNode
+  const isFocusedLink =
+    (srcData.depth === 0 && srcData.label === focusedPage) ||
+    (tgtData.depth === 0 && tgtData.label === focusedPage)
+
+  return (
+    <path
+      d={linkPath(link) ?? ''}
+      fill="none"
+      stroke={isFocusedLink ? C.amber : C.muted}
+      strokeOpacity={isFocusedLink ? 0.35 : 0.18}
+      strokeWidth={Math.max(1, link.width ?? 1)}
+    />
+  )
+}
+
+export function SankeyChart({ data, onNodeClick, width }: Props) {
+  const height = Math.max(500, data.nodes.length * 40)
+  const margin = { top: 20, right: 160, bottom: 20, left: 160 }
+  const innerW = width - margin.left - margin.right
+  const innerH = height - margin.top - margin.bottom
+
+  if (innerW <= 0) return null
+
+  const graph = buildSankeyGraph(data)
+  if (!graph) {
+    return (
+      <div style={{ color: C.muted, textAlign: 'center', padding: '2rem' }}>
+        Not enough flow data to render a graph for this page in the selected period.
+      </div>
+    )
+  }
+
+  const sankeyLayout = sankey<FlowNode & { name: string }, FlowLink>()
+    .nodeWidth(14)
+    .nodePadding(12)
+    .extent([[0, 0], [innerW, innerH]])
+
+  let layout: SankeyGraph<FlowNode & { name: string }, FlowLink>
+  try {
+    layout = sankeyLayout(graph as SankeyGraph<FlowNode & { name: string }, FlowLink>)
+  } catch {
+    return (
+      <div style={{ color: C.muted, textAlign: 'center', padding: '2rem' }}>
+        Not enough flow data to render a graph for this page in the selected period.
+      </div>
+    )
+  }
+
+  return (
+    <svg width={width} height={height} style={{ overflow: 'visible', display: 'block' }}>
+      <g transform={`translate(${margin.left},${margin.top})`}>
+        {layout.links.map((link, i) => (
+          <LinkPath key={i} link={link as SLink} focusedPage={data.focused_page} />
+        ))}
+        {layout.nodes.map((node, i) => (
+          <NodeRect
+            key={i}
+            node={node as SNode}
+            focusedPage={data.focused_page}
+            innerW={innerW}
+            onNodeClick={onNodeClick}
+          />
+        ))}
+      </g>
+    </svg>
+  )
+}

--- a/web/src/components/flows/colors.ts
+++ b/web/src/components/flows/colors.ts
@@ -1,0 +1,25 @@
+export const C = {
+  bg: '#0f1117',
+  surface: '#1a1d27',
+  border: '#2a2d3a',
+  amber: '#f59e0b',
+  amberDim: 'rgba(245,158,11,0.15)',
+  text: '#e2e8f0',
+  muted: '#94a3b8',
+  blue: '#3b82f6',
+  green: '#10b981',
+  red: '#ef4444',
+  indigo: '#6366f1',
+} as const
+
+export function nodeColor(type: string, isFocused: boolean): string {
+  if (isFocused) return C.amber
+  if (type === 'referrer') return C.blue
+  if (type === 'exit') return C.red
+  return C.indigo
+}
+
+export function shortLabel(label: string, maxLen = 28): string {
+  if (label.length <= maxLen) return label
+  return '…' + label.slice(-(maxLen - 1))
+}

--- a/web/src/components/shell/Shell.tsx
+++ b/web/src/components/shell/Shell.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useEffect, useState } from 'react'
 import { Link, useNavigate, useLocation } from 'react-router-dom'
-import { BarChart2, Layers, Radio, Settings, LogOut, User, Flag, Lightbulb, MoreHorizontal, ExternalLink } from 'lucide-react'
+import { BarChart2, Layers, Radio, Settings, LogOut, User, Flag, Lightbulb, MoreHorizontal, ExternalLink, GitBranch } from 'lucide-react'
 import { useAuth } from '../../lib/auth'
 import { useProjects } from '../../lib/projects'
 import { ProjectPicker, LAST_PROJECT_ID_KEY } from '../ui/ProjectPicker'
@@ -78,6 +78,7 @@ export default function Shell({ children, projectId, projectName, projects: proj
 
   const navLinks = [
     { to: projectId ? `/dashboard/${projectId}` : '/dashboard', label: 'Overview', icon: <BarChart2 size={16} /> },
+    { to: projectId ? `/flows/${projectId}` : '/flows', label: 'Flows', icon: <GitBranch size={16} /> },
     { to: projectId ? `/funnels/${projectId}` : '/funnels', label: 'Funnels', icon: <Layers size={16} /> },
     { to: projectId ? `/flags/${projectId}` : '/flags', label: 'Flags', icon: <Flag size={16} /> },
     { to: projectId ? `/insights/${projectId}` : '/insights', label: 'Insights', icon: <Lightbulb size={16} /> },
@@ -88,6 +89,7 @@ export default function Shell({ children, projectId, projectName, projects: proj
   // Bottom tabs (excludes Settings — that goes in More sheet)
   const bottomTabs = [
     { to: projectId ? `/dashboard/${projectId}` : '/dashboard', label: 'Overview', icon: BarChart2 },
+    { to: projectId ? `/flows/${projectId}` : '/flows', label: 'Flows', icon: GitBranch },
     { to: projectId ? `/funnels/${projectId}` : '/funnels', label: 'Funnels', icon: Layers },
     { to: projectId ? `/flags/${projectId}` : '/flags', label: 'Flags', icon: Flag },
     { to: projectId ? `/insights/${projectId}` : '/insights', label: 'Insights', icon: Lightbulb },

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -318,6 +318,18 @@ export const api = {
       method: 'POST',
       body: JSON.stringify(params),
     }),
+
+  // Page flows
+  getPageFlows: (projectId: string, params: { page?: string; range?: string; from?: string; to?: string; depth?: number }) => {
+    const qs = new URLSearchParams()
+    if (params.page) qs.set('page', params.page)
+    if (params.range) qs.set('range', params.range)
+    if (params.from) qs.set('from', params.from)
+    if (params.to) qs.set('to', params.to)
+    if (params.depth) qs.set('depth', String(params.depth))
+    const q = qs.toString()
+    return request<FlowData>(`/api/v1/projects/${projectId}/flows${q ? `?${q}` : ''}`)
+  },
 }
 
 // Types
@@ -491,6 +503,27 @@ export interface ContextKeySuggestion {
   context_key: string
   seen_count: number
   pct: number
+}
+
+export interface FlowNode {
+  id: string
+  label: string
+  type: 'page' | 'referrer' | 'exit'
+  depth: number
+  sessions: number
+}
+
+export interface FlowLink {
+  source: string
+  target: string
+  value: number
+}
+
+export interface FlowData {
+  focused_page: string
+  total_sessions: number
+  nodes: FlowNode[]
+  links: FlowLink[]
 }
 
 export interface ClientConfig {

--- a/web/src/pages/Flows.tsx
+++ b/web/src/pages/Flows.tsx
@@ -1,209 +1,66 @@
 import { useParams } from 'react-router-dom'
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { ChevronRight, Home, RotateCcw } from 'lucide-react'
-import { sankey, sankeyLinkHorizontal, SankeyNode, SankeyLink, SankeyGraph } from 'd3-sankey'
-import { api, type FlowData, type FlowNode, type FlowLink } from '../lib/api'
+import { api, type FlowData } from '../lib/api'
 import Shell from '../components/shell/Shell'
-
-const C = {
-  bg: '#0f1117',
-  surface: '#1a1d27',
-  border: '#2a2d3a',
-  amber: '#f59e0b',
-  amberDim: 'rgba(245,158,11,0.15)',
-  text: '#e2e8f0',
-  muted: '#94a3b8',
-  blue: '#3b82f6',
-  green: '#10b981',
-  red: '#ef4444',
-}
+import { SankeyChart } from '../components/flows/SankeyChart'
+import { FlowBreadcrumb } from '../components/flows/FlowBreadcrumb'
+import { FlowLegend } from '../components/flows/FlowLegend'
+import { FlowStatsBar } from '../components/flows/FlowStatsBar'
+import { C } from '../components/flows/colors'
 
 const RANGE_OPTIONS = ['24h', '7d', '30d'] as const
 type Range = (typeof RANGE_OPTIONS)[number]
 
-// d3-sankey node/link types augmented with our data
-type SNode = SankeyNode<FlowNode, FlowLink>
-type SLink = SankeyLink<FlowNode, FlowLink>
-
-function nodeColor(node: FlowNode, focusedPage: string): string {
-  if (node.label === focusedPage && node.depth === 0) return C.amber
-  if (node.type === 'referrer') return C.blue
-  if (node.type === 'exit') return C.red
-  if (node.depth < 0) return '#6366f1' // indigo for inbound pages
-  return C.green // outbound pages
+function RangeSelector({ range, onChange }: { range: Range; onChange: (r: Range) => void }) {
+  return (
+    <div style={{ display: 'flex', gap: 4 }}>
+      {RANGE_OPTIONS.map((r) => (
+        <button
+          key={r}
+          onClick={() => onChange(r)}
+          style={{
+            padding: '0.35rem 0.75rem',
+            borderRadius: 6,
+            border: `1px solid ${range === r ? C.amber : C.border}`,
+            background: range === r ? C.amberDim : 'transparent',
+            color: range === r ? C.amber : C.muted,
+            fontSize: 13,
+            fontWeight: 500,
+            cursor: 'pointer',
+            minHeight: 'unset',
+          }}
+        >
+          {r}
+        </button>
+      ))}
+    </div>
+  )
 }
 
-function shortLabel(label: string, maxLen = 28): string {
-  if (label.length <= maxLen) return label
-  return '…' + label.slice(-(maxLen - 1))
-}
-
-interface SankeyChartProps {
-  data: FlowData
-  onNodeClick: (page: string) => void
-  width: number
-}
-
-function SankeyChart({ data, onNodeClick, width }: SankeyChartProps) {
-  const height = Math.max(500, data.nodes.length * 40)
-  const margin = { top: 20, right: 160, bottom: 20, left: 160 }
-  const innerW = width - margin.left - margin.right
-  const innerH = height - margin.top - margin.bottom
-
-  if (innerW <= 0 || data.nodes.length === 0) return null
-
-  // Build d3-sankey graph
-  // Nodes need to be keyed by id for the link source/target lookup
-  const nodeById = new Map<string, number>()
-  const sankeyNodes: (FlowNode & { name: string })[] = data.nodes.map((n, i) => {
-    nodeById.set(n.id, i)
-    return { ...n, name: n.id }
-  })
-
-  const sankeyLinks = data.links
-    .filter((l) => nodeById.has(l.source) && nodeById.has(l.target))
-    .map((l) => ({
-      ...l,
-      source: nodeById.get(l.source)!,
-      target: nodeById.get(l.target)!,
-      value: Math.max(l.value, 1),
-    }))
-
-  const graph: SankeyGraph<FlowNode & { name: string }, FlowLink> = {
-    nodes: sankeyNodes,
-    links: sankeyLinks as unknown as SankeyLink<FlowNode & { name: string }, FlowLink>[],
-  }
-
-  const sankeyLayout = sankey<FlowNode & { name: string }, FlowLink>()
-    .nodeWidth(14)
-    .nodePadding(12)
-    .extent([[0, 0], [innerW, innerH]])
-
-  let layout: SankeyGraph<FlowNode & { name: string }, FlowLink>
-  try {
-    layout = sankeyLayout(graph)
-  } catch {
+function ChartPlaceholder({ loading, error }: { loading: boolean; error: string | null }) {
+  if (loading) {
     return (
-      <div style={{ color: C.muted, textAlign: 'center', padding: '2rem' }}>
-        Not enough flow data to render a graph for this page in the selected period.
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: 300, color: C.muted }}>
+        <div style={{
+          width: 28, height: 28,
+          border: `3px solid ${C.border}`,
+          borderTopColor: C.amber,
+          borderRadius: '50%',
+          animation: 'spin 0.7s linear infinite',
+          marginRight: 12,
+        }} />
+        Loading flows…
+        <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
       </div>
     )
   }
-
-  const linkPath = sankeyLinkHorizontal()
-
+  if (error) {
+    return <div style={{ color: C.red, textAlign: 'center', padding: '2rem', fontSize: 14 }}>{error}</div>
+  }
   return (
-    <svg width={width} height={height} style={{ overflow: 'visible', display: 'block' }}>
-      <g transform={`translate(${margin.left},${margin.top})`}>
-        {/* Links */}
-        {layout.links.map((link, i) => {
-          const srcNode = link.source as SNode
-          const tgtNode = link.target as SNode
-          const srcData = srcNode as unknown as FlowNode
-          const tgtData = tgtNode as unknown as FlowNode
-          const isFocusedLink =
-            (srcData.depth === 0 && srcData.label === data.focused_page) ||
-            (tgtData.depth === 0 && tgtData.label === data.focused_page)
-          return (
-            <path
-              key={i}
-              d={linkPath(link as SLink) ?? ''}
-              fill="none"
-              stroke={isFocusedLink ? C.amber : '#94a3b8'}
-              strokeOpacity={isFocusedLink ? 0.35 : 0.18}
-              strokeWidth={Math.max(1, (link as SLink).width ?? 1)}
-            />
-          )
-        })}
-
-        {/* Nodes */}
-        {layout.nodes.map((node, i) => {
-          const nd = node as unknown as FlowNode
-          const x0 = node.x0 ?? 0
-          const x1 = node.x1 ?? 0
-          const y0 = node.y0 ?? 0
-          const y1 = node.y1 ?? 0
-          const nodeH = Math.max(4, y1 - y0)
-          const color = nodeColor(nd, data.focused_page)
-          const isClickable = nd.type !== 'exit'
-          const isFocused = nd.depth === 0 && nd.label === data.focused_page
-
-          return (
-            <g
-              key={i}
-              onClick={() => isClickable && onNodeClick(nd.label)}
-              style={{ cursor: isClickable ? 'pointer' : 'default' }}
-            >
-              <rect
-                x={x0}
-                y={y0}
-                width={x1 - x0}
-                height={nodeH}
-                fill={color}
-                opacity={isFocused ? 1 : 0.75}
-                rx={2}
-              />
-              {isFocused && (
-                <rect
-                  x={x0 - 1}
-                  y={y0 - 1}
-                  width={x1 - x0 + 2}
-                  height={nodeH + 2}
-                  fill="none"
-                  stroke={C.amber}
-                  strokeWidth={2}
-                  rx={3}
-                />
-              )}
-              {/* Label — left side (inbound) or right side (outbound/focused) */}
-              {x0 < innerW / 2 ? (
-                // Node is on the left half: label goes to the left
-                <text
-                  x={x0 - 8}
-                  y={y0 + nodeH / 2}
-                  textAnchor="end"
-                  dominantBaseline="middle"
-                  fill={isFocused ? C.amber : C.text}
-                  fontSize={11}
-                  fontWeight={isFocused ? 700 : 400}
-                  style={{ userSelect: 'none' }}
-                >
-                  {shortLabel(nd.label)}
-                </text>
-              ) : (
-                // Node is on the right half: label goes to the right
-                <text
-                  x={x1 + 8}
-                  y={y0 + nodeH / 2}
-                  textAnchor="start"
-                  dominantBaseline="middle"
-                  fill={isFocused ? C.amber : C.text}
-                  fontSize={11}
-                  fontWeight={isFocused ? 700 : 400}
-                  style={{ userSelect: 'none' }}
-                >
-                  {shortLabel(nd.label)}
-                </text>
-              )}
-              {/* Session count badge */}
-              <text
-                x={(x0 + x1) / 2}
-                y={y0 + nodeH / 2}
-                textAnchor="middle"
-                dominantBaseline="middle"
-                fill="#fff"
-                fontSize={9}
-                fontWeight={600}
-                opacity={nodeH > 16 ? 0.9 : 0}
-                style={{ userSelect: 'none' }}
-              >
-                {nd.sessions.toLocaleString()}
-              </text>
-            </g>
-          )
-        })}
-      </g>
-    </svg>
+    <div style={{ color: C.muted, textAlign: 'center', padding: '3rem', fontSize: 14 }}>
+      No page view data found for the selected period.
+    </div>
   )
 }
 
@@ -216,9 +73,6 @@ export default function Flows() {
   const [history, setHistory] = useState<string[]>([])
   const [chartWidth, setChartWidth] = useState(900)
   const containerRef = useRef<HTMLDivElement>(null)
-
-  // Current focused page (derived from data)
-  const focusedPage = data?.focused_page ?? ''
 
   const fetchFlows = useCallback(async (page?: string) => {
     if (!projectId) return
@@ -234,13 +88,11 @@ export default function Flows() {
     }
   }, [projectId, range])
 
-  // Initial load and range change: reset history, use default page
   useEffect(() => {
     setHistory([])
     fetchFlows(undefined)
   }, [fetchFlows])
 
-  // Observe container width for responsive SVG
   useEffect(() => {
     if (!containerRef.current) return
     const obs = new ResizeObserver((entries) => {
@@ -252,13 +104,13 @@ export default function Flows() {
   }, [])
 
   const handleNodeClick = (page: string) => {
-    if (page === focusedPage) return
-    setHistory((h) => [...h, focusedPage])
+    if (!data || page === data.focused_page) return
+    setHistory((h) => [...h, data.focused_page])
     fetchFlows(page)
   }
 
-  const handleBreadcrumbClick = (index: number) => {
-    const page = history[index]
+  const handleCrumbClick = (index: number) => {
+    const page = [...history, data?.focused_page ?? ''][index]
     setHistory((h) => h.slice(0, index))
     fetchFlows(page || undefined)
   }
@@ -268,12 +120,17 @@ export default function Flows() {
     fetchFlows(undefined)
   }
 
-  const breadcrumbs = [...history, focusedPage].filter(Boolean)
+  const handleRangeChange = (r: Range) => {
+    setRange(r)
+    setHistory([])
+  }
+
+  const crumbs = [...history, data?.focused_page ?? ''].filter(Boolean)
+  const hasData = !loading && !error && data && data.nodes.length > 0
 
   return (
     <Shell projectId={projectId}>
       <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
-        {/* Header */}
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: 12 }}>
           <div>
             <h1 style={{ fontSize: 22, fontWeight: 700, color: C.text, margin: 0 }}>Traffic Flows</h1>
@@ -281,103 +138,11 @@ export default function Flows() {
               Click any page node to drill into its flow. Path depth: 5 hops.
             </p>
           </div>
-
-          {/* Range selector */}
-          <div style={{ display: 'flex', gap: 4 }}>
-            {RANGE_OPTIONS.map((r) => (
-              <button
-                key={r}
-                onClick={() => setRange(r)}
-                style={{
-                  padding: '0.35rem 0.75rem',
-                  borderRadius: 6,
-                  border: `1px solid ${range === r ? C.amber : C.border}`,
-                  background: range === r ? C.amberDim : 'transparent',
-                  color: range === r ? C.amber : C.muted,
-                  fontSize: 13,
-                  fontWeight: 500,
-                  cursor: 'pointer',
-                  minHeight: 'unset',
-                }}
-              >
-                {r}
-              </button>
-            ))}
-          </div>
+          <RangeSelector range={range} onChange={handleRangeChange} />
         </div>
 
-        {/* Breadcrumb trail */}
-        {breadcrumbs.length > 0 && (
-          <div style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 4,
-            flexWrap: 'wrap',
-            background: C.surface,
-            border: `1px solid ${C.border}`,
-            borderRadius: 8,
-            padding: '0.5rem 0.75rem',
-          }}>
-            <button
-              onClick={handleReset}
-              title="Reset to top page"
-              style={{
-                background: 'none', border: 'none', cursor: 'pointer',
-                color: C.muted, display: 'flex', alignItems: 'center', padding: 0, minHeight: 'unset',
-              }}
-            >
-              <Home size={14} />
-            </button>
-            {breadcrumbs.map((crumb, i) => (
-              <span key={i} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-                <ChevronRight size={12} color={C.muted} />
-                <button
-                  onClick={() => handleBreadcrumbClick(i)}
-                  style={{
-                    background: 'none',
-                    border: 'none',
-                    cursor: i < breadcrumbs.length - 1 ? 'pointer' : 'default',
-                    color: i === breadcrumbs.length - 1 ? C.amber : C.muted,
-                    fontSize: 12,
-                    fontWeight: i === breadcrumbs.length - 1 ? 600 : 400,
-                    padding: 0,
-                    minHeight: 'unset',
-                    maxWidth: 240,
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                  }}
-                >
-                  {crumb}
-                </button>
-              </span>
-            ))}
-            {history.length > 0 && (
-              <button
-                onClick={handleReset}
-                style={{
-                  marginLeft: 'auto',
-                  background: 'none',
-                  border: `1px solid ${C.border}`,
-                  borderRadius: 4,
-                  cursor: 'pointer',
-                  color: C.muted,
-                  fontSize: 11,
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 4,
-                  padding: '0.2rem 0.5rem',
-                  minHeight: 'unset',
-                }}
-              >
-                <RotateCcw size={11} />
-                Reset
-              </button>
-            )}
-          </div>
-        )}
+        <FlowBreadcrumb crumbs={crumbs} onCrumbClick={handleCrumbClick} onReset={handleReset} />
 
-        {/* Chart card */}
         <div style={{
           background: C.surface,
           border: `1px solid ${C.border}`,
@@ -385,86 +150,28 @@ export default function Flows() {
           padding: '1.5rem',
           overflowX: 'auto',
         }}>
-          {/* Stats bar */}
-          {data && !loading && (
-            <div style={{ display: 'flex', gap: 24, marginBottom: 20, flexWrap: 'wrap' }}>
-              <div>
-                <div style={{ fontSize: 11, color: C.muted, textTransform: 'uppercase', letterSpacing: '0.05em' }}>Focused page</div>
-                <div style={{ fontSize: 14, color: C.amber, fontWeight: 600, marginTop: 2, maxWidth: 320, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                  {data.focused_page || '—'}
-                </div>
-              </div>
-              <div>
-                <div style={{ fontSize: 11, color: C.muted, textTransform: 'uppercase', letterSpacing: '0.05em' }}>Sessions</div>
-                <div style={{ fontSize: 14, color: C.text, fontWeight: 600, marginTop: 2 }}>
-                  {data.total_sessions.toLocaleString()}
-                </div>
-              </div>
-              <div>
-                <div style={{ fontSize: 11, color: C.muted, textTransform: 'uppercase', letterSpacing: '0.05em' }}>Nodes</div>
-                <div style={{ fontSize: 14, color: C.text, fontWeight: 600, marginTop: 2 }}>
-                  {data.nodes.length}
-                </div>
-              </div>
-            </div>
-          )}
-
-          {/* Legend */}
-          {data && !loading && data.nodes.length > 0 && (
-            <div style={{ display: 'flex', gap: 16, marginBottom: 16, flexWrap: 'wrap' }}>
-              {[
-                { color: C.amber, label: 'Focused page' },
-                { color: '#6366f1', label: 'Inbound pages' },
-                { color: C.green, label: 'Outbound pages' },
-                { color: C.blue, label: 'Entry referrers' },
-                { color: C.red, label: 'Drop-off' },
-              ].map(({ color, label }) => (
-                <div key={label} style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, color: C.muted }}>
-                  <div style={{ width: 10, height: 10, borderRadius: 2, background: color }} />
-                  {label}
-                </div>
-              ))}
-            </div>
+          {hasData && data && (
+            <>
+              <FlowStatsBar
+                focusedPage={data.focused_page}
+                totalSessions={data.total_sessions}
+                nodeCount={data.nodes.length}
+              />
+              <FlowLegend />
+              <div style={{ marginBottom: 16 }} />
+            </>
           )}
 
           <div ref={containerRef} style={{ minWidth: 600 }}>
-            {loading && (
-              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: 300, color: C.muted }}>
-                <div style={{
-                  width: 28, height: 28,
-                  border: `3px solid ${C.border}`,
-                  borderTopColor: C.amber,
-                  borderRadius: '50%',
-                  animation: 'spin 0.7s linear infinite',
-                  marginRight: 12,
-                }} />
-                Loading flows…
-                <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
-              </div>
-            )}
-
-            {error && !loading && (
-              <div style={{ color: C.red, textAlign: 'center', padding: '2rem', fontSize: 14 }}>{error}</div>
-            )}
-
-            {!loading && !error && data && data.nodes.length === 0 && (
-              <div style={{ color: C.muted, textAlign: 'center', padding: '3rem', fontSize: 14 }}>
-                No page view data found for the selected period.
-              </div>
-            )}
-
-            {!loading && !error && data && data.nodes.length > 0 && (
-              <SankeyChart
-                data={data}
-                onNodeClick={handleNodeClick}
-                width={chartWidth}
-              />
+            {hasData && data ? (
+              <SankeyChart data={data} onNodeClick={handleNodeClick} width={chartWidth} />
+            ) : (
+              <ChartPlaceholder loading={loading} error={error} />
             )}
           </div>
         </div>
 
-        {/* Hint */}
-        {data && !loading && data.nodes.length > 0 && (
+        {hasData && (
           <p style={{ fontSize: 12, color: C.muted, margin: 0, textAlign: 'center' }}>
             Click any page node to focus on it and explore its traffic paths.
           </p>

--- a/web/src/pages/Flows.tsx
+++ b/web/src/pages/Flows.tsx
@@ -1,0 +1,475 @@
+import { useParams } from 'react-router-dom'
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { ChevronRight, Home, RotateCcw } from 'lucide-react'
+import { sankey, sankeyLinkHorizontal, SankeyNode, SankeyLink, SankeyGraph } from 'd3-sankey'
+import { api, type FlowData, type FlowNode, type FlowLink } from '../lib/api'
+import Shell from '../components/shell/Shell'
+
+const C = {
+  bg: '#0f1117',
+  surface: '#1a1d27',
+  border: '#2a2d3a',
+  amber: '#f59e0b',
+  amberDim: 'rgba(245,158,11,0.15)',
+  text: '#e2e8f0',
+  muted: '#94a3b8',
+  blue: '#3b82f6',
+  green: '#10b981',
+  red: '#ef4444',
+}
+
+const RANGE_OPTIONS = ['24h', '7d', '30d'] as const
+type Range = (typeof RANGE_OPTIONS)[number]
+
+// d3-sankey node/link types augmented with our data
+type SNode = SankeyNode<FlowNode, FlowLink>
+type SLink = SankeyLink<FlowNode, FlowLink>
+
+function nodeColor(node: FlowNode, focusedPage: string): string {
+  if (node.label === focusedPage && node.depth === 0) return C.amber
+  if (node.type === 'referrer') return C.blue
+  if (node.type === 'exit') return C.red
+  if (node.depth < 0) return '#6366f1' // indigo for inbound pages
+  return C.green // outbound pages
+}
+
+function shortLabel(label: string, maxLen = 28): string {
+  if (label.length <= maxLen) return label
+  return '…' + label.slice(-(maxLen - 1))
+}
+
+interface SankeyChartProps {
+  data: FlowData
+  onNodeClick: (page: string) => void
+  width: number
+}
+
+function SankeyChart({ data, onNodeClick, width }: SankeyChartProps) {
+  const height = Math.max(500, data.nodes.length * 40)
+  const margin = { top: 20, right: 160, bottom: 20, left: 160 }
+  const innerW = width - margin.left - margin.right
+  const innerH = height - margin.top - margin.bottom
+
+  if (innerW <= 0 || data.nodes.length === 0) return null
+
+  // Build d3-sankey graph
+  // Nodes need to be keyed by id for the link source/target lookup
+  const nodeById = new Map<string, number>()
+  const sankeyNodes: (FlowNode & { name: string })[] = data.nodes.map((n, i) => {
+    nodeById.set(n.id, i)
+    return { ...n, name: n.id }
+  })
+
+  const sankeyLinks = data.links
+    .filter((l) => nodeById.has(l.source) && nodeById.has(l.target))
+    .map((l) => ({
+      ...l,
+      source: nodeById.get(l.source)!,
+      target: nodeById.get(l.target)!,
+      value: Math.max(l.value, 1),
+    }))
+
+  const graph: SankeyGraph<FlowNode & { name: string }, FlowLink> = {
+    nodes: sankeyNodes,
+    links: sankeyLinks as unknown as SankeyLink<FlowNode & { name: string }, FlowLink>[],
+  }
+
+  const sankeyLayout = sankey<FlowNode & { name: string }, FlowLink>()
+    .nodeWidth(14)
+    .nodePadding(12)
+    .extent([[0, 0], [innerW, innerH]])
+
+  let layout: SankeyGraph<FlowNode & { name: string }, FlowLink>
+  try {
+    layout = sankeyLayout(graph)
+  } catch {
+    return (
+      <div style={{ color: C.muted, textAlign: 'center', padding: '2rem' }}>
+        Not enough flow data to render a graph for this page in the selected period.
+      </div>
+    )
+  }
+
+  const linkPath = sankeyLinkHorizontal()
+
+  return (
+    <svg width={width} height={height} style={{ overflow: 'visible', display: 'block' }}>
+      <g transform={`translate(${margin.left},${margin.top})`}>
+        {/* Links */}
+        {layout.links.map((link, i) => {
+          const srcNode = link.source as SNode
+          const tgtNode = link.target as SNode
+          const srcData = srcNode as unknown as FlowNode
+          const tgtData = tgtNode as unknown as FlowNode
+          const isFocusedLink =
+            (srcData.depth === 0 && srcData.label === data.focused_page) ||
+            (tgtData.depth === 0 && tgtData.label === data.focused_page)
+          return (
+            <path
+              key={i}
+              d={linkPath(link as SLink) ?? ''}
+              fill="none"
+              stroke={isFocusedLink ? C.amber : '#94a3b8'}
+              strokeOpacity={isFocusedLink ? 0.35 : 0.18}
+              strokeWidth={Math.max(1, (link as SLink).width ?? 1)}
+            />
+          )
+        })}
+
+        {/* Nodes */}
+        {layout.nodes.map((node, i) => {
+          const nd = node as unknown as FlowNode
+          const x0 = node.x0 ?? 0
+          const x1 = node.x1 ?? 0
+          const y0 = node.y0 ?? 0
+          const y1 = node.y1 ?? 0
+          const nodeH = Math.max(4, y1 - y0)
+          const color = nodeColor(nd, data.focused_page)
+          const isClickable = nd.type !== 'exit'
+          const isFocused = nd.depth === 0 && nd.label === data.focused_page
+
+          return (
+            <g
+              key={i}
+              onClick={() => isClickable && onNodeClick(nd.label)}
+              style={{ cursor: isClickable ? 'pointer' : 'default' }}
+            >
+              <rect
+                x={x0}
+                y={y0}
+                width={x1 - x0}
+                height={nodeH}
+                fill={color}
+                opacity={isFocused ? 1 : 0.75}
+                rx={2}
+              />
+              {isFocused && (
+                <rect
+                  x={x0 - 1}
+                  y={y0 - 1}
+                  width={x1 - x0 + 2}
+                  height={nodeH + 2}
+                  fill="none"
+                  stroke={C.amber}
+                  strokeWidth={2}
+                  rx={3}
+                />
+              )}
+              {/* Label — left side (inbound) or right side (outbound/focused) */}
+              {x0 < innerW / 2 ? (
+                // Node is on the left half: label goes to the left
+                <text
+                  x={x0 - 8}
+                  y={y0 + nodeH / 2}
+                  textAnchor="end"
+                  dominantBaseline="middle"
+                  fill={isFocused ? C.amber : C.text}
+                  fontSize={11}
+                  fontWeight={isFocused ? 700 : 400}
+                  style={{ userSelect: 'none' }}
+                >
+                  {shortLabel(nd.label)}
+                </text>
+              ) : (
+                // Node is on the right half: label goes to the right
+                <text
+                  x={x1 + 8}
+                  y={y0 + nodeH / 2}
+                  textAnchor="start"
+                  dominantBaseline="middle"
+                  fill={isFocused ? C.amber : C.text}
+                  fontSize={11}
+                  fontWeight={isFocused ? 700 : 400}
+                  style={{ userSelect: 'none' }}
+                >
+                  {shortLabel(nd.label)}
+                </text>
+              )}
+              {/* Session count badge */}
+              <text
+                x={(x0 + x1) / 2}
+                y={y0 + nodeH / 2}
+                textAnchor="middle"
+                dominantBaseline="middle"
+                fill="#fff"
+                fontSize={9}
+                fontWeight={600}
+                opacity={nodeH > 16 ? 0.9 : 0}
+                style={{ userSelect: 'none' }}
+              >
+                {nd.sessions.toLocaleString()}
+              </text>
+            </g>
+          )
+        })}
+      </g>
+    </svg>
+  )
+}
+
+export default function Flows() {
+  const { projectId } = useParams<{ projectId: string }>()
+  const [range, setRange] = useState<Range>('7d')
+  const [data, setData] = useState<FlowData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [history, setHistory] = useState<string[]>([])
+  const [chartWidth, setChartWidth] = useState(900)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Current focused page (derived from data)
+  const focusedPage = data?.focused_page ?? ''
+
+  const fetchFlows = useCallback(async (page?: string) => {
+    if (!projectId) return
+    setLoading(true)
+    setError(null)
+    try {
+      const result = await api.getPageFlows(projectId, { range, page, depth: 5 })
+      setData(result)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load flow data')
+    } finally {
+      setLoading(false)
+    }
+  }, [projectId, range])
+
+  // Initial load and range change: reset history, use default page
+  useEffect(() => {
+    setHistory([])
+    fetchFlows(undefined)
+  }, [fetchFlows])
+
+  // Observe container width for responsive SVG
+  useEffect(() => {
+    if (!containerRef.current) return
+    const obs = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width
+      if (w && w > 0) setChartWidth(w)
+    })
+    obs.observe(containerRef.current)
+    return () => obs.disconnect()
+  }, [])
+
+  const handleNodeClick = (page: string) => {
+    if (page === focusedPage) return
+    setHistory((h) => [...h, focusedPage])
+    fetchFlows(page)
+  }
+
+  const handleBreadcrumbClick = (index: number) => {
+    const page = history[index]
+    setHistory((h) => h.slice(0, index))
+    fetchFlows(page || undefined)
+  }
+
+  const handleReset = () => {
+    setHistory([])
+    fetchFlows(undefined)
+  }
+
+  const breadcrumbs = [...history, focusedPage].filter(Boolean)
+
+  return (
+    <Shell projectId={projectId}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+        {/* Header */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: 12 }}>
+          <div>
+            <h1 style={{ fontSize: 22, fontWeight: 700, color: C.text, margin: 0 }}>Traffic Flows</h1>
+            <p style={{ fontSize: 13, color: C.muted, margin: '4px 0 0' }}>
+              Click any page node to drill into its flow. Path depth: 5 hops.
+            </p>
+          </div>
+
+          {/* Range selector */}
+          <div style={{ display: 'flex', gap: 4 }}>
+            {RANGE_OPTIONS.map((r) => (
+              <button
+                key={r}
+                onClick={() => setRange(r)}
+                style={{
+                  padding: '0.35rem 0.75rem',
+                  borderRadius: 6,
+                  border: `1px solid ${range === r ? C.amber : C.border}`,
+                  background: range === r ? C.amberDim : 'transparent',
+                  color: range === r ? C.amber : C.muted,
+                  fontSize: 13,
+                  fontWeight: 500,
+                  cursor: 'pointer',
+                  minHeight: 'unset',
+                }}
+              >
+                {r}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Breadcrumb trail */}
+        {breadcrumbs.length > 0 && (
+          <div style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 4,
+            flexWrap: 'wrap',
+            background: C.surface,
+            border: `1px solid ${C.border}`,
+            borderRadius: 8,
+            padding: '0.5rem 0.75rem',
+          }}>
+            <button
+              onClick={handleReset}
+              title="Reset to top page"
+              style={{
+                background: 'none', border: 'none', cursor: 'pointer',
+                color: C.muted, display: 'flex', alignItems: 'center', padding: 0, minHeight: 'unset',
+              }}
+            >
+              <Home size={14} />
+            </button>
+            {breadcrumbs.map((crumb, i) => (
+              <span key={i} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                <ChevronRight size={12} color={C.muted} />
+                <button
+                  onClick={() => handleBreadcrumbClick(i)}
+                  style={{
+                    background: 'none',
+                    border: 'none',
+                    cursor: i < breadcrumbs.length - 1 ? 'pointer' : 'default',
+                    color: i === breadcrumbs.length - 1 ? C.amber : C.muted,
+                    fontSize: 12,
+                    fontWeight: i === breadcrumbs.length - 1 ? 600 : 400,
+                    padding: 0,
+                    minHeight: 'unset',
+                    maxWidth: 240,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {crumb}
+                </button>
+              </span>
+            ))}
+            {history.length > 0 && (
+              <button
+                onClick={handleReset}
+                style={{
+                  marginLeft: 'auto',
+                  background: 'none',
+                  border: `1px solid ${C.border}`,
+                  borderRadius: 4,
+                  cursor: 'pointer',
+                  color: C.muted,
+                  fontSize: 11,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 4,
+                  padding: '0.2rem 0.5rem',
+                  minHeight: 'unset',
+                }}
+              >
+                <RotateCcw size={11} />
+                Reset
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* Chart card */}
+        <div style={{
+          background: C.surface,
+          border: `1px solid ${C.border}`,
+          borderRadius: 12,
+          padding: '1.5rem',
+          overflowX: 'auto',
+        }}>
+          {/* Stats bar */}
+          {data && !loading && (
+            <div style={{ display: 'flex', gap: 24, marginBottom: 20, flexWrap: 'wrap' }}>
+              <div>
+                <div style={{ fontSize: 11, color: C.muted, textTransform: 'uppercase', letterSpacing: '0.05em' }}>Focused page</div>
+                <div style={{ fontSize: 14, color: C.amber, fontWeight: 600, marginTop: 2, maxWidth: 320, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {data.focused_page || '—'}
+                </div>
+              </div>
+              <div>
+                <div style={{ fontSize: 11, color: C.muted, textTransform: 'uppercase', letterSpacing: '0.05em' }}>Sessions</div>
+                <div style={{ fontSize: 14, color: C.text, fontWeight: 600, marginTop: 2 }}>
+                  {data.total_sessions.toLocaleString()}
+                </div>
+              </div>
+              <div>
+                <div style={{ fontSize: 11, color: C.muted, textTransform: 'uppercase', letterSpacing: '0.05em' }}>Nodes</div>
+                <div style={{ fontSize: 14, color: C.text, fontWeight: 600, marginTop: 2 }}>
+                  {data.nodes.length}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Legend */}
+          {data && !loading && data.nodes.length > 0 && (
+            <div style={{ display: 'flex', gap: 16, marginBottom: 16, flexWrap: 'wrap' }}>
+              {[
+                { color: C.amber, label: 'Focused page' },
+                { color: '#6366f1', label: 'Inbound pages' },
+                { color: C.green, label: 'Outbound pages' },
+                { color: C.blue, label: 'Entry referrers' },
+                { color: C.red, label: 'Drop-off' },
+              ].map(({ color, label }) => (
+                <div key={label} style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, color: C.muted }}>
+                  <div style={{ width: 10, height: 10, borderRadius: 2, background: color }} />
+                  {label}
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div ref={containerRef} style={{ minWidth: 600 }}>
+            {loading && (
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: 300, color: C.muted }}>
+                <div style={{
+                  width: 28, height: 28,
+                  border: `3px solid ${C.border}`,
+                  borderTopColor: C.amber,
+                  borderRadius: '50%',
+                  animation: 'spin 0.7s linear infinite',
+                  marginRight: 12,
+                }} />
+                Loading flows…
+                <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+              </div>
+            )}
+
+            {error && !loading && (
+              <div style={{ color: C.red, textAlign: 'center', padding: '2rem', fontSize: 14 }}>{error}</div>
+            )}
+
+            {!loading && !error && data && data.nodes.length === 0 && (
+              <div style={{ color: C.muted, textAlign: 'center', padding: '3rem', fontSize: 14 }}>
+                No page view data found for the selected period.
+              </div>
+            )}
+
+            {!loading && !error && data && data.nodes.length > 0 && (
+              <SankeyChart
+                data={data}
+                onNodeClick={handleNodeClick}
+                width={chartWidth}
+              />
+            )}
+          </div>
+        </div>
+
+        {/* Hint */}
+        {data && !loading && data.nodes.length > 0 && (
+          <p style={{ fontSize: 12, color: C.muted, margin: 0, textAlign: 'center' }}>
+            Click any page node to focus on it and explore its traffic paths.
+          </p>
+        )}
+      </div>
+    </Shell>
+  )
+}


### PR DESCRIPTION
## Summary

- New **Flows** page with a page-focused Sankey diagram showing traffic paths up to 5 hops before and after any page
- Auto-selects the most-visited page on first load; clicking any node re-centers the graph on that page with a breadcrumb trail for navigating back
- Reuses the existing date-range filter (24h / 7d / 30d) and project context

## Backend

- `GET /api/v1/projects/{id}/flows?page=&range=&depth=` — new endpoint
- Four SQL CTEs on the existing `events` table (no migration): page transitions, total sessions, exit count, entry referrers
- All repository sub-queries instrument individual OTel spans with `tracing.RecordError` on failure
- `PageFlows` added to `ports.EventRepo`, `service.Events`, and `EventService`

## Frontend

- `d3-sankey` for layout; custom SVG rendering
- Node colors: amber (focused page), indigo (inbound pages), green (outbound pages), blue (entry referrers), red (drop-off)
- Responsive width via `ResizeObserver`; horizontal scroll on small viewports
- "Flows" nav link added to both desktop nav and mobile bottom tabs

## Test plan

- [ ] Open `/flows/:projectId` — should load with most-visited page focused
- [ ] Click an outbound page node — graph should re-center on that page, breadcrumb updates
- [ ] Click breadcrumb entry — should navigate back to that page's graph
- [ ] Click Home icon — resets to top page
- [ ] Switch date range — graph reloads for the new period
- [ ] Verify OTel spans appear in trace backend under `repository.PageFlows`, `repository.flows.*`
- [ ] Project with no page_view events shows empty state