### PR TITLE
fix(deploy): wire R2 and dogfood API key env vars into deployment manifests

### DIFF
--- a/deploy/k8s/production/deployment.yaml
+++ b/deploy/k8s/production/deployment.yaml
@@ -113,6 +113,30 @@ spec:
                   optional: true
             - name: FUNNELBARN_DOGFOOD_PROJECT
               value: funnelbarn
+            - name: FUNNELBARN_R2_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_R2_ENDPOINT
+                  optional: true
+            - name: FUNNELBARN_R2_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_R2_ACCESS_KEY_ID
+                  optional: true
+            - name: FUNNELBARN_R2_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_R2_SECRET_ACCESS_KEY
+                  optional: true
+            - name: FUNNELBARN_R2_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_R2_BUCKET
+                  optional: true
             - name: FUNNELBARN_SPANBARN_ENDPOINT
               valueFrom:
                 secretKeyRef:

--- a/deploy/k8s/staging/deployment.yaml
+++ b/deploy/k8s/staging/deployment.yaml
@@ -107,6 +107,30 @@ spec:
                   optional: true
             - name: FUNNELBARN_DOGFOOD_PROJECT
               value: funnelbarn
+            - name: FUNNELBARN_R2_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_R2_ENDPOINT
+                  optional: true
+            - name: FUNNELBARN_R2_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_R2_ACCESS_KEY_ID
+                  optional: true
+            - name: FUNNELBARN_R2_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_R2_SECRET_ACCESS_KEY
+                  optional: true
+            - name: FUNNELBARN_R2_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_R2_BUCKET
+                  optional: true
             - name: FUNNELBARN_SPANBARN_ENDPOINT
               valueFrom:
                 secretKeyRef:

--- a/deploy/k8s/testing/deployment.yaml
+++ b/deploy/k8s/testing/deployment.yaml
@@ -113,6 +113,38 @@ spec:
                   name: funnelbarn-secrets
                   key: FUNNELBARN_SPANBARN_API_KEY
                   optional: true
+            - name: FUNNELBARN_DOGFOOD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_DOGFOOD_API_KEY
+                  optional: true
+            - name: FUNNELBARN_DOGFOOD_PROJECT
+              value: funnelbarn
+            - name: FUNNELBARN_R2_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_R2_ENDPOINT
+                  optional: true
+            - name: FUNNELBARN_R2_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_R2_ACCESS_KEY_ID
+                  optional: true
+            - name: FUNNELBARN_R2_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_R2_SECRET_ACCESS_KEY
+                  optional: true
+            - name: FUNNELBARN_R2_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: funnelbarn-secrets
+                  key: FUNNELBARN_R2_BUCKET
+                  optional: true
             - name: FUNNELBARN_IAMBARN_CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/deploy/k8s/testing/secret.yaml
+++ b/deploy/k8s/testing/secret.yaml
@@ -1,39 +1,40 @@
-apiVersion: ENC[AES256_GCM,data:TEc=,iv:eEgj7dR0yNkoenGo86jZ6oMeeYFqBnjFFpi0mUDN9QM=,tag:vDsrQCR/9XqJQO8NipH1gQ==,type:str]
-kind: ENC[AES256_GCM,data:mkUEw8TM,iv:tPqdalY4tmeyvEOIfQSt8e8MghVh7vx7er3ynG/cyHs=,tag:faGDdlzm+bDm5NIFU8b69g==,type:str]
+apiVersion: ENC[AES256_GCM,data:h50=,iv:IBhRLpp672/BPM4xzzrCvsg4TLQwciAo9opjf8BRFH8=,tag:y/CMfnKqtiCv5WBYL5/gGA==,type:str]
+kind: ENC[AES256_GCM,data:0omCkJGS,iv:evzMuF/UWvnSTxrzK5bRv6IT3r44iQtoDxkkvhIvzvs=,tag:Nzh9gVVeOE5UU1eHGnq4yQ==,type:str]
 metadata:
-    name: ENC[AES256_GCM,data:0tRbJgMMhUR9AQ7329IavTYR,iv:wZxNc3r/vQ20zYNISEnGpZUKrH6yFT16ISfMoXZoQ7E=,tag:8s+RYI6ocMj3fZg8LnN9sg==,type:str]
-    namespace: ENC[AES256_GCM,data:2tRMVCJWZeaN7BRMDE46oaW9,iv:yy00hPifXb3lVGGG1b3CpkTuMSUaQfgPChioN8AjIKw=,tag:jrC+rvwO/m5pTRMcquqG9Q==,type:str]
+    name: ENC[AES256_GCM,data:hB6gvq0ReUFguMVceI77WIZW,iv:WcWo+0zUAE79OswEQXNXKqNNUBPPG/+8b5eT543T74g=,tag:jYGPK+nzKhIpzH3WXsrkew==,type:str]
+    namespace: ENC[AES256_GCM,data:nJcxVGfM3jWGfafQYl/CoW0u,iv:qtOENp5tLdwulvAOe8hveWr6N0g6+mk81qUSW/VIHT8=,tag:TbYtWp9FyNuTl9YAG4l7cA==,type:str]
 stringData:
-    FUNNELBARN_ADMIN_PASSWORD_BCRYPT: ENC[AES256_GCM,data:ffu8XKb64kfeUGw+ZpKIm2jdBE+y4APhgvEq32GnywTmADyd5YtQ1c/qDAW/CC3heP+XOJQaOuSIhMNY,iv:fXeD71GE2PtVZbUpAyWai9YOkgM3ET640KG/sWtZCKs=,tag:k9WPUUqT4zidusydMeh+1Q==,type:str]
-    FUNNELBARN_ADMIN_USERNAME: ENC[AES256_GCM,data:9f97UtQ=,iv:WAuxqo9m9LwTH2awR0rQ10nbKY/Az0/ZxkZn0AS0dik=,tag:OjKYmQc3QfKD3f2APNyebg==,type:str]
-    FUNNELBARN_API_KEY: ENC[AES256_GCM,data:nuNIjCITAyzPoeFh5eVmlNEyN6ey9g3tDWbfPCDlAOTPbUsTreiJUQGlUytP8qDt+NWdaSdPCaJKF5cOpfzSTw==,iv:LN8ixG2V2seI86wQjn4YdfGNAqcZms5+ySWj31hp5p8=,tag:X+80k5MY7XYtRZo35pf0bg==,type:str]
-    FUNNELBARN_ENVIRONMENT: ENC[AES256_GCM,data:2BPjlSr/BQ==,iv:WCty+n2yMUfIQG2fMgApIO0EdekH7/ZUsDudj3lowjw=,tag:A3nvDNRo0ueSOtHv+3Glog==,type:str]
-    FUNNELBARN_SELF_API_KEY: ENC[AES256_GCM,data:d3mf8s+SNcyiAeihD4thuON9jq/PIN+PMDHuaJ8mb9JxM2cRwxx3Pg==,iv:i6O5lRdNsLH1ITwCznxYp0I+rI3azI8WM0VfxuusXmQ=,tag:bwLZbOS2AHhfTkiN7Zh0nw==,type:str]
-    FUNNELBARN_SELF_ENDPOINT: ENC[AES256_GCM,data:HDcAtUL0Bw0v+FZv91QJ3Pzqmmhb+V6jBBiPKGfq,iv:aaGFuAWc9fSLKt55BjpL9mk3fPy04oaotpc6xyunXAo=,tag:dU9Eg7AGrrAmWYcSfymRmg==,type:str]
-    FUNNELBARN_SESSION_SECRET: ENC[AES256_GCM,data:SXv8HjyPnn5VzSuDSjKjY8WTFajZ23TsEyaWL/xpoprZFRD+9D2YvIPEn0u8K/AXZKx2awZgNGBTIa1JZioxeA==,iv:WlRgZp00I+rTSQHMhyjPRjfFqE9z5KyCwlPzfoQPBqg=,tag:rXUGeOWUfsNI80WYBsK0Nw==,type:str]
-    FUNNELBARN_SPANBARN_ENDPOINT: ENC[AES256_GCM,data:9dRIR1E+CbvEa3nqE1x6wwK5xvqscOaEh+M0asqL+YzwzFu1mNU/KOA=,iv:3aXO2M+tkvdILkwS45yOdMY/EgprF4LHtl4O8MKDBQM=,tag:Q/i1g9p+KzcWDGj1EEjzbQ==,type:str]
-    FUNNELBARN_SPANBARN_API_KEY: ENC[AES256_GCM,data:xARir4qf0zjyd7XXPreVfd/GozynEeHgX0lQ0S6uxMsRpKzgBj/6fQ==,iv:uMWUnncvR/2wqWUrLEOKo8zngmIEHM3dnhMEJzB1Im8=,tag:o7CnuA48YvPkiHaoPkSr/Q==,type:str]
-    FUNNELBARN_IAMBARN_ENABLED: ENC[AES256_GCM,data:fil8nlg=,iv:dz/0VyqdCwAq1Ta48xsplFuGrb/Hz+cyw8V2miWCysY=,tag:nqanWvBQjWnLwHU3BqTkCg==,type:str]
-    FUNNELBARN_IAMBARN_CLIENT_ID: ENC[AES256_GCM,data:mlXG+0mbLXzZ6Cm7ViDdUNi4t+8oI2nf6ZNHAoI8rhVpGI+meWoTZt0i938=,iv:UA6hrKu1F+sJHlb8qDx/xXy9P334OpTL1+PFig/uCVU=,tag:7HaqG8e/gzhcNMMilLBsCQ==,type:str]
-    GEOIPUPDATE_ACCOUNT_ID: ENC[AES256_GCM,data:Ka/ZFevDbw==,iv:xCgk3Ad9US2f3+GfxeGVj6f1563rhiaFyUDLFBXxs8c=,tag:KcO/M5hV6BmveYA64x99Cg==,type:str]
-    GEOIPUPDATE_LICENSE_KEY: ENC[AES256_GCM,data:zm8XEHoROW2xoAfVXZ9lHcb7zop+Xf4iQ1jSNhW5eyQIoIyO/vs5Sg==,iv:Qj6BUtsR5W6oNks/FSVKZHGn2trEelvpyFU5MBL2+So=,tag:CqeMphiW36Mp0aPcOC5ekg==,type:str]
-    FUNNELBARN_R2_ENDPOINT: ENC[AES256_GCM,data:XeVCRvWvqlpt9UtxBUjZLJNgHYpZOWjkgTR21mc+C3M3SIOKnV8QpBaMa70M6jME4tLVknGzu4DwHPEIvi4WPmpsyyo=,iv:HkE16ZNPcV5Kbnm6XOxDxAUNKb7MjeUabS3L7L69SY0=,tag:G3paXeEyDUXDKOJttC6TFw==,type:str]
-    FUNNELBARN_R2_ACCESS_KEY_ID: ENC[AES256_GCM,data:OXMQ07awbBQJ7F21IL8sAcn4j03L731AdlWrCJDopAU=,iv:BL+MWkch6sAtEdYCF1NfHldr9Xhj3FwJUA+od7vcxlk=,tag:bk0HfhybXdburdtDVHV7nw==,type:str]
-    FUNNELBARN_R2_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:F4RKa1ABrmvU0gdi2NNQupwkRXgrZmndtkwY14YnKGSuCniLtr4fe/9UfvflmsMMnfw3tn9kecctxOAA2PYdBw==,iv:VrFPPH76nsuvnECmAe8wYuB7oF7kOPTi9m+tE3V8Hk0=,tag:tSWrrH/vkbCoQgDDvErvkA==,type:str]
-    FUNNELBARN_R2_BUCKET: ENC[AES256_GCM,data:Eco99kvAk7k9co88nWiHXrA3SUZcF/4Bs9pdmlU=,iv:wJf85CXcJvI3jfod+IgCfJAPb61Ct/0jBA7XB/at3zM=,tag:9H/mtJSWv0lKa4S8BYvzmQ==,type:str]
-type: ENC[AES256_GCM,data:znGPdHUD,iv:mFtm6T8KY+BXCylBiJkYTSEWPPqwaEO+NHNYsSOoTHE=,tag:ysSqg9E1CYOlv0rHxRrfjw==,type:str]
+    FUNNELBARN_ADMIN_PASSWORD_BCRYPT: ENC[AES256_GCM,data:dlQMoVl+bmRUKZ0xlqesLr4wF9mGaO1GfARrBv1bq2k2OZ7D06v9gT7NyNN3pXH5J5vrFxnMdGvkifbx,iv:tmi2Ep3jAsiORA0gFD6eRX7kg9bvZElfxiIMmzT+Cs0=,tag:cK12kI4qkZJameUvCzO82A==,type:str]
+    FUNNELBARN_ADMIN_USERNAME: ENC[AES256_GCM,data:nnnAM+Q=,iv:BBqKkwnOjE8SCa3IrPhZ4ssc4PUyx7z6wvbY9z+KwJE=,tag:1Zky1E9TJg0HCeXM6OtZ5g==,type:str]
+    FUNNELBARN_API_KEY: ENC[AES256_GCM,data:AMM1JdIRpzv0z6YJd19HkoDnkNyp374mRBiSxMaaDp8eus1DX69TDN6sqlC6KKadWfpTiar8/L4L1ukdq/pXGw==,iv:ipQuWvuNnKYbbsGcf5qm77qAUTQELrX8TM4PUh65ytU=,tag:WrdBhy13fNOARpzbMS9O3w==,type:str]
+    FUNNELBARN_ENVIRONMENT: ENC[AES256_GCM,data:Nj6RF2WZhA==,iv:DxnOapjG+Ym8VRa2iOj523uYBFTUK8LuGGE7hDf2uCM=,tag:rJEaVMItytGyheuWtFWwXg==,type:str]
+    FUNNELBARN_SELF_API_KEY: ENC[AES256_GCM,data:a+8Z+RhNsNpV2kkofAz9R3H3/xElJwO1M9Xap/B2rxECnMke0CCTqg==,iv:M/MdI8vMaWbkyqjVUxJwqTAvh52+phgV03mS+LlNW6M=,tag:zvn89C5qQeYRE9tv9cbnEA==,type:str]
+    FUNNELBARN_SELF_ENDPOINT: ENC[AES256_GCM,data:NZDbWKYY0Ve/IYyn2IsfqcueiIGOE3r89Rj4uEat,iv:k/QyI2Lkn9dNONhhMXTNt4UCflfuUX5NaRl6LNGGX24=,tag:6k6mH8DrD6RbjQroJ7nNcQ==,type:str]
+    FUNNELBARN_SESSION_SECRET: ENC[AES256_GCM,data:1i2+PBpedblPPTfmb2gKeVnwp4j/rROpUxaKmQBFKTJMJbrfccmSeffb/q/zXTu0ML3gC64g1tH0DV4FRm91Hg==,iv:aiYxZXKrzcJ4TCV63q2tjRUJKOj0wDbn6Ilhb0sWtW0=,tag:KbrbFULvnKIuVRH5RmObSA==,type:str]
+    FUNNELBARN_SPANBARN_ENDPOINT: ENC[AES256_GCM,data:Dr5cOVaY1Rs57uPCVxfVd+EEFlIRY+mD4Yz33U8Zp4tSJMtSip1nB74=,iv:HXpbjuDBAjDhCTzmeIPI44UCEZnMDTkDR8P5LtpH8EE=,tag:MJQjHo/iC/cuaaza1X5r6A==,type:str]
+    FUNNELBARN_SPANBARN_API_KEY: ENC[AES256_GCM,data:Y0xDZYGFAxKNXGZVokxFXu88z84dQTe/+IMRTzxRn4OCM8SQiHMwUQ==,iv:Yel4uadnnNbd0DkhP3qKS2Bm5NCftZwYdLkTLnZBxTY=,tag:7TxUUwa9IaKOBZ5dPRk15g==,type:str]
+    FUNNELBARN_IAMBARN_ENABLED: ENC[AES256_GCM,data:jsD5rlc=,iv:eT8Zjq1sxrLvPZntlZqBFhs1SrvnqSxOZKdlLmyyie8=,tag:/kh32TaEXGAosIOkY60EMA==,type:str]
+    FUNNELBARN_IAMBARN_CLIENT_ID: ENC[AES256_GCM,data:UtH60yQ2czmQsPt0cMgcp/gRxR5M4bKYmXTKdAKhjVEe11Taj1LK1V5Um3s=,iv:0AjRU/XqLe48voIYu/UDBrQXgbSgGbg5HVEJKDQmKF8=,tag:D/J8p/Z/+CbqyKtX+sWNEA==,type:str]
+    GEOIPUPDATE_ACCOUNT_ID: ENC[AES256_GCM,data:cWsOHBX6uQ==,iv:VV9nRk2z0MJNdRFWr1QlvUiHj8wTH71vwx7YfEM52rg=,tag:Xid+3XjGxOWufocdt54Saw==,type:str]
+    GEOIPUPDATE_LICENSE_KEY: ENC[AES256_GCM,data:fQ9iXIXZncK8H9K0x7O0pGvI4+a9pm6gaLwyIRbPfo/o9Vusq4PmiA==,iv:WCtPraDskE3OwqZ+7dvzExl+RaY2vxAjlP+Ie58if4c=,tag:pj3P5uYuma1HM+f+/+Z+uA==,type:str]
+    FUNNELBARN_DOGFOOD_API_KEY: ENC[AES256_GCM,data:gZgSNZgkmzWMlYokasS+TNLup1d5WeG09AMvsSsGInSvc89Ppc4RKvMyr+NCCX5YExotL7HlIW8mge0dQ13QLA==,iv:JUcVNNfnO+fEWq48rsinOtskcvMfH/2XK4zn2ahUSiI=,tag:g1ShUXIHClkIZpV/zEJrug==,type:str]
+    FUNNELBARN_R2_ENDPOINT: ENC[AES256_GCM,data:SwRfDPgbew5NQAMQeCJdDOXB53xMZT+tafl416+UhFS8AH28fbA0VrD5rgn2hpvkBdLux6rlKHrlJCb/UnmqhiXWbqk=,iv:gmoEJw3g2iskKMYr0CA4mhUlI5M9Gb00VMkTdq99+8I=,tag:GUw3gFVbU/u31MP6W1UnaQ==,type:str]
+    FUNNELBARN_R2_ACCESS_KEY_ID: ENC[AES256_GCM,data:72wqI3JWNo8w5oYedkq/ta43BGJ4w6FlqtZFL4xm74M=,iv:7T7CJjrbH8HmuSf4g/W7Jj331wkaJDLLSKkNK/yLjLk=,tag:U99miyM+7QTfMafpryCoOg==,type:str]
+    FUNNELBARN_R2_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:3BBwEKM+36Fc1OvYX1NhB4fgg065g1VHKOjw+M991Hl0RMfkKrIa5RSIuRlDbafTJSjblcGojCUETwptbEhNzg==,iv:NJb3vqvNnQcoIqXrPO+XQuOSI4oc5CPE8Wc/7CRX+2E=,tag:nsYhEVVp0BY0s8QsC84R9A==,type:str]
+    FUNNELBARN_R2_BUCKET: ENC[AES256_GCM,data:DSWo5+uAb5GPW1Um/LcnU2ZDXH9Fi5TD3Jxm+0g=,iv:y3SJXw+RwQgFXrymiJyBpmm5ZUz0YPePbAYaeAMi7D0=,tag:JfQ1n/X22wGcGt8HGef8Eg==,type:str]
+type: ENC[AES256_GCM,data:JOKFg516,iv:3BiOJL7fLdpNn0aoOogF41SR1RN4p/Y/+pvtf9O0BKA=,tag:89IkNNI1O0ZLqQV1Bw6ADQ==,type:str]
 sops:
     age:
         - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPalhKakNsRXpYNHRBSUhu
-            eFUwc3R5OTBnczRJV2NjalczSG5sd1RpRkZJCmI2M2JtZ2pRWUJ3UzIrY2dQREx2
-            Vm9tM3RzWk9vZ1NDL3JqS3IvOFZ3UDQKLS0tIEVXQ2V5Qlhva0JMQ0tzSE5FeGpX
-            eWY4UitFZkh6cS9ZUE5sS25FbGJ4cGMKR6Mz2R6HVNCJnXF129Obt0QJByNKf9Sx
-            hpst4VqBQgDFpgiXcxtyGX3XKSgZTnbgvZjf7i2QuGFJl0O3GcrZ9g==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjdmxwWEdOU1BqSVgwT0FB
+            TytrQUFVQkgrZTVHNnpId3NKWmoybkp2V0NvCjA2dmthZVZiRG5xaDJTaUN6b1NT
+            T0owTVlMQm5Ld2xVVUFpVmxYTW41SmsKLS0tIGxPaG1GSk8xT2NuWnFFLzFXMmRh
+            K3MxUHliV1ZOdzV0RVU2aEJYQnNDcEkKPXTOuXqEQLX7DpxdAbARmY3UZvrEOat/
+            5RCzjxgtx7iICabVdbaaENir7HH86RrsvaI/zBTsEO32tJABuO5mgg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-07T14:13:36Z"
-    mac: ENC[AES256_GCM,data:/unFugaQZC1FvG1YdISN20UvemKBiEV4sSd707h8XmMjiSRAN9w+mD3APTOTvJeZJ3A2J2SaGNpZ9AgTru/VcGkFG4AO4h47cCdTT31wHrL+YEXOqEUMHGr2cetJKtK6zTPKGNMuhkAtt7ipjd2bQHwElHJNRsY7hVi5MlZx6wQ=,iv:qZiZbCxZ3zgV2rOo9bSkNGYbTldLMmyrKK4h9xEwaxc=,tag:R+3nNldlokaqIk1jZoMv5Q==,type:str]
+    lastmodified: "2026-06-07T23:25:26Z"
+    mac: ENC[AES256_GCM,data:iQu3/qg90MOub6VjcAd260+NalM9wj43gjdOauBdCPzw6SO5Z6XqDKh1IBSuRUB0c4QkngSHxm65eyyNXZpJ66NL9ckHncywMZrGCSHC7PsZ82HfvG34EzTV/jTBykamG0A9ydK+g2TAavogbiVlai6zXpIxzEGdsaDA1GO/DPA=,iv:30mGPgLy6y4FX2a8ogDBFu0icSLXkp407SeLFSNazPQ=,tag:gavzN0uZLiFQs3qEXBf6Sg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Summary
- R2 credentials (`FUNNELBARN_R2_ENDPOINT/ACCESS_KEY_ID/SECRET_ACCESS_KEY/BUCKET`) were stored in SOPS secrets but never referenced in any `deployment.yaml` — pods started without them, so `s.recordings == nil` and session recording was silently disabled
- Adds `envFrom`-style individual `secretKeyRef` entries for all four R2 vars to testing, staging, and production deployments
- Adds `FUNNELBARN_DOGFOOD_API_KEY` + `FUNNELBARN_DOGFOOD_PROJECT` to the testing deployment (staging/production already had them)
- Adds the dogfood API key value to the testing SOPS secret

## Effect
After this merges and deploys to testing: navigate the dashboard → recordings appear in Sessions → funnelbarn project within ~10s