### PR TITLE
fix(project-switcher): always navigate to last-visited project

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -59,6 +59,7 @@ import React from 'react'
 // Pull DefaultProjectRoute out by re-rendering App at the /dashboard path.
 // Because all providers and pages are mocked, only the routing logic is exercised.
 import App from './App'
+import { LAST_PROJECT_ID_KEY } from './components/ui/ProjectPicker'
 
 function renderAt(path: string) {
   // Patch window.location to the desired path before rendering
@@ -75,6 +76,7 @@ const loggedInUser = { id: 'u1', username: 'admin', has_projects: true }
 describe('DefaultProjectRoute', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    localStorage.clear()
     // Default: user is authenticated
     mockUseAuth.mockReturnValue({ user: loggedInUser, isLoading: false })
   })
@@ -135,7 +137,29 @@ describe('DefaultProjectRoute', () => {
     expect(window.location.pathname).toBe('/dashboard/p1')
   })
 
-  it('redirects to the defaultProject when it is set and valid', async () => {
+  it('redirects to the last-visited project when set in localStorage', async () => {
+    localStorage.setItem(LAST_PROJECT_ID_KEY, 'p2')
+    mockUseProjects.mockReturnValue({
+      projects: [
+        { id: 'p1', name: 'Alpha', slug: 'alpha', status: 'active' },
+        { id: 'p2', name: 'Beta', slug: 'beta', status: 'active' },
+      ],
+      isLoading: false,
+      defaultProjectId: null,
+      refetch: vi.fn(),
+      setDefaultProjectId: vi.fn(),
+    })
+
+    renderAt('/dashboard')
+
+    await waitFor(() =>
+      expect(screen.getByTestId('dashboard-page')).toBeInTheDocument(),
+    )
+    expect(window.location.pathname).toBe('/dashboard/p2')
+  })
+
+  it('falls back to explicit default when no last-visited is stored', async () => {
+    // No localStorage entry — simulates fresh session / first login.
     mockUseProjects.mockReturnValue({
       projects: [
         { id: 'p1', name: 'Alpha', slug: 'alpha', status: 'active' },
@@ -154,6 +178,28 @@ describe('DefaultProjectRoute', () => {
     )
     expect(window.location.pathname).toBe('/dashboard/p2')
   })
+
+  it('last-visited takes priority over explicit default', async () => {
+    localStorage.setItem(LAST_PROJECT_ID_KEY, 'p1')
+    mockUseProjects.mockReturnValue({
+      projects: [
+        { id: 'p1', name: 'Alpha', slug: 'alpha', status: 'active' },
+        { id: 'p2', name: 'Beta', slug: 'beta', status: 'active' },
+      ],
+      isLoading: false,
+      defaultProjectId: 'p2', // explicit default differs from last-visited
+      refetch: vi.fn(),
+      setDefaultProjectId: vi.fn(),
+    })
+
+    renderAt('/dashboard')
+
+    await waitFor(() =>
+      expect(screen.getByTestId('dashboard-page')).toBeInTheDocument(),
+    )
+    // last-visited (p1) wins over explicit default (p2)
+    expect(window.location.pathname).toBe('/dashboard/p1')
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -163,6 +209,7 @@ describe('DefaultProjectRoute', () => {
 describe('RootRedirect', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    localStorage.clear()
   })
 
   it('renders the marketing Landing page for unauthenticated visitors', async () => {
@@ -199,7 +246,8 @@ describe('RootRedirect', () => {
     expect(screen.queryByTestId('dashboard-page')).toBeNull()
   })
 
-  it('redirects authenticated users to the default project dashboard', async () => {
+  it('redirects authenticated users to the last-visited project', async () => {
+    localStorage.setItem(LAST_PROJECT_ID_KEY, 'p2')
     mockUseAuth.mockReturnValue({ user: loggedInUser, isLoading: false })
     mockUseProjects.mockReturnValue({
       projects: [
@@ -207,7 +255,7 @@ describe('RootRedirect', () => {
         { id: 'p2', name: 'Beta', slug: 'beta', status: 'active' },
       ],
       isLoading: false,
-      defaultProjectId: 'p2',
+      defaultProjectId: null,
       refetch: vi.fn(),
       setDefaultProjectId: vi.fn(),
     })

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,6 +13,7 @@ import Insights from './pages/Insights'
 import Flows from './pages/Flows'
 import FirstRunWizard from './components/wizards/FirstRunWizard'
 import { ErrorBoundary } from './components/ui/ErrorBoundary'
+import { LAST_PROJECT_ID_KEY } from './components/ui/ProjectPicker'
 import { trackPageView } from './lib/analytics'
 
 function ProtectedRoute({ children }: { children: ReactNode }) {
@@ -84,7 +85,7 @@ function RootRedirect() {
 }
 
 function DefaultProjectRoute({ base }: { base: string }) {
-  const { projects, isLoading, defaultProjectId } = useProjects()
+  const { projects, isLoading } = useProjects()
 
   if (isLoading) {
     return (
@@ -113,9 +114,15 @@ function DefaultProjectRoute({ base }: { base: string }) {
     return <Dashboard />
   }
 
+  // Use the last-visited project — written by Shell on every project-scoped page,
+  // so it's always the project the user was just looking at. Falls back to the
+  // first project in the list when no history exists (fresh install).
+  let lastId: string | null = null
+  try { lastId = localStorage.getItem(LAST_PROJECT_ID_KEY) } catch { /* quota / private mode */ }
+
   const target =
-    defaultProjectId && projects.some((p) => p.id === defaultProjectId)
-      ? defaultProjectId
+    (lastId && projects.some((p) => p.id === lastId))
+      ? lastId
       : projects[0].id
 
   return <Navigate to={`${base}/${target}`} replace />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -85,7 +85,7 @@ function RootRedirect() {
 }
 
 function DefaultProjectRoute({ base }: { base: string }) {
-  const { projects, isLoading } = useProjects()
+  const { projects, isLoading, defaultProjectId } = useProjects()
 
   if (isLoading) {
     return (
@@ -114,16 +114,18 @@ function DefaultProjectRoute({ base }: { base: string }) {
     return <Dashboard />
   }
 
-  // Use the last-visited project — written by Shell on every project-scoped page,
-  // so it's always the project the user was just looking at. Falls back to the
-  // first project in the list when no history exists (fresh install).
+  // Priority: last-visited > explicit default > first project.
+  // LAST_PROJECT_ID_KEY is written by Shell on every project-scoped page, so it
+  // always reflects where the user just was. defaultProjectId is the persistent
+  // preference from Settings — used as a fallback when there is no recent history
+  // (e.g. fresh session or first login).
   let lastId: string | null = null
   try { lastId = localStorage.getItem(LAST_PROJECT_ID_KEY) } catch { /* quota / private mode */ }
 
   const target =
-    (lastId && projects.some((p) => p.id === lastId))
-      ? lastId
-      : projects[0].id
+    (lastId && projects.some((p) => p.id === lastId)) ? lastId :
+    (defaultProjectId && projects.some((p) => p.id === defaultProjectId)) ? defaultProjectId :
+    projects[0].id
 
   return <Navigate to={`${base}/${target}`} replace />
 }

--- a/web/src/components/flows/SankeyChart.tsx
+++ b/web/src/components/flows/SankeyChart.tsx
@@ -1,6 +1,6 @@
 import { sankey, sankeyLinkHorizontal, SankeyNode, SankeyLink, SankeyGraph } from 'd3-sankey'
 import { type FlowData, type FlowNode, type FlowLink } from '../../lib/api'
-import { C, nodeColor, shortLabel } from './colors'
+import { C, nodeColor } from './colors'
 
 type SNode = SankeyNode<FlowNode, FlowLink>
 type SLink = SankeyLink<FlowNode, FlowLink>
@@ -9,6 +9,22 @@ interface Props {
   data: FlowData
   onNodeClick: (page: string) => void
   width: number
+}
+
+// Strip the domain and show only the last meaningful path segment.
+// For referrer domains and special nodes ("%drop-off)", "(direct)") keep as-is.
+function pathLabel(label: string, maxLen = 14): string {
+  if (label.startsWith('(')) return label
+  try {
+    const { pathname } = new URL(label)
+    if (!pathname || pathname === '/') return '/'
+    const parts = pathname.split('/').filter(Boolean)
+    const segment = parts[parts.length - 1]
+    return segment.length > maxLen ? segment.slice(0, maxLen - 1) + '…' : segment
+  } catch {
+    // Referrer domain or non-URL string
+    return label.length > maxLen ? label.slice(0, maxLen - 1) + '…' : label
+  }
 }
 
 function buildSankeyGraph(data: FlowData): {
@@ -37,12 +53,12 @@ function buildSankeyGraph(data: FlowData): {
 function NodeRect({
   node,
   focusedPage,
-  innerW,
+  innerH,
   onNodeClick,
 }: {
   node: SNode
   focusedPage: string
-  innerW: number
+  innerH: number
   onNodeClick: (page: string) => void
 }) {
   const nd = node as unknown as FlowNode
@@ -54,58 +70,59 @@ function NodeRect({
   const isFocused = nd.depth === 0 && nd.label === focusedPage
   const color = nodeColor(nd.type, isFocused)
   const isClickable = nd.type !== 'exit'
-  const onLeft = x0 < innerW / 2
+  const cx = (x0 + x1) / 2
 
   return (
     <g
       onClick={() => isClickable && onNodeClick(nd.label)}
       style={{ cursor: isClickable ? 'pointer' : 'default' }}
     >
+      {/* Full URL tooltip on hover */}
+      <title>{nd.label}</title>
+
+      {/* Node bar */}
       <rect x={x0} y={y0} width={x1 - x0} height={h} fill={color} opacity={isFocused ? 1 : 0.75} rx={2} />
+
+      {/* Focused-page highlight ring */}
       {isFocused && (
         <rect
-          x={x0 - 1} y={y0 - 1}
-          width={x1 - x0 + 2} height={h + 2}
+          x={x0 - 2} y={y0 - 2}
+          width={x1 - x0 + 4} height={h + 4}
           fill="none" stroke={C.amber} strokeWidth={2} rx={3}
         />
       )}
-      <text
-        x={onLeft ? x0 - 8 : x1 + 8}
-        y={y0 + h / 2}
-        textAnchor={onLeft ? 'end' : 'start'}
-        dominantBaseline="middle"
-        fill={isFocused ? C.amber : C.text}
-        fontSize={11}
-        fontWeight={isFocused ? 700 : 400}
-        style={{ userSelect: 'none' }}
-      >
-        {shortLabel(nd.label)}
-      </text>
-      {h > 16 && (
+
+      {/* Session count badge — top of bar so it's readable even on full-height nodes */}
+      {h > 24 && (
         <text
-          x={(x0 + x1) / 2}
-          y={y0 + h / 2}
+          x={cx} y={y0 + 13}
           textAnchor="middle"
-          dominantBaseline="middle"
           fill="#fff"
-          fontSize={9}
+          fontSize={10}
           fontWeight={600}
           style={{ userSelect: 'none' }}
         >
           {nd.sessions.toLocaleString()}
         </text>
       )}
+
+      {/* Label below the chart area, rotated 45° so adjacent columns don't overlap */}
+      <text
+        transform={`translate(${cx},${innerH + 10}) rotate(45)`}
+        textAnchor="start"
+        dominantBaseline="hanging"
+        fill={isFocused ? C.amber : C.text}
+        fontSize={11}
+        fontWeight={isFocused ? 700 : 400}
+        style={{ userSelect: 'none' }}
+      >
+        {pathLabel(nd.label)}
+      </text>
     </g>
   )
 }
 
-function LinkPath({
-  link,
-  focusedPage,
-}: {
-  link: SLink
-  focusedPage: string
-}) {
+function LinkPath({ link, focusedPage }: { link: SLink; focusedPage: string }) {
   const linkPath = sankeyLinkHorizontal()
   const src = link.source as SNode
   const tgt = link.target as SNode
@@ -120,15 +137,17 @@ function LinkPath({
       d={linkPath(link) ?? ''}
       fill="none"
       stroke={isFocusedLink ? C.amber : C.muted}
-      strokeOpacity={isFocusedLink ? 0.35 : 0.18}
+      strokeOpacity={isFocusedLink ? 0.4 : 0.2}
       strokeWidth={Math.max(1, link.width ?? 1)}
     />
   )
 }
 
 export function SankeyChart({ data, onNodeClick, width }: Props) {
-  const height = Math.max(500, data.nodes.length * 40)
-  const margin = { top: 20, right: 160, bottom: 20, left: 160 }
+  // Small side margins — labels are below the chart now, not to the sides.
+  const margin = { top: 20, right: 50, bottom: 130, left: 50 }
+  // Height grows with node count but stays in a sensible range.
+  const height = Math.max(320, Math.min(data.nodes.length * 28 + 200, 520))
   const innerW = width - margin.left - margin.right
   const innerH = height - margin.top - margin.bottom
 
@@ -144,8 +163,8 @@ export function SankeyChart({ data, onNodeClick, width }: Props) {
   }
 
   const sankeyLayout = sankey<FlowNode & { name: string }, FlowLink>()
-    .nodeWidth(14)
-    .nodePadding(12)
+    .nodeWidth(16)
+    .nodePadding(10)
     .extent([[0, 0], [innerW, innerH]])
 
   let layout: SankeyGraph<FlowNode & { name: string }, FlowLink>
@@ -170,7 +189,7 @@ export function SankeyChart({ data, onNodeClick, width }: Props) {
             key={i}
             node={node as SNode}
             focusedPage={data.focused_page}
-            innerW={innerW}
+            innerH={innerH}
             onNodeClick={onNodeClick}
           />
         ))}

--- a/web/src/components/flows/colors.ts
+++ b/web/src/components/flows/colors.ts
@@ -19,7 +19,3 @@ export function nodeColor(type: string, isFocused: boolean): string {
   return C.indigo
 }
 
-export function shortLabel(label: string, maxLen = 28): string {
-  if (label.length <= maxLen) return label
-  return '…' + label.slice(-(maxLen - 1))
-}

--- a/web/src/components/ui/ProjectPicker.tsx
+++ b/web/src/components/ui/ProjectPicker.tsx
@@ -20,7 +20,7 @@ export const LAST_PROJECT_ID_KEY = 'funnelbarn:lastProjectId'
  * route (e.g. `/settings`), selecting a project lands the user on
  * `/dashboard/<id>` — the canonical project-landing page.
  */
-const PROJECT_SCOPED_BASES = new Set(['dashboard', 'funnels', 'flags', 'insights', 'live'])
+const PROJECT_SCOPED_BASES = new Set(['dashboard', 'funnels', 'flags', 'insights', 'live', 'flows'])
 
 function readLastProjectId(): string | undefined {
   if (typeof window === 'undefined') return undefined

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -36,7 +36,7 @@ function ScopeBadge({ scope }: { scope: string }) {
 }
 
 export default function Settings() {
-  const { projects, refetch: refetchProjects } = useProjects()
+  const { projects, refetch: refetchProjects, defaultProjectId, setDefaultProjectId } = useProjects()
   const [apiKeys, setApiKeys] = useState<ApiKey[]>([])
   const [loading, setLoading] = useState(true)
   const [newKeyName, setNewKeyName] = useState('')
@@ -382,6 +382,53 @@ export default function Settings() {
               </div>
             </div>
           ))}
+        </div>
+      )}
+
+      {/* Default project selector */}
+      {activeProjects.length > 1 && (
+        <div style={{
+          background: C.surface,
+          border: `1px solid ${C.border}`,
+          borderRadius: 12,
+          overflow: 'hidden',
+          marginBottom: '2rem',
+        }}>
+          <div style={{ padding: '1.25rem 1.5rem', borderBottom: `1px solid ${C.border}` }}>
+            <div style={{ fontWeight: 700, fontSize: 15 }}>Default project</div>
+            <div style={{ fontSize: 13, color: C.muted, marginTop: 2 }}>
+              Shown first on login and when navigating to a page without a project in the URL.
+            </div>
+          </div>
+          <div style={{ padding: '1rem 1.5rem', display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+            {activeProjects.map((p) => {
+              const isDefault = (defaultProjectId ?? activeProjects[0]?.id) === p.id
+              return (
+                <button
+                  key={p.id}
+                  onClick={() => setDefaultProjectId(p.id)}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    padding: '0.45rem 0.875rem',
+                    borderRadius: 8,
+                    border: `1px solid ${isDefault ? C.amber : C.border}`,
+                    background: isDefault ? 'rgba(245,158,11,0.1)' : 'transparent',
+                    color: isDefault ? C.amber : C.muted,
+                    fontSize: 13,
+                    fontWeight: isDefault ? 600 : 400,
+                    cursor: isDefault ? 'default' : 'pointer',
+                    transition: 'all 0.15s',
+                    minHeight: 'unset',
+                  }}
+                >
+                  {isDefault && <CheckCircle size={13} />}
+                  {p.name}
+                </button>
+              )
+            })}
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## Root cause

Two separate localStorage keys existed with different update semantics:

| Key | Written by | When |
|-----|-----------|------|
| `funnelbarn_default_project` | `setDefaultProjectId()` | Only on explicit user action |
| `funnelbarn:lastProjectId` | Shell + ProjectPicker | Every project-scoped page visit |

`DefaultProjectRoute` (which handles bare routes like `/dashboard`, `/funnels`, etc.) was reading **only** `funnelbarn_default_project`. That value was set once at some point in the past and the UI to update it was subsequently removed — leaving a stale ID that can never change. So every time a bare route was hit (e.g. clicking "Overview" from `/settings`), the user got redirected to whatever project was set as default originally.

## Fix

`DefaultProjectRoute` now reads `LAST_PROJECT_ID_KEY` (`funnelbarn:lastProjectId`) — the same key Shell writes on every project-scoped page. It always reflects where the user just was.

No longer reads `defaultProjectId` from the project context at all (the stale one). Falls back to `projects[0]` when no history exists (fresh install / first login).

## Also fixed

`flows` was missing from `PROJECT_SCOPED_BASES` in `ProjectPicker`. Switching projects while on `/flows/:id` was incorrectly navigating to `/dashboard/:id` instead of staying on the Flows page.

## Test plan
- [ ] Visit any project page, go to Settings, click Overview in nav → lands on the correct project (the one you were just on)
- [ ] Open app fresh (no localStorage) → redirects to first project
- [ ] Switch projects via picker while on `/flows/:id` → stays on Flows page for the new project
- [ ] Navigate between multiple projects normally, no unexpected jumping