### PR TITLE
feat(recording): per-project URL rules and server-side recording overrides

### DIFF
--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -264,6 +264,7 @@ func run() error {
 		IAMBarnFlagProject:  cfg.DogfoodProject,
 		OIDC:                oidcClient,
 		Recordings:          recordingsSvc,
+		RecordingSettings:   store,
 	})
 	if cfg.MetricsToken != "" {
 		apiServer.SetMetricsToken(cfg.MetricsToken)

--- a/internal/api/recording_settings.go
+++ b/internal/api/recording_settings.go
@@ -1,0 +1,167 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	"github.com/wiebe-xyz/funnelbarn/internal/repository"
+)
+
+// ProjectRecordingSettingsRepo is the narrow repo interface for per-project recording settings.
+type ProjectRecordingSettingsRepo interface {
+	GetProjectRecordingSettings(ctx context.Context, projectID string) (*repository.ProjectRecordingSettings, error)
+	UpsertProjectRecordingSettings(ctx context.Context, settings *repository.ProjectRecordingSettings) error
+}
+
+// handleGetProjectRecordingSettings returns the per-project recording settings.
+// GET /api/v1/projects/{id}/recording-settings
+func (s *Server) handleGetProjectRecordingSettings(w http.ResponseWriter, r *http.Request) {
+	if s.recordingSettings == nil {
+		jsonError(w, "recording settings not available", http.StatusServiceUnavailable)
+		return
+	}
+	projectID := r.PathValue("id")
+
+	settings, err := s.recordingSettings.GetProjectRecordingSettings(r.Context(), projectID)
+	if err != nil {
+		mapServiceError(w, err, "handleGetProjectRecordingSettings")
+		return
+	}
+
+	effective := s.resolveEffectiveRecordingConfig(r, settings)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"enabled":           settings.Enabled,
+		"sample_rate":       settings.SampleRate,
+		"rules":             settings.Rules,
+		"effective_enabled": effective.Enabled,
+		"effective_rate":    effective.SampleRate,
+	})
+}
+
+// handleUpdateProjectRecordingSettings saves per-project recording settings.
+// PUT /api/v1/projects/{id}/recording-settings
+func (s *Server) handleUpdateProjectRecordingSettings(w http.ResponseWriter, r *http.Request) {
+	if s.recordingSettings == nil {
+		jsonError(w, "recording settings not available", http.StatusServiceUnavailable)
+		return
+	}
+	projectID := r.PathValue("id")
+
+	var body struct {
+		Enabled    *bool                      `json:"enabled"`
+		SampleRate *float64                   `json:"sample_rate"`
+		Rules      []repository.RecordingRule `json:"rules"`
+	}
+	if err := readJSON(r, &body); err != nil {
+		jsonError(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+
+	if body.SampleRate != nil && (*body.SampleRate < 0 || *body.SampleRate > 1) {
+		jsonError(w, "sample_rate must be between 0 and 1", http.StatusBadRequest)
+		return
+	}
+	for _, rule := range body.Rules {
+		if rule.Action != "capture" && rule.Action != "ignore" {
+			jsonError(w, "rule action must be 'capture' or 'ignore'", http.StatusBadRequest)
+			return
+		}
+		if rule.Pattern == "" {
+			jsonError(w, "rule pattern must not be empty", http.StatusBadRequest)
+			return
+		}
+	}
+	if body.Rules == nil {
+		body.Rules = []repository.RecordingRule{}
+	}
+
+	settings := &repository.ProjectRecordingSettings{
+		ProjectID:  projectID,
+		Enabled:    body.Enabled,
+		SampleRate: body.SampleRate,
+		Rules:      body.Rules,
+	}
+	if err := s.recordingSettings.UpsertProjectRecordingSettings(r.Context(), settings); err != nil {
+		mapServiceError(w, err, "handleUpdateProjectRecordingSettings")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// effectiveRecordingConfig is the resolved recording config for a project.
+type effectiveRecordingConfig struct {
+	Enabled    bool
+	SampleRate float64
+	Rules      []repository.RecordingRule
+}
+
+// resolveEffectiveRecordingConfig merges per-project settings with instance defaults.
+func (s *Server) resolveEffectiveRecordingConfig(r *http.Request, settings *repository.ProjectRecordingSettings) effectiveRecordingConfig {
+	cfg := effectiveRecordingConfig{
+		Enabled:    false,
+		SampleRate: 1.0,
+	}
+
+	// Apply instance-level defaults first.
+	if s.instanceSettings != nil {
+		if all, err := s.instanceSettings.GetAllInstanceSettings(r.Context()); err == nil {
+			cfg.Enabled = all["recording_enabled"] == "true"
+			if rv := all["recording_sample_rate"]; rv != "" {
+				if rate, err := strconv.ParseFloat(rv, 64); err == nil && rate >= 0 && rate <= 1 {
+					cfg.SampleRate = rate
+				}
+			}
+		}
+	}
+
+	// Per-project overrides win over instance defaults.
+	if settings != nil {
+		if settings.Enabled != nil {
+			cfg.Enabled = *settings.Enabled
+		}
+		if settings.SampleRate != nil {
+			cfg.SampleRate = *settings.SampleRate
+		}
+		cfg.Rules = settings.Rules
+	}
+
+	if cfg.Rules == nil {
+		cfg.Rules = []repository.RecordingRule{}
+	}
+	return cfg
+}
+
+// handleGetRecordingConfig returns the effective recording config for the project
+// identified by the API key. Used by the JS SDK on init.
+// GET /api/v1/recording-config
+func (s *Server) handleGetRecordingConfig(w http.ResponseWriter, r *http.Request) {
+	// Identify project via API key (same mechanism as event ingest).
+	projectID, _, ok := s.ingest.APIKeyProjectScope(r)
+	if !ok {
+		// No valid API key — return the instance-level defaults (unauthenticated context).
+		// The SDK will use these as a fallback.
+		cfg := s.resolveEffectiveRecordingConfig(r, nil)
+		writeJSON(w, http.StatusOK, map[string]any{
+			"enabled":     cfg.Enabled,
+			"sample_rate": cfg.SampleRate,
+			"rules":       cfg.Rules,
+		})
+		return
+	}
+
+	var settings *repository.ProjectRecordingSettings
+	if s.recordingSettings != nil {
+		if ps, err := s.recordingSettings.GetProjectRecordingSettings(r.Context(), projectID); err == nil {
+			settings = ps
+		}
+	}
+
+	cfg := s.resolveEffectiveRecordingConfig(r, settings)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"enabled":     cfg.Enabled,
+		"sample_rate": cfg.SampleRate,
+		"rules":       cfg.Rules,
+	})
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -67,11 +67,12 @@ type ServerConfig struct {
 	// login flow at /api/v1/oidc/{login,callback}. Independent of IAMBarnProvider.
 	OIDC *auth.OIDCClient
 
-	InstanceSettings InstanceSettingsRepo
-	GeoAnonymizer    GeoAnonymizer
-	Segments         service.Segments
-	Distributions    DistributionRepo
-	Recordings       service.Recordings
+	InstanceSettings  InstanceSettingsRepo
+	GeoAnonymizer     GeoAnonymizer
+	Segments          service.Segments
+	Distributions     DistributionRepo
+	Recordings        service.Recordings
+	RecordingSettings ProjectRecordingSettingsRepo
 }
 
 // DistributionRepo provides session field distribution data.
@@ -126,6 +127,7 @@ type Server struct {
 	segments           service.Segments
 	distributions      DistributionRepo
 	recordings         service.Recordings
+	recordingSettings  ProjectRecordingSettingsRepo
 
 	loginLimiter  *rateLimiter
 	eventsLimiter *rateLimiter
@@ -181,6 +183,7 @@ func NewServer(cfg ServerConfig) *Server {
 		segments:           cfg.Segments,
 		distributions:      cfg.Distributions,
 		recordings:         cfg.Recordings,
+		recordingSettings:  cfg.RecordingSettings,
 	}
 	s.registerRoutes()
 	return s
@@ -285,6 +288,11 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/recordings/{rid}/flags", s.requireSession(s.handleGetRecordingFlags))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/funnels/{fid}/steps/{step}/sessions", s.requireSession(s.handleFunnelStepSessions))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/flows/sessions", s.requireSession(s.handleFlowPageSessions))
+	s.mux.HandleFunc("GET /api/v1/projects/{id}/recording-settings", s.requireSession(s.handleGetProjectRecordingSettings))
+	s.mux.HandleFunc("PUT /api/v1/projects/{id}/recording-settings", s.requireSession(s.handleUpdateProjectRecordingSettings))
+
+	// SDK recording config (API key auth, public — returns effective config for the project)
+	s.mux.HandleFunc("GET /api/v1/recording-config", s.handleGetRecordingConfig)
 
 	// API keys
 	s.mux.HandleFunc("GET /api/v1/apikeys", s.requireSession(s.handleListAPIKeys))

--- a/internal/repository/migrations/00020_project_recording_settings.sql
+++ b/internal/repository/migrations/00020_project_recording_settings.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+CREATE TABLE project_recording_settings (
+    project_id   TEXT PRIMARY KEY REFERENCES projects(id) ON DELETE CASCADE,
+    enabled      INTEGER,  -- NULL=inherit, 0=off, 1=on
+    sample_rate  REAL,     -- NULL=inherit from instance
+    rules        TEXT NOT NULL DEFAULT '[]',
+    updated_at   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS project_recording_settings;

--- a/internal/repository/project_recording_settings.go
+++ b/internal/repository/project_recording_settings.go
@@ -1,0 +1,100 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+// RecordingRule is a URL pattern rule used to decide whether to capture or ignore a page.
+type RecordingRule struct {
+	Pattern string `json:"pattern"`
+	Action  string `json:"action"` // "capture" or "ignore"
+}
+
+// ProjectRecordingSettings holds per-project recording overrides.
+// Nil pointer fields mean "inherit from instance settings".
+type ProjectRecordingSettings struct {
+	ProjectID  string
+	Enabled    *bool    // nil = inherit from instance
+	SampleRate *float64 // nil = inherit from instance
+	Rules      []RecordingRule
+	UpdatedAt  time.Time
+}
+
+// GetProjectRecordingSettings returns per-project recording settings.
+// Returns a zero-value struct (all nil) if no settings have been saved yet.
+func (s *Store) GetProjectRecordingSettings(ctx context.Context, projectID string) (*ProjectRecordingSettings, error) {
+	const q = `SELECT enabled, sample_rate, rules, updated_at
+               FROM project_recording_settings WHERE project_id = ?`
+	row := s.db.QueryRowContext(ctx, q, projectID)
+
+	var enabledInt sql.NullInt64
+	var sampleRate sql.NullFloat64
+	var rulesJSON string
+	var updatedAt time.Time
+
+	err := row.Scan(&enabledInt, &sampleRate, &rulesJSON, &updatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return &ProjectRecordingSettings{
+			ProjectID: projectID,
+			Rules:     []RecordingRule{},
+		}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	out := &ProjectRecordingSettings{
+		ProjectID: projectID,
+		UpdatedAt: updatedAt,
+	}
+	if enabledInt.Valid {
+		b := enabledInt.Int64 != 0
+		out.Enabled = &b
+	}
+	if sampleRate.Valid {
+		out.SampleRate = &sampleRate.Float64
+	}
+
+	if rulesJSON == "" || rulesJSON == "null" {
+		out.Rules = []RecordingRule{}
+	} else if err := json.Unmarshal([]byte(rulesJSON), &out.Rules); err != nil {
+		out.Rules = []RecordingRule{}
+	}
+
+	return out, nil
+}
+
+// UpsertProjectRecordingSettings saves per-project recording overrides.
+func (s *Store) UpsertProjectRecordingSettings(ctx context.Context, settings *ProjectRecordingSettings) error {
+	rulesJSON, err := json.Marshal(settings.Rules)
+	if err != nil {
+		return err
+	}
+
+	var enabledVal sql.NullInt64
+	if settings.Enabled != nil {
+		if *settings.Enabled {
+			enabledVal = sql.NullInt64{Int64: 1, Valid: true}
+		} else {
+			enabledVal = sql.NullInt64{Int64: 0, Valid: true}
+		}
+	}
+	var sampleRateVal sql.NullFloat64
+	if settings.SampleRate != nil {
+		sampleRateVal = sql.NullFloat64{Float64: *settings.SampleRate, Valid: true}
+	}
+
+	const q = `INSERT INTO project_recording_settings (project_id, enabled, sample_rate, rules, updated_at)
+               VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+               ON CONFLICT(project_id) DO UPDATE SET
+                   enabled = excluded.enabled,
+                   sample_rate = excluded.sample_rate,
+                   rules = excluded.rules,
+                   updated_at = CURRENT_TIMESTAMP`
+	_, err = s.db.ExecContext(ctx, q, settings.ProjectID, enabledVal, sampleRateVal, string(rulesJSON))
+	return err
+}

--- a/internal/repository/project_recording_settings_test.go
+++ b/internal/repository/project_recording_settings_test.go
@@ -1,0 +1,76 @@
+package repository_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wiebe-xyz/funnelbarn/internal/repository"
+)
+
+func TestStore_ProjectRecordingSettings(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	// Create a project to attach settings to.
+	proj, err := s.CreateProject(ctx, "rec-settings-test", "rec-settings-test")
+	require.NoError(t, err)
+
+	// Default: no settings saved yet — returns zero struct with empty rules.
+	got, err := s.GetProjectRecordingSettings(ctx, proj.ID)
+	require.NoError(t, err)
+	assert.Nil(t, got.Enabled)
+	assert.Nil(t, got.SampleRate)
+	assert.Empty(t, got.Rules)
+
+	// Upsert with enabled=true and a sample rate.
+	enabled := true
+	rate := 0.5
+	settings := &repository.ProjectRecordingSettings{
+		ProjectID:  proj.ID,
+		Enabled:    &enabled,
+		SampleRate: &rate,
+		Rules:      []repository.RecordingRule{},
+	}
+	require.NoError(t, s.UpsertProjectRecordingSettings(ctx, settings))
+
+	got, err = s.GetProjectRecordingSettings(ctx, proj.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.Enabled)
+	assert.True(t, *got.Enabled)
+	require.NotNil(t, got.SampleRate)
+	assert.Equal(t, 0.5, *got.SampleRate)
+	assert.Empty(t, got.Rules)
+
+	// Update with URL rules and enabled=false.
+	disabled := false
+	settings.Enabled = &disabled
+	settings.Rules = []repository.RecordingRule{
+		{Pattern: "/admin/**", Action: "ignore"},
+		{Pattern: "/checkout", Action: "capture"},
+	}
+	require.NoError(t, s.UpsertProjectRecordingSettings(ctx, settings))
+
+	got, err = s.GetProjectRecordingSettings(ctx, proj.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.Enabled)
+	assert.False(t, *got.Enabled)
+	require.Len(t, got.Rules, 2)
+	assert.Equal(t, "/admin/**", got.Rules[0].Pattern)
+	assert.Equal(t, "ignore", got.Rules[0].Action)
+	assert.Equal(t, "/checkout", got.Rules[1].Pattern)
+	assert.Equal(t, "capture", got.Rules[1].Action)
+
+	// Upsert with nil Enabled resets to inherit.
+	settings.Enabled = nil
+	settings.SampleRate = nil
+	settings.Rules = []repository.RecordingRule{}
+	require.NoError(t, s.UpsertProjectRecordingSettings(ctx, settings))
+
+	got, err = s.GetProjectRecordingSettings(ctx, proj.ID)
+	require.NoError(t, err)
+	assert.Nil(t, got.Enabled)
+	assert.Nil(t, got.SampleRate)
+	assert.Empty(t, got.Rules)
+}

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -8,6 +8,11 @@
 
 import { record } from "rrweb";
 
+export interface RecordingRule {
+  pattern: string;
+  action: 'capture' | 'ignore';
+}
+
 export interface FunnelBarnOptions {
   apiKey: string;
   endpoint: string;
@@ -17,10 +22,14 @@ export interface FunnelBarnOptions {
   flushInterval?: number;
   /** Session idle timeout in ms (default: 30 minutes) */
   sessionTimeout?: number;
-  /** Enable session recording (default: false) */
+  /** Enable session recording by default (default: false). Server config can override. */
   recording?: boolean;
   /** Recording chunk flush interval in ms (default: 10000) */
   recordingChunkMs?: number;
+  /** URL path patterns to always capture (checked before server rules) */
+  recordInclude?: string[];
+  /** URL path patterns to always ignore (checked before server rules) */
+  recordExclude?: string[];
 }
 
 export interface EventProperties {
@@ -98,6 +107,8 @@ export class FunnelBarnClient {
   private recordingStartedAt = '';
   private recordingStartMs = 0;
   private recordingTimer?: ReturnType<typeof setInterval>;
+  private recordingOptions: FunnelBarnOptions;
+  private serverRecordingRules: RecordingRule[] = [];
 
   constructor(options: FunnelBarnOptions) {
     this.apiKey = options.apiKey;
@@ -105,6 +116,7 @@ export class FunnelBarnClient {
     this.projectName = options.projectName;
     this.flushInterval = options.flushInterval ?? 5000;
     this.sessionTimeout = options.sessionTimeout ?? SESSION_TIMEOUT_DEFAULT;
+    this.recordingOptions = options;
 
     this.startFlushTimer();
 
@@ -134,20 +146,12 @@ export class FunnelBarnClient {
       }
       window.addEventListener("beforeunload", flushVitals);
 
-      // Session recording.
+      // Session recording — start locally if requested, then apply server overrides async.
       if (options.recording) {
-        this.recordingId = this.generateSessionID();
-        this.recordingStartedAt = new Date().toISOString();
-        this.recordingStartMs = Date.now();
-        this.rrwebStop = record({
-          emit: (event) => { this.rrwebBuffer.push(event); },
-          maskInputOptions: { password: true },
-          blockClass: 'fb-block',
-        });
-        const chunkMs = options.recordingChunkMs ?? 10_000;
-        this.recordingTimer = setInterval(() => { this.flushRecordingChunk().catch(() => {}); }, chunkMs);
-        window.addEventListener('beforeunload', () => { this.flushRecordingChunk().catch(() => {}); });
+        this.startRecording(options.recordingChunkMs);
       }
+      // Fetch server recording config and apply overrides (does not block init).
+      this.applyServerRecordingConfig(options.recordingChunkMs).catch(() => {});
 
       // LCP observer.
       try {
@@ -488,7 +492,102 @@ export class FunnelBarnClient {
     }
   }
 
+  private startRecording(chunkMs?: number): void {
+    if (this.rrwebStop) return; // already running
+    this.recordingId = this.generateSessionID();
+    this.recordingStartedAt = new Date().toISOString();
+    this.recordingStartMs = Date.now();
+    this.rrwebStop = record({
+      emit: (event) => { this.rrwebBuffer.push(event); },
+      maskInputOptions: { password: true },
+      blockClass: 'fb-block',
+    });
+    const interval = chunkMs ?? 10_000;
+    this.recordingTimer = setInterval(() => { this.flushRecordingChunk().catch(() => {}); }, interval);
+    window.addEventListener('beforeunload', () => { this.flushRecordingChunk().catch(() => {}); });
+  }
+
+  private stopRecording(): void {
+    if (this.rrwebStop) {
+      this.rrwebStop();
+      this.rrwebStop = undefined;
+    }
+    if (this.recordingTimer !== undefined) {
+      clearInterval(this.recordingTimer);
+      this.recordingTimer = undefined;
+    }
+    this.rrwebBuffer = [];
+  }
+
+  private async applyServerRecordingConfig(chunkMs?: number): Promise<void> {
+    try {
+      const resp = await fetch(`${this.endpoint}/api/v1/recording-config`, {
+        headers: { 'x-funnelbarn-api-key': this.apiKey },
+      });
+      if (!resp.ok) return;
+      const cfg = await resp.json() as { enabled: boolean; sample_rate: number; rules: RecordingRule[] };
+      this.serverRecordingRules = cfg.rules ?? [];
+
+      // Apply sample-rate decision: skip recording if random roll is above rate.
+      const rate = cfg.sample_rate ?? 1;
+      const sampled = Math.random() < rate;
+
+      if (cfg.enabled && sampled && !this.rrwebStop) {
+        this.startRecording(chunkMs);
+      } else if (!cfg.enabled && this.rrwebStop) {
+        this.stopRecording();
+      }
+    } catch {
+      // best-effort — local config remains in effect
+    }
+  }
+
+  // matchesPattern checks a URL path against a glob pattern.
+  // * matches any single path segment, ** matches any number of segments.
+  private matchesPattern(pattern: string, path: string): boolean {
+    const escaped = pattern
+      .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+      .replace(/\*\*/g, '\x00')
+      .replace(/\*/g, '[^/]*')
+      .replace(/\x00/g, '.*');
+    try {
+      return new RegExp(`^${escaped}$`).test(path);
+    } catch {
+      return false;
+    }
+  }
+
+  // shouldRecordCurrentPage checks SDK-local and server rules to decide
+  // whether to flush recording events for the current page.
+  private shouldRecordCurrentPage(): boolean {
+    if (typeof window === 'undefined') return true;
+    const path = window.location.pathname;
+    const opts = this.recordingOptions;
+
+    // SDK-local include/exclude (checked first, highest priority).
+    for (const p of opts.recordExclude ?? []) {
+      if (this.matchesPattern(p, path)) return false;
+    }
+    for (const p of opts.recordInclude ?? []) {
+      if (this.matchesPattern(p, path)) return true;
+    }
+
+    // Server rules (first match wins).
+    for (const rule of this.serverRecordingRules) {
+      if (this.matchesPattern(rule.pattern, path)) {
+        return rule.action === 'capture';
+      }
+    }
+
+    return true; // default: capture
+  }
+
   private async flushRecordingChunk(): Promise<void> {
+    if (!this.shouldRecordCurrentPage()) {
+      // Discard buffered events for this page — don't send them.
+      this.rrwebBuffer = [];
+      return;
+    }
     const events = this.rrwebBuffer.splice(0);
     if (!events.length) return;
     try {

--- a/web/src/components/settings/ProjectRecordingSettings.tsx
+++ b/web/src/components/settings/ProjectRecordingSettings.tsx
@@ -1,0 +1,286 @@
+import { useEffect, useState } from 'react'
+import { Plus, Trash2, ChevronDown, ChevronUp } from 'lucide-react'
+import { api, type RecordingRule, type ProjectRecordingSettings as ProjectRecordingSettingsData } from '../../lib/api'
+
+const C = {
+  bg: '#0f1117',
+  surface: '#1a1d27',
+  border: '#2a2d3a',
+  amber: '#f59e0b',
+  text: '#e2e8f0',
+  muted: '#94a3b8',
+  error: '#ef4444',
+  success: '#10b981',
+}
+
+interface Props {
+  projectId: string
+}
+
+export function ProjectRecordingSettings({ projectId }: Props) {
+  const [open, setOpen] = useState(false)
+  const [settings, setSettings] = useState<ProjectRecordingSettingsData | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [savedMsg, setSavedMsg] = useState(false)
+
+  // Editable state
+  const [enabled, setEnabled] = useState<boolean | null>(null)
+  const [sampleRate, setSampleRate] = useState<number | null>(null)
+  const [rules, setRules] = useState<RecordingRule[]>([])
+
+  useEffect(() => {
+    if (!open || settings) return
+    setLoading(true)
+    api.getProjectRecordingSettings(projectId)
+      .then((s) => {
+        setSettings(s)
+        setEnabled(s.enabled)
+        setSampleRate(s.sample_rate)
+        setRules(s.rules ?? [])
+      })
+      .finally(() => setLoading(false))
+  }, [open, projectId, settings])
+
+  const handleSave = async () => {
+    setSaving(true)
+    try {
+      await api.updateProjectRecordingSettings(projectId, {
+        enabled,
+        sample_rate: sampleRate,
+        rules,
+      })
+      setSettings(null) // force refresh on next open
+      setSavedMsg(true)
+      setTimeout(() => setSavedMsg(false), 2000)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const addRule = () => setRules((r) => [...r, { pattern: '/', action: 'capture' }])
+  const removeRule = (i: number) => setRules((r) => r.filter((_, idx) => idx !== i))
+  const updateRule = (i: number, field: keyof RecordingRule, value: string) =>
+    setRules((r) => r.map((rule, idx) => idx === i ? { ...rule, [field]: value } : rule))
+
+  const buttonBase: React.CSSProperties = {
+    border: `1px solid ${C.border}`,
+    borderRadius: 6,
+    padding: '0.3rem 0.75rem',
+    fontSize: 12,
+    fontWeight: 600,
+    cursor: 'pointer',
+    background: 'transparent',
+    color: C.muted,
+  }
+
+  return (
+    <div style={{ borderTop: `1px solid ${C.border}`, marginTop: 8 }}>
+      <button
+        onClick={() => setOpen((v) => !v)}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+          width: '100%',
+          background: 'none',
+          border: 'none',
+          padding: '0.6rem 0',
+          color: C.muted,
+          fontSize: 13,
+          cursor: 'pointer',
+          textAlign: 'left',
+        }}
+      >
+        {open ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+        Recording settings
+      </button>
+
+      {open && (
+        <div style={{ paddingBottom: '1rem' }}>
+          {loading && (
+            <div style={{ color: C.muted, fontSize: 13 }}>Loading…</div>
+          )}
+
+          {!loading && (
+            <>
+              {/* Enable override */}
+              <div style={{ marginBottom: '1rem' }}>
+                <div style={{ fontSize: 12, color: C.muted, marginBottom: 6 }}>Recording</div>
+                <div style={{ display: 'flex', gap: 6 }}>
+                  {([null, true, false] as const).map((val) => {
+                    const label = val === null ? 'Inherit' : val ? 'Force on' : 'Force off'
+                    const active = enabled === val
+                    return (
+                      <button
+                        key={String(val)}
+                        onClick={() => setEnabled(val)}
+                        style={{
+                          ...buttonBase,
+                          background: active ? 'rgba(245,158,11,0.12)' : 'transparent',
+                          borderColor: active ? C.amber : C.border,
+                          color: active ? C.amber : C.muted,
+                        }}
+                      >
+                        {label}
+                      </button>
+                    )
+                  })}
+                </div>
+                {settings && (
+                  <div style={{ fontSize: 11, color: C.muted, marginTop: 4 }}>
+                    Effective: {settings.effective_enabled ? 'on' : 'off'} at {Math.round((settings.effective_rate ?? 1) * 100)}%
+                  </div>
+                )}
+              </div>
+
+              {/* Sample rate override */}
+              <div style={{ marginBottom: '1rem' }}>
+                <div style={{ fontSize: 12, color: C.muted, marginBottom: 6 }}>Sample rate override</div>
+                <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                  <button
+                    onClick={() => setSampleRate(null)}
+                    style={{
+                      ...buttonBase,
+                      background: sampleRate === null ? 'rgba(245,158,11,0.12)' : 'transparent',
+                      borderColor: sampleRate === null ? C.amber : C.border,
+                      color: sampleRate === null ? C.amber : C.muted,
+                    }}
+                  >
+                    Inherit
+                  </button>
+                  {[0.1, 0.25, 0.5, 1].map((rate) => (
+                    <button
+                      key={rate}
+                      onClick={() => setSampleRate(rate)}
+                      style={{
+                        ...buttonBase,
+                        background: sampleRate === rate ? 'rgba(245,158,11,0.12)' : 'transparent',
+                        borderColor: sampleRate === rate ? C.amber : C.border,
+                        color: sampleRate === rate ? C.amber : C.muted,
+                      }}
+                    >
+                      {Math.round(rate * 100)}%
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* URL rules */}
+              <div style={{ marginBottom: '1rem' }}>
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 6 }}>
+                  <div style={{ fontSize: 12, color: C.muted }}>URL rules <span style={{ color: '#4a5568' }}>(first match wins)</span></div>
+                  <button
+                    onClick={addRule}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 4,
+                      background: 'transparent',
+                      border: `1px solid ${C.border}`,
+                      borderRadius: 5,
+                      padding: '0.2rem 0.5rem',
+                      color: C.muted,
+                      fontSize: 12,
+                      cursor: 'pointer',
+                    }}
+                  >
+                    <Plus size={11} />
+                    Add rule
+                  </button>
+                </div>
+
+                {rules.length === 0 && (
+                  <div style={{ fontSize: 12, color: '#4a5568' }}>
+                    No rules — all pages captured (when recording is on).
+                  </div>
+                )}
+
+                {rules.map((rule, i) => (
+                  <div key={i} style={{ display: 'flex', gap: 6, marginBottom: 6, alignItems: 'center' }}>
+                    <input
+                      value={rule.pattern}
+                      onChange={(e) => updateRule(i, 'pattern', e.target.value)}
+                      placeholder="/path/* or /exact"
+                      style={{
+                        flex: 1,
+                        background: C.bg,
+                        border: `1px solid ${C.border}`,
+                        borderRadius: 6,
+                        padding: '0.35rem 0.6rem',
+                        color: C.text,
+                        fontSize: 12,
+                        fontFamily: '"SF Mono", "Fira Code", monospace',
+                        outline: 'none',
+                      }}
+                      onFocus={(e) => (e.target.style.borderColor = C.amber)}
+                      onBlur={(e) => (e.target.style.borderColor = C.border)}
+                    />
+                    <select
+                      value={rule.action}
+                      onChange={(e) => updateRule(i, 'action', e.target.value)}
+                      style={{
+                        background: C.bg,
+                        border: `1px solid ${C.border}`,
+                        borderRadius: 6,
+                        padding: '0.35rem 0.5rem',
+                        color: rule.action === 'capture' ? C.success : C.error,
+                        fontSize: 12,
+                        outline: 'none',
+                        cursor: 'pointer',
+                      }}
+                    >
+                      <option value="capture">Capture</option>
+                      <option value="ignore">Ignore</option>
+                    </select>
+                    <button
+                      onClick={() => removeRule(i)}
+                      style={{
+                        background: 'transparent',
+                        border: 'none',
+                        color: C.muted,
+                        cursor: 'pointer',
+                        padding: 2,
+                        display: 'flex',
+                      }}
+                    >
+                      <Trash2 size={13} />
+                    </button>
+                  </div>
+                ))}
+
+                {rules.length > 0 && (
+                  <div style={{ fontSize: 11, color: '#4a5568', marginTop: 4 }}>
+                    Use <code style={{ fontFamily: 'monospace' }}>*</code> for a single path segment, <code style={{ fontFamily: 'monospace' }}>**</code> for any depth.
+                  </div>
+                )}
+              </div>
+
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <button
+                  onClick={handleSave}
+                  disabled={saving}
+                  style={{
+                    background: C.amber,
+                    border: 'none',
+                    borderRadius: 6,
+                    padding: '0.4rem 1rem',
+                    color: '#0f1117',
+                    fontSize: 13,
+                    fontWeight: 700,
+                    cursor: saving ? 'not-allowed' : 'pointer',
+                  }}
+                >
+                  {saving ? 'Saving…' : 'Save'}
+                </button>
+                {savedMsg && (
+                  <span style={{ fontSize: 13, color: C.success }}>Saved!</span>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/settings/ProjectSettings.tsx
+++ b/web/src/components/settings/ProjectSettings.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Trash2, Save, CheckCircle, Link, X } from 'lucide-react'
 import { api, Project } from '../../lib/api'
 import { CopyButton } from '../ui/CopyButton'
+import { ProjectRecordingSettings } from './ProjectRecordingSettings'
 
 const C = {
   bg: '#0f1117',
@@ -385,6 +386,7 @@ export function ProjectSettings({
                   Saved!
                 </div>
               )}
+              <ProjectRecordingSettings projectId={p.id} />
               {deleteProjectConfirm === p.id && (
                 <div style={{
                   width: '100%',

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -364,6 +364,18 @@ export const api = {
   getRecordingFlags: (projectId: string, recordingId: string) =>
     request<{ evaluations: FlagEvaluationEntry[] }>(`/api/v1/projects/${projectId}/recordings/${recordingId}/flags`),
 
+  getProjectRecordingSettings: (projectId: string) =>
+    request<ProjectRecordingSettings>(`/api/v1/projects/${projectId}/recording-settings`),
+
+  updateProjectRecordingSettings: (
+    projectId: string,
+    settings: { enabled: boolean | null; sample_rate: number | null; rules: RecordingRule[] }
+  ) =>
+    request<void>(`/api/v1/projects/${projectId}/recording-settings`, {
+      method: 'PUT',
+      body: JSON.stringify(settings),
+    }),
+
   getFunnelStepSessions: (projectId: string, funnelId: string, step: number, params: { from?: string; to?: string } = {}) => {
     const qs = new URLSearchParams()
     if (params.from) qs.set('from', params.from)
@@ -588,6 +600,19 @@ export interface Recording {
   device_type: string
   is_bot: boolean
   page_url?: string
+}
+
+export interface RecordingRule {
+  pattern: string
+  action: 'capture' | 'ignore'
+}
+
+export interface ProjectRecordingSettings {
+  enabled: boolean | null
+  sample_rate: number | null
+  rules: RecordingRule[]
+  effective_enabled: boolean
+  effective_rate: number
 }
 
 export interface FlagEvaluationEntry {


### PR DESCRIPTION
## Summary
- **Dashboard**: each project in Settings now has a collapsible "Recording settings" panel — toggle inherit/force-on/force-off, set a per-project sample rate, and define URL capture/ignore rules
- **Backend**: new `project_recording_settings` table; `GET/PUT /api/v1/projects/{id}/recording-settings` for the dashboard; `GET /api/v1/recording-config` (API key auth) for the SDK
- **SDK**: on init, fetches server recording config and applies overrides — server can force recording on or off regardless of the `record: true/false` option; new `recordInclude`/`recordExclude` options for client-side URL rules; `*` matches a single path segment, `**` matches any depth

## URL rule priority
1. SDK `recordExclude` patterns (always ignore)
2. SDK `recordInclude` patterns (always capture)
3. Server rules in order (first match wins)
4. Default: capture

## Test plan
- [ ] Enable recording globally via instance settings (Settings → Recording)
- [ ] Open a project's "Recording settings" panel, set Force off → verify no recordings appear for that project
- [ ] Add an ignore rule `/admin/*` → navigate to `/admin/something` → no chunk stored; navigate elsewhere → chunk stored
- [ ] Set sample rate to 10% on one project while instance is at 100% → confirm roughly 10% of sessions record
- [ ] Pass `recordExclude: ['/checkout']` in SDK init → verify checkout page chunks are discarded
- [ ] Verify CI passes (gofmt, go vet, tsc, eslint, vitest)