### PR TITLE
fix(e2e): delete test project after creation to prevent dropdown accumulation

### DIFF
--- a/e2e/api.spec.ts
+++ b/e2e/api.spec.ts
@@ -80,6 +80,14 @@ test.describe('API: projects', () => {
     // The API serialises Go struct fields with their original casing (no json tags on Project)
     expect(body.Slug ?? body.slug).toBe(slug)
     expect(body.Name ?? body.name).toBe('E2E Test Project')
+
+    // Clean up — delete the project so the dropdown doesn't accumulate duplicates.
+    const projectId = body.ID ?? body.id
+    if (projectId) {
+      await request.delete(`/api/v1/projects/${projectId}`, {
+        headers: { 'X-FunnelBarn-CSRF': csrf },
+      })
+    }
   })
 })
 


### PR DESCRIPTION
## Summary
- E2E project creation test now deletes the created project after asserting success
- Prevents accumulation of "E2E Test Project" duplicates in the project dropdown across test runs

## Test plan
- [ ] Existing E2E suite passes
- [ ] Run E2E tests multiple times and verify project count stays stable
- [ ] Manually clean up existing duplicate projects on test environment