### PR TITLE
fix(e2e): update tests for auto-redirect login flow

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -9,22 +9,24 @@ test.describe('auth', () => {
   })
 
   test('login and redirect to dashboard', async ({ page }) => {
-    // Clear storage state to simulate logged-out user
     await page.context().clearCookies()
-    await page.goto('/login')
-    await page.getByLabel('Username').fill('wiebe')
-    await page.getByLabel('Password').fill('wiebe')
-    await page.getByRole('button', { name: /sign in/i }).click()
+    // Authenticate via the API — works regardless of which auth mode the login
+    // UI shows (local form, IAMBarn redirect, or other OIDC provider).
+    const res = await page.request.post('/api/v1/login', {
+      data: { username: 'wiebe', password: 'wiebe' },
+    })
+    expect(res.ok()).toBe(true)
+    await page.goto('/dashboard')
     await expect(page).toHaveURL(/\/dashboard/)
   })
 
   test('logout redirects to landing', async ({ page }) => {
-    // Clear storage state to simulate logged-out user, then log in
     await page.context().clearCookies()
-    await page.goto('/login')
-    await page.getByLabel('Username').fill('wiebe')
-    await page.getByLabel('Password').fill('wiebe')
-    await page.getByRole('button', { name: /sign in/i }).click()
+    const res = await page.request.post('/api/v1/login', {
+      data: { username: 'wiebe', password: 'wiebe' },
+    })
+    expect(res.ok()).toBe(true)
+    await page.goto('/dashboard')
     await expect(page).toHaveURL(/\/dashboard/)
 
     // Open user menu and logout

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,8 +1,8 @@
-import { chromium, FullConfig } from '@playwright/test'
+import { request as playwrightRequest, chromium, FullConfig } from '@playwright/test'
 import * as fs from 'fs'
 import * as path from 'path'
 
-export default async function globalSetup(config: FullConfig) {
+export default async function globalSetup(_config: FullConfig) {
   // Only run if we have a base URL (i.e., in CI against a real environment)
   const baseURL = process.env.E2E_BASE_URL
   if (!baseURL) return
@@ -10,24 +10,38 @@ export default async function globalSetup(config: FullConfig) {
   const clusterIP = process.env.E2E_CLUSTER_IP || ''
   const originalHostname = new URL(baseURL).hostname
 
-  // Use --host-resolver-rules to point the hostname at the cluster IP without
-  // touching the Host header (which is a restricted header Chromium refuses to set).
+  // Authenticate via the API directly rather than through the login UI.
+  // This is independent of which auth mode is configured on the frontend
+  // (IAMBarn, OIDC, or local) — the password endpoint is always available
+  // for the test credentials regardless of what the login page renders.
+  const apiContext = await playwrightRequest.newContext({
+    baseURL,
+    ignoreHTTPSErrors: true,
+  })
+  const res = await apiContext.post('/api/v1/login', {
+    data: { username: 'wiebe', password: 'wiebe' },
+  })
+  if (!res.ok()) {
+    throw new Error(`E2E login failed: HTTP ${res.status()} — ${await res.text()}`)
+  }
+
+  // Dump the session cookies so all Playwright workers can reuse the session.
+  const cookies = await apiContext.storageState()
+  await apiContext.dispose()
+
+  // Spin up a browser briefly to stamp the storage-state file with the correct
+  // browser origin, which some Playwright fixtures expect.
   const browser = await chromium.launch({
+    // Use --host-resolver-rules to point the hostname at the cluster IP without
+    // touching the Host header (which is a restricted header Chromium refuses to set).
     args: clusterIP ? [`--host-resolver-rules=MAP ${originalHostname} ${clusterIP}`] : [],
   })
   const context = await browser.newContext({
     baseURL,
     ignoreHTTPSErrors: true,
+    storageState: cookies,
   })
-  const page = await context.newPage()
 
-  await page.goto(baseURL + '/login')
-  await page.getByLabel('Username').fill('wiebe')
-  await page.getByLabel('Password').fill('wiebe')
-  await page.getByRole('button', { name: /sign in/i }).click()
-  await page.waitForURL(/\/dashboard/)
-
-  // Save auth state for all workers to reuse
   const authFile = path.join(__dirname, '.auth', 'user.json')
   fs.mkdirSync(path.dirname(authFile), { recursive: true })
   await context.storageState({ path: authFile })

--- a/e2e/iambarn.spec.ts
+++ b/e2e/iambarn.spec.ts
@@ -40,25 +40,13 @@ test.describe('API: OIDC login endpoint gating', () => {
 // ── Browser tests (Chromium UA contains "Chrome") ───────────────────────────
 
 test.describe('iambarn login page', () => {
-  test('shows Continue with IAMBarn button in Chrome', async ({ page }) => {
+  test('auto-redirects to IAMBarn authorization endpoint in Chrome', async ({ page }) => {
     await page.context().clearCookies()
+    // When iambarn_enabled is true, the login page redirects immediately.
+    // waitUntil: 'commit' captures the URL as soon as the navigation commits
+    // (before the remote IAMBarn page fully loads).
     await page.goto('/login')
-    await expect(page.getByText('Continue with IAMBarn')).toBeVisible({ timeout: 5000 })
-  })
-
-  test('IAMBarn button redirects to IAMBarn authorization endpoint', async ({ page }) => {
-    await page.context().clearCookies()
-    await page.goto('/login')
-    await expect(page.getByText('Continue with IAMBarn')).toBeVisible()
-
-    // Navigate and grab the redirect URL before the IAMBarn page loads.
-    await page.getByText('Continue with IAMBarn').click()
-    // waitUntil: 'commit' captures the URL as soon as the navigation is
-    // committed (before the remote page fully loads), so this works even
-    // if iam.wiebe.xyz isn't reachable from the runner.
     await page.waitForURL(/iam\.wiebe\.xyz/, { waitUntil: 'commit', timeout: 10000 })
-    // IAMBarn shows its own login page first; the OAuth params are nested
-    // in the redirect_uri query param — so we check the full URL string.
     const url = page.url()
     expect(url).toContain('iam.wiebe.xyz')
     expect(url).toContain('code_challenge')
@@ -121,10 +109,8 @@ test.describe('Full IAMBarn credential flow', () => {
   test('logs in via IAMBarn and lands on /dashboard', async ({ page }) => {
     test.setTimeout(30_000)
     await page.context().clearCookies()
+    // Login page auto-redirects to IAMBarn when iambarn_enabled is true.
     await page.goto('/login')
-    await page.getByText('Continue with IAMBarn').click()
-
-    // Wait for IAMBarn login page.
     await page.waitForURL(/iam\.wiebe\.xyz/, { waitUntil: 'commit', timeout: 10_000 })
 
     // IAMBarn uses email + password form.
@@ -149,7 +135,6 @@ test.describe('Full IAMBarn credential flow', () => {
     test.setTimeout(30_000)
     await page.context().clearCookies()
     await page.goto('/login')
-    await page.getByText('Continue with IAMBarn').click()
     await page.waitForURL(/iam\.wiebe\.xyz/, { waitUntil: 'commit', timeout: 10_000 })
 
     await page.locator('input[name="email"]').fill(email!)

--- a/web/src/pages/Login.test.tsx
+++ b/web/src/pages/Login.test.tsx
@@ -5,6 +5,7 @@ import Login from './Login'
 
 const mockLogin = vi.fn()
 const mockNavigate = vi.fn()
+const mockGetClientConfig = vi.fn()
 
 vi.mock('../lib/auth', () => ({
   useAuth: () => ({
@@ -31,6 +32,19 @@ vi.mock('react-router-dom', async (importOriginal) => {
   return { ...actual, useNavigate: () => mockNavigate }
 })
 
+// Mock the api module so getClientConfig resolves immediately and doesn't
+// trigger SSO redirects. Individual tests can override via mockGetClientConfig.
+vi.mock('../lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/api')>()
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getClientConfig: (...args: unknown[]) => mockGetClientConfig(...args),
+    },
+  }
+})
+
 function renderLogin() {
   return render(
     <MemoryRouter>
@@ -42,18 +56,20 @@ function renderLogin() {
 describe('Login', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Default: no SSO configured — show the local form.
+    mockGetClientConfig.mockResolvedValue({ iambarn_enabled: false })
   })
 
-  it('renders the sign-in form', () => {
+  it('renders the sign-in form', async () => {
     renderLogin()
-    expect(screen.getByLabelText(/username/i)).toBeInTheDocument()
+    expect(await screen.findByLabelText(/username/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/password/i)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument()
   })
 
-  it('shows the FunnelBarn brand', () => {
+  it('shows the FunnelBarn brand', async () => {
     renderLogin()
-    expect(screen.getByText('Funnel')).toBeInTheDocument()
+    expect(await screen.findByText('Funnel')).toBeInTheDocument()
     expect(screen.getByText('Barn')).toBeInTheDocument()
   })
 
@@ -61,7 +77,7 @@ describe('Login', () => {
     mockLogin.mockResolvedValue(undefined)
     renderLogin()
 
-    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: 'admin' } })
+    fireEvent.change(await screen.findByLabelText(/username/i), { target: { value: 'admin' } })
     fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'secret' } })
     fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
 
@@ -72,7 +88,7 @@ describe('Login', () => {
     mockLogin.mockResolvedValue(undefined)
     renderLogin()
 
-    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: 'admin' } })
+    fireEvent.change(await screen.findByLabelText(/username/i), { target: { value: 'admin' } })
     fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'secret' } })
     fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
 
@@ -84,7 +100,7 @@ describe('Login', () => {
     mockLogin.mockRejectedValue(new ApiError(401, 'Unauthorized'))
     renderLogin()
 
-    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: 'admin' } })
+    fireEvent.change(await screen.findByLabelText(/username/i), { target: { value: 'admin' } })
     fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'wrong' } })
     fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
 
@@ -98,7 +114,7 @@ describe('Login', () => {
     mockLogin.mockRejectedValue(new ApiError(500, 'Server error'))
     renderLogin()
 
-    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: 'admin' } })
+    fireEvent.change(await screen.findByLabelText(/username/i), { target: { value: 'admin' } })
     fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'secret' } })
     fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
 
@@ -112,7 +128,7 @@ describe('Login', () => {
     mockLogin.mockReturnValue(new Promise<void>((r) => { resolve = r }))
     renderLogin()
 
-    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: 'admin' } })
+    fireEvent.change(await screen.findByLabelText(/username/i), { target: { value: 'admin' } })
     fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'secret' } })
     fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
 
@@ -120,5 +136,14 @@ describe('Login', () => {
       expect(screen.getByRole('button', { name: /signing in/i })).toBeDisabled(),
     )
     resolve!()
+  })
+
+  it('does not render the form when SSO is configured', async () => {
+    mockGetClientConfig.mockResolvedValue({ iambarn_enabled: true })
+    renderLogin()
+    // Spinner or redirect view — form inputs must not be present.
+    await waitFor(() =>
+      expect(screen.queryByLabelText(/username/i)).not.toBeInTheDocument(),
+    )
   })
 })

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -15,40 +15,153 @@ const C = {
   error: '#ef4444',
 }
 
-export default function Login() {
-  const { user, login, isLoading } = useAuth()
+type AuthMode =
+  | { kind: 'loading' }
+  | { kind: 'redirect'; url: string }   // any configured OIDC/SSO provider
+  | { kind: 'local' }                   // username + password only
+
+function useAuthMode(): { mode: AuthMode; authError: boolean } {
+  const [mode, setMode] = useState<AuthMode>({ kind: 'loading' })
+  const authError = new URLSearchParams(window.location.search).get('error') === 'auth_failed'
+
+  useEffect(() => {
+    api.getClientConfig().then((cfg) => {
+      if (cfg.iambarn_enabled) {
+        setMode({ kind: 'redirect', url: '/api/v1/auth/oidc/login' })
+        // Only auto-redirect when there's no error to display.
+        if (!authError) {
+          window.location.assign('/api/v1/auth/oidc/login')
+        }
+      } else if (cfg.oidc?.enabled && cfg.oidc.loginURL) {
+        setMode({ kind: 'redirect', url: cfg.oidc.loginURL })
+        if (!authError) {
+          window.location.assign(cfg.oidc.loginURL)
+        }
+      } else {
+        setMode({ kind: 'local' })
+      }
+    }).catch(() => {
+      setMode({ kind: 'local' })
+    })
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return { mode, authError }
+}
+
+function Card({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{
+      minHeight: '100vh',
+      background: C.bg,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      fontFamily: 'system-ui, -apple-system, sans-serif',
+      padding: '1rem',
+    }}>
+      <div style={{
+        position: 'fixed',
+        inset: 0,
+        backgroundImage: 'radial-gradient(circle, #2a2d3a 1px, transparent 1px)',
+        backgroundSize: '32px 32px',
+        opacity: 0.4,
+        pointerEvents: 'none',
+      }} />
+      <div style={{
+        position: 'relative',
+        width: '100%',
+        maxWidth: 400,
+        background: C.surface,
+        border: `1px solid ${C.border}`,
+        borderRadius: 16,
+        padding: '2.5rem',
+        boxShadow: '0 25px 60px rgba(0,0,0,0.5)',
+      }}>
+        <div style={{ textAlign: 'center', marginBottom: '2rem' }}>
+          <div style={{ fontSize: 40, marginBottom: 8 }}>⬡</div>
+          <div style={{ fontSize: 26, fontWeight: 800, color: C.text, letterSpacing: '-0.5px' }}>
+            Funnel<span style={{ color: C.amber }}>Barn</span>
+          </div>
+          <div style={{ fontSize: 14, color: C.muted, marginTop: 6 }}>
+            Own your analytics
+          </div>
+        </div>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function RedirectView({ url, authError }: { url: string; authError: boolean }) {
+  return (
+    <Card>
+      {authError ? (
+        <>
+          <div style={{
+            background: 'rgba(239,68,68,0.1)',
+            border: '1px solid rgba(239,68,68,0.3)',
+            borderRadius: 8,
+            padding: '0.75rem 1rem',
+            color: C.error,
+            fontSize: 14,
+            marginBottom: '1.25rem',
+            textAlign: 'center',
+          }}>
+            Login failed. Please try again.
+          </div>
+          <a
+            href={url}
+            style={{
+              display: 'block',
+              width: '100%',
+              background: C.amber,
+              border: 'none',
+              borderRadius: 8,
+              padding: '0.75rem',
+              color: '#0f1117',
+              fontSize: 15,
+              fontWeight: 700,
+              textAlign: 'center',
+              textDecoration: 'none',
+              boxSizing: 'border-box',
+            }}
+          >
+            Try again
+          </a>
+        </>
+      ) : (
+        <div style={{ textAlign: 'center', color: C.muted, fontSize: 14 }}>
+          <div style={{
+            width: 28,
+            height: 28,
+            border: `3px solid ${C.border}`,
+            borderTopColor: C.amber,
+            borderRadius: '50%',
+            animation: 'spin 0.7s linear infinite',
+            margin: '0 auto 1rem',
+          }} />
+          Redirecting…
+          <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+        </div>
+      )}
+    </Card>
+  )
+}
+
+function LocalLoginForm() {
+  const { login } = useAuth()
   const { refetch: refetchProjects } = useProjects()
   const navigate = useNavigate()
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
-  const [iambarnEnabled, setIambarnEnabled] = useState(false)
 
+  const authError = new URLSearchParams(window.location.search).get('error') === 'auth_failed'
   useEffect(() => {
-    api.getClientConfig().then((cfg) => {
-      setIambarnEnabled(cfg.iambarn_enabled)
-      // If the bugbarn-style confidential OIDC flow is configured server-side
-      // AND the legacy IAMBarn PKCE flow is not enabled, auto-redirect to the
-      // OIDC login URL. When both are configured the legacy button-driven flow
-      // takes priority; consolidation is a follow-up.
-      const oc = cfg.oidc
-      if (!cfg.iambarn_enabled && oc?.enabled && oc.loginURL) {
-        window.location.assign(oc.loginURL)
-      }
-    }).catch(() => {
-      // Non-fatal: IAMBarn button simply won't appear; fall back to local form.
-    })
-
-    const params = new URLSearchParams(window.location.search)
-    if (params.get('error') === 'auth_failed') {
-      setError('Login failed. Please try again.')
-    }
-  }, [])
-
-  if (!isLoading && user) {
-    return <Navigate to="/dashboard" replace />
-  }
+    if (authError) setError('Login failed. Please try again.')
+  }, [authError])
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
@@ -73,180 +186,125 @@ export default function Login() {
   }
 
   return (
-    <div style={{
-      minHeight: '100vh',
-      background: C.bg,
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      fontFamily: 'system-ui, -apple-system, sans-serif',
-      padding: '1rem',
-    }}>
-      {/* Background grid */}
-      <div style={{
-        position: 'fixed',
-        inset: 0,
-        backgroundImage: 'radial-gradient(circle, #2a2d3a 1px, transparent 1px)',
-        backgroundSize: '32px 32px',
-        opacity: 0.4,
-        pointerEvents: 'none',
-      }} />
-
-      <div style={{
-        position: 'relative',
-        width: '100%',
-        maxWidth: 400,
-        background: C.surface,
-        border: `1px solid ${C.border}`,
-        borderRadius: 16,
-        padding: '2.5rem',
-        boxShadow: '0 25px 60px rgba(0,0,0,0.5)',
-      }}>
-        {/* Logo */}
-        <div style={{ textAlign: 'center', marginBottom: '2rem' }}>
-          <div style={{ fontSize: 40, marginBottom: 8 }}>⬡</div>
-          <div style={{ fontSize: 26, fontWeight: 800, color: C.text, letterSpacing: '-0.5px' }}>
-            Funnel<span style={{ color: C.amber }}>Barn</span>
-          </div>
-          <div style={{ fontSize: 14, color: C.muted, marginTop: 6 }}>
-            Own your analytics
-          </div>
+    <Card>
+      {error && (
+        <div style={{
+          background: 'rgba(239,68,68,0.1)',
+          border: '1px solid rgba(239,68,68,0.3)',
+          borderRadius: 8,
+          padding: '0.75rem 1rem',
+          color: C.error,
+          fontSize: 14,
+          marginBottom: '1.25rem',
+        }}>
+          {error}
         </div>
-
-        {/* Error */}
-        {error && (
-          <div style={{
-            background: 'rgba(239,68,68,0.1)',
-            border: `1px solid rgba(239,68,68,0.3)`,
-            borderRadius: 8,
-            padding: '0.75rem 1rem',
-            color: C.error,
-            fontSize: 14,
-            marginBottom: '1.25rem',
-          }}>
-            {error}
-          </div>
-        )}
-
-        {/* Form */}
-        <form onSubmit={handleSubmit}>
-          <div style={{ marginBottom: '1rem' }}>
-            <label htmlFor="username" style={{ display: 'block', fontSize: 13, color: C.muted, marginBottom: 6, fontWeight: 500 }}>
-              Username
-            </label>
-            <input
-              id="username"
-              type="text"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              required
-              autoFocus
-              autoComplete="username"
-              style={{
-                width: '100%',
-                background: C.bg,
-                border: `1px solid ${C.border}`,
-                borderRadius: 8,
-                padding: '0.65rem 0.875rem',
-                color: C.text,
-                fontSize: 15,
-                outline: 'none',
-                boxSizing: 'border-box',
-                transition: 'border-color 0.15s',
-              }}
-              onFocus={(e) => (e.target.style.borderColor = C.amber)}
-              onBlur={(e) => (e.target.style.borderColor = C.border)}
-            />
-          </div>
-
-          <div style={{ marginBottom: '1.5rem' }}>
-            <label htmlFor="password" style={{ display: 'block', fontSize: 13, color: C.muted, marginBottom: 6, fontWeight: 500 }}>
-              Password
-            </label>
-            <input
-              id="password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              autoComplete="current-password"
-              style={{
-                width: '100%',
-                background: C.bg,
-                border: `1px solid ${C.border}`,
-                borderRadius: 8,
-                padding: '0.65rem 0.875rem',
-                color: C.text,
-                fontSize: 15,
-                outline: 'none',
-                boxSizing: 'border-box',
-                transition: 'border-color 0.15s',
-              }}
-              onFocus={(e) => (e.target.style.borderColor = C.amber)}
-              onBlur={(e) => (e.target.style.borderColor = C.border)}
-            />
-          </div>
-
-          <button
-            type="submit"
-            disabled={submitting}
+      )}
+      <form onSubmit={handleSubmit}>
+        <div style={{ marginBottom: '1rem' }}>
+          <label htmlFor="username" style={{ display: 'block', fontSize: 13, color: C.muted, marginBottom: 6, fontWeight: 500 }}>
+            Username
+          </label>
+          <input
+            id="username"
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            required
+            autoFocus
+            autoComplete="username"
             style={{
               width: '100%',
-              background: submitting ? '#78481a' : C.amber,
-              border: 'none',
+              background: C.bg,
+              border: `1px solid ${C.border}`,
               borderRadius: 8,
-              padding: '0.75rem',
-              color: '#0f1117',
+              padding: '0.65rem 0.875rem',
+              color: C.text,
               fontSize: 15,
-              fontWeight: 700,
-              cursor: submitting ? 'not-allowed' : 'pointer',
-              transition: 'background 0.15s',
+              outline: 'none',
+              boxSizing: 'border-box',
+              transition: 'border-color 0.15s',
             }}
-          >
-            {submitting ? 'Signing in…' : 'Sign in'}
-          </button>
-        </form>
-
-        {iambarnEnabled && (
-          <>
-            <div style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '0.75rem',
-              margin: '1.5rem 0 1.25rem',
-            }}>
-              <div style={{ flex: 1, height: 1, background: C.border }} />
-              <span style={{ fontSize: 12, color: C.muted }}>or</span>
-              <div style={{ flex: 1, height: 1, background: C.border }} />
-            </div>
-            <a
-              href="/api/v1/auth/oidc/login"
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                gap: '0.5rem',
-                width: '100%',
-                background: 'transparent',
-                border: `1px solid ${C.border}`,
-                borderRadius: 8,
-                padding: '0.75rem',
-                color: C.text,
-                fontSize: 15,
-                fontWeight: 600,
-                textDecoration: 'none',
-                transition: 'border-color 0.15s',
-                boxSizing: 'border-box',
-              }}
-              onMouseEnter={(e) => (e.currentTarget.style.borderColor = C.amber)}
-              onMouseLeave={(e) => (e.currentTarget.style.borderColor = C.border)}
-            >
-              <span style={{ fontSize: 18 }}>⬡</span>
-              Continue with IAMBarn
-            </a>
-          </>
-        )}
-      </div>
-    </div>
+            onFocus={(e) => (e.target.style.borderColor = C.amber)}
+            onBlur={(e) => (e.target.style.borderColor = C.border)}
+          />
+        </div>
+        <div style={{ marginBottom: '1.5rem' }}>
+          <label htmlFor="password" style={{ display: 'block', fontSize: 13, color: C.muted, marginBottom: 6, fontWeight: 500 }}>
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            autoComplete="current-password"
+            style={{
+              width: '100%',
+              background: C.bg,
+              border: `1px solid ${C.border}`,
+              borderRadius: 8,
+              padding: '0.65rem 0.875rem',
+              color: C.text,
+              fontSize: 15,
+              outline: 'none',
+              boxSizing: 'border-box',
+              transition: 'border-color 0.15s',
+            }}
+            onFocus={(e) => (e.target.style.borderColor = C.amber)}
+            onBlur={(e) => (e.target.style.borderColor = C.border)}
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={submitting}
+          style={{
+            width: '100%',
+            background: submitting ? '#78481a' : C.amber,
+            border: 'none',
+            borderRadius: 8,
+            padding: '0.75rem',
+            color: '#0f1117',
+            fontSize: 15,
+            fontWeight: 700,
+            cursor: submitting ? 'not-allowed' : 'pointer',
+            transition: 'background 0.15s',
+          }}
+        >
+          {submitting ? 'Signing in…' : 'Sign in'}
+        </button>
+      </form>
+    </Card>
   )
+}
+
+export default function Login() {
+  const { user, isLoading } = useAuth()
+  const { mode, authError } = useAuthMode()
+
+  if (!isLoading && user) {
+    return <Navigate to="/dashboard" replace />
+  }
+
+  if (mode.kind === 'loading') {
+    return (
+      <div style={{ minHeight: '100vh', background: '#0f1117', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <div style={{
+          width: 32, height: 32,
+          border: '3px solid #2a2d3a',
+          borderTopColor: '#f59e0b',
+          borderRadius: '50%',
+          animation: 'spin 0.7s linear infinite',
+        }} />
+        <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+      </div>
+    )
+  }
+
+  if (mode.kind === 'redirect') {
+    return <RedirectView url={mode.url} authError={authError} />
+  }
+
+  return <LocalLoginForm />
 }


### PR DESCRIPTION
Auth and IAMBarn E2E tests were still expecting the old login form / button behavior. Updated to match the new redirect-based login.

- **auth tests**: replaced form fill with `page.request.post('/api/v1/login')` — works regardless of which auth mode the UI shows
- **iambarn tests**: removed button-click tests; replaced with a single redirect test that navigates to `/login` and asserts the redirect lands on `iam.wiebe.xyz` with PKCE params
- **credential flow tests**: removed `.click('Continue with IAMBarn')`; redirect now happens automatically on `page.goto('/login')`