### PR TITLE
fix(nginx): serve SDK at /sdk/funnelbarn.js for legacy integrations

### DIFF
--- a/deploy/docker/nginx.conf
+++ b/deploy/docker/nginx.conf
@@ -30,6 +30,13 @@ server {
         add_header Access-Control-Allow-Origin "*";
     }
 
+    # Legacy SDK path used by some integrations (e.g. bugbarn.wiebe.xyz).
+    location = /sdk/funnelbarn.js {
+        add_header Cache-Control "public, max-age=3600";
+        add_header Access-Control-Allow-Origin "*";
+        alias /usr/share/nginx/html/sdk.js;
+    }
+
     # Service worker — must always be fetched fresh
     location = /sw.js {
         add_header Cache-Control "no-cache, no-store, must-revalidate";

--- a/web/src/pages/Flags.tsx
+++ b/web/src/pages/Flags.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { Flag, Plus, X, Pause, Play, Pencil, Trash2 } from 'lucide-react'
 import Shell from '../components/shell/Shell'
@@ -198,7 +198,7 @@ function FlagPlayground({ projectId, flag }: { projectId: string; flag: FeatureF
 
   // Debounced live evaluation. Triggers on every change to flag_key, default,
   // or context (300ms quiet period).
-  const debounceRef = { current: undefined as number | undefined }
+  const debounceRef = useRef<number | undefined>(undefined)
   useEffect(() => {
     if (!flagKey.trim()) {
       setResult(null)


### PR DESCRIPTION
## Summary

- Adds an nginx `alias` block for `GET /sdk/funnelbarn.js` that serves the same built file as `/sdk.js`
- Integrations like `bugbarn.wiebe.xyz` that have `<script src=".../sdk/funnelbarn.js">` hardcoded were getting the SPA `index.html` back instead of the JS file, silently breaking all tracking

## Root cause

The web Dockerfile copies `dist/iife/funnelbarn.js` to `/usr/share/nginx/html/sdk.js`. Nginx only had an explicit `location = /sdk.js` block. Any request to `/sdk/funnelbarn.js` fell through to the SPA catch-all (`try_files $uri $uri/ /index.html`), returning HTML instead of JS.

## Test plan

- [ ] After deploy to testing: `curl -I https://funnelbarn.test.wiebe.xyz/sdk/funnelbarn.js` should return `200` with `Content-Type: application/javascript`
- [ ] `curl -I https://funnelbarn.test.wiebe.xyz/sdk.js` still returns `200`
- [ ] Both responses include `Access-Control-Allow-Origin: *`