### PR TITLE
fix(recordings): track first_chunk_index and fix chunk fetch for partial recordings

### DIFF
--- a/internal/api/recordings.go
+++ b/internal/api/recordings.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -44,6 +45,13 @@ func (s *Server) handleIngestRecordingChunk(w http.ResponseWriter, r *http.Reque
 	chunk.UserAgent = r.Header.Get("User-Agent")
 
 	if err := s.recordings.IngestChunk(r.Context(), chunk); err != nil {
+		slog.ErrorContext(r.Context(), "ingest recording chunk failed",
+			"error", err, "handled", false,
+			"recording_id", chunk.RecordingID,
+			"project_id", chunk.ProjectID,
+			"chunk_index", chunk.ChunkIndex,
+			"request_id", RequestIDFromContext(r.Context()),
+		)
 		jsonError(w, "failed to ingest chunk", http.StatusInternalServerError)
 		return
 	}
@@ -126,10 +134,18 @@ func (s *Server) handleGetRecordingChunk(w http.ResponseWriter, r *http.Request)
 
 	data, err := s.recordings.GetChunk(r.Context(), projectID, recordingID, index)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
+		errStr := err.Error()
+		if strings.Contains(errStr, "not found") || strings.Contains(errStr, "NoSuchKey") || strings.Contains(errStr, "404") {
 			jsonError(w, "not found", http.StatusNotFound)
 			return
 		}
+		slog.ErrorContext(r.Context(), "fetch recording chunk failed",
+			"error", err, "handled", false,
+			"recording_id", recordingID,
+			"project_id", projectID,
+			"chunk_index", index,
+			"request_id", RequestIDFromContext(r.Context()),
+		)
 		jsonError(w, "failed to fetch chunk", http.StatusInternalServerError)
 		return
 	}

--- a/internal/repository/migrations/00021_recordings_first_chunk.sql
+++ b/internal/repository/migrations/00021_recordings_first_chunk.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE recordings ADD COLUMN first_chunk_index INTEGER NOT NULL DEFAULT 0;
+
+-- +goose Down
+-- SQLite does not support DROP COLUMN on older versions; migration is a no-op on rollback.

--- a/internal/repository/recordings.go
+++ b/internal/repository/recordings.go
@@ -10,19 +10,20 @@ import (
 
 // Recording holds metadata for a session recording.
 type Recording struct {
-	ID          string     `json:"id"`
-	ProjectID   string     `json:"project_id"`
-	SessionID   string     `json:"session_id"`
-	Environment string     `json:"environment"`
-	ChunkCount  int        `json:"chunk_count"`
-	DurationMs  int64      `json:"duration_ms"`
-	StartedAt   time.Time  `json:"started_at"`
-	EndedAt     *time.Time `json:"ended_at,omitempty"`
-	CreatedAt   time.Time  `json:"created_at"`
-	DeviceType  string     `json:"device_type"`
-	UserAgent   string     `json:"user_agent,omitempty"`
-	IsBot       bool       `json:"is_bot"`
-	PageURL     string     `json:"page_url,omitempty"`
+	ID              string     `json:"id"`
+	ProjectID       string     `json:"project_id"`
+	SessionID       string     `json:"session_id"`
+	Environment     string     `json:"environment"`
+	FirstChunkIndex int        `json:"first_chunk_index"`
+	ChunkCount      int        `json:"chunk_count"`
+	DurationMs      int64      `json:"duration_ms"`
+	StartedAt       time.Time  `json:"started_at"`
+	EndedAt         *time.Time `json:"ended_at,omitempty"`
+	CreatedAt       time.Time  `json:"created_at"`
+	DeviceType      string     `json:"device_type"`
+	UserAgent       string     `json:"user_agent,omitempty"`
+	IsBot           bool       `json:"is_bot"`
+	PageURL         string     `json:"page_url,omitempty"`
 }
 
 // FlagEvaluationEntry is a flag evaluation linked to a session.
@@ -44,16 +45,17 @@ type RecordingListOpts struct {
 }
 
 // UpsertRecording inserts a new recording or updates an existing one's
-// chunk count, duration, and ended_at timestamp. Metadata fields
-// (device_type, user_agent, is_bot, page_url) are set only on insert.
+// chunk count, duration, and ended_at timestamp. first_chunk_index and
+// metadata fields (device_type, user_agent, is_bot, page_url) are set
+// only on insert and never overwritten.
 func (s *Store) UpsertRecording(ctx context.Context, r Recording) error {
 	const q = `
 		INSERT INTO recordings
-			(id, project_id, session_id, environment, chunk_count, duration_ms, started_at, ended_at,
+			(id, project_id, session_id, environment, first_chunk_index, chunk_count, duration_ms, started_at, ended_at,
 			 device_type, user_agent, is_bot, page_url)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
-			chunk_count = excluded.chunk_count,
+			chunk_count = chunk_count + 1,
 			duration_ms = excluded.duration_ms,
 			ended_at    = excluded.ended_at`
 	var endedAt interface{}
@@ -66,7 +68,7 @@ func (s *Store) UpsertRecording(ctx context.Context, r Recording) error {
 	}
 	_, err := s.db.ExecContext(ctx, q,
 		r.ID, r.ProjectID, r.SessionID, r.Environment,
-		r.ChunkCount, r.DurationMs, r.StartedAt, endedAt,
+		r.FirstChunkIndex, r.DurationMs, r.StartedAt, endedAt,
 		r.DeviceType, r.UserAgent, isBot, r.PageURL,
 	)
 	return err
@@ -75,7 +77,7 @@ func (s *Store) UpsertRecording(ctx context.Context, r Recording) error {
 // GetRecording fetches a single recording by ID.
 func (s *Store) GetRecording(ctx context.Context, id string) (Recording, error) {
 	const q = `
-		SELECT id, project_id, session_id, environment, chunk_count, duration_ms, started_at, ended_at, created_at,
+		SELECT id, project_id, session_id, environment, first_chunk_index, chunk_count, duration_ms, started_at, ended_at, created_at,
 		       device_type, user_agent, is_bot, page_url
 		FROM recordings WHERE id = ?`
 	return scanRecording(s.db.QueryRowContext(ctx, q, id))
@@ -117,7 +119,7 @@ func (s *Store) ListRecordings(ctx context.Context, projectID string, opts Recor
 	offset := opts.Offset
 
 	q := fmt.Sprintf(`
-		SELECT id, project_id, session_id, environment, chunk_count, duration_ms, started_at, ended_at, created_at,
+		SELECT id, project_id, session_id, environment, first_chunk_index, chunk_count, duration_ms, started_at, ended_at, created_at,
 		       device_type, user_agent, is_bot, page_url
 		FROM recordings
 		WHERE %s
@@ -203,7 +205,7 @@ func scanRecording(row *sql.Row) (Recording, error) {
 	var isBot int
 	err := row.Scan(
 		&r.ID, &r.ProjectID, &r.SessionID, &r.Environment,
-		&r.ChunkCount, &r.DurationMs, &r.StartedAt, &endedAt, &r.CreatedAt,
+		&r.FirstChunkIndex, &r.ChunkCount, &r.DurationMs, &r.StartedAt, &endedAt, &r.CreatedAt,
 		&r.DeviceType, &r.UserAgent, &isBot, &r.PageURL,
 	)
 	if endedAt.Valid {
@@ -219,7 +221,7 @@ func scanRecordingRow(scan func(...any) error) (Recording, error) {
 	var isBot int
 	err := scan(
 		&r.ID, &r.ProjectID, &r.SessionID, &r.Environment,
-		&r.ChunkCount, &r.DurationMs, &r.StartedAt, &endedAt, &r.CreatedAt,
+		&r.FirstChunkIndex, &r.ChunkCount, &r.DurationMs, &r.StartedAt, &endedAt, &r.CreatedAt,
 		&r.DeviceType, &r.UserAgent, &isBot, &r.PageURL,
 	)
 	if endedAt.Valid {

--- a/internal/repository/recordings_test.go
+++ b/internal/repository/recordings_test.go
@@ -12,17 +12,18 @@ import (
 
 func makeRecording(projectID, sessionID string, start time.Time) repository.Recording {
 	return repository.Recording{
-		ID:          "placeholder", // caller must override
-		ProjectID:   projectID,
-		SessionID:   sessionID,
-		Environment: "testing",
-		ChunkCount:  1,
-		DurationMs:  5000,
-		StartedAt:   start,
-		DeviceType:  "desktop",
-		UserAgent:   "Mozilla/5.0",
-		IsBot:       false,
-		PageURL:     "https://example.com/",
+		ID:              "placeholder", // caller must override
+		ProjectID:       projectID,
+		SessionID:       sessionID,
+		Environment:     "testing",
+		FirstChunkIndex: 0,
+		ChunkCount:      1,
+		DurationMs:      5000,
+		StartedAt:       start,
+		DeviceType:      "desktop",
+		UserAgent:       "Mozilla/5.0",
+		IsBot:           false,
+		PageURL:         "https://example.com/",
 	}
 }
 
@@ -61,17 +62,42 @@ func TestRecording_UpsertUpdatesProgress(t *testing.T) {
 	rec.ID = "rec-upd"
 	require.NoError(t, s.UpsertRecording(ctx, rec))
 
-	// Second upsert with different chunk_count/duration — metadata stays the same.
-	rec.ChunkCount = 5
+	// Each successful ingest increments chunk_count by 1; metadata stays the same.
 	rec.DurationMs = 50000
 	rec.DeviceType = "mobile" // should NOT be updated
+	require.NoError(t, s.UpsertRecording(ctx, rec))
 	require.NoError(t, s.UpsertRecording(ctx, rec))
 
 	got, err := s.GetRecording(ctx, "rec-upd")
 	require.NoError(t, err)
-	assert.Equal(t, 5, got.ChunkCount)
+	assert.Equal(t, 3, got.ChunkCount) // 1 insert + 2 upserts
 	assert.Equal(t, int64(50000), got.DurationMs)
 	assert.Equal(t, "desktop", got.DeviceType) // unchanged from first insert
+}
+
+func TestRecording_FirstChunkIndexPreserved(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	p, err := s.CreateProject(ctx, "First Chunk", "first-chunk")
+	require.NoError(t, err)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	// Simulates chunk 0 being lost — first successful ingest is chunk index 1.
+	rec := makeRecording(p.ID, "sess-fc", now)
+	rec.ID = "rec-fc"
+	rec.FirstChunkIndex = 1
+	require.NoError(t, s.UpsertRecording(ctx, rec))
+
+	// Second chunk (index 2) arrives — first_chunk_index must NOT change.
+	rec.FirstChunkIndex = 2
+	rec.DurationMs = 20000
+	require.NoError(t, s.UpsertRecording(ctx, rec))
+
+	got, err := s.GetRecording(ctx, "rec-fc")
+	require.NoError(t, err)
+	assert.Equal(t, 1, got.FirstChunkIndex) // preserved from first insert
+	assert.Equal(t, 2, got.ChunkCount)
 }
 
 func TestRecording_ListRecordings(t *testing.T) {

--- a/internal/service/recordings.go
+++ b/internal/service/recordings.go
@@ -64,18 +64,19 @@ func (svc *RecordingService) IngestChunk(ctx context.Context, chunk RecordingChu
 
 	endedAt := chunk.StartedAt.Add(time.Duration(chunk.DurationMs) * time.Millisecond)
 	rec := repository.Recording{
-		ID:          chunk.RecordingID,
-		ProjectID:   chunk.ProjectID,
-		SessionID:   chunk.SessionID,
-		Environment: chunk.Environment,
-		ChunkCount:  chunk.ChunkIndex + 1,
-		DurationMs:  chunk.DurationMs,
-		StartedAt:   chunk.StartedAt,
-		EndedAt:     &endedAt,
-		UserAgent:   chunk.UserAgent,
-		DeviceType:  DetectDeviceType(chunk.UserAgent),
-		IsBot:       DetectBot(chunk.UserAgent),
-		PageURL:     chunk.PageURL,
+		ID:              chunk.RecordingID,
+		ProjectID:       chunk.ProjectID,
+		SessionID:       chunk.SessionID,
+		Environment:     chunk.Environment,
+		FirstChunkIndex: chunk.ChunkIndex,
+		ChunkCount:      1,
+		DurationMs:      chunk.DurationMs,
+		StartedAt:       chunk.StartedAt,
+		EndedAt:         &endedAt,
+		UserAgent:       chunk.UserAgent,
+		DeviceType:      DetectDeviceType(chunk.UserAgent),
+		IsBot:           DetectBot(chunk.UserAgent),
+		PageURL:         chunk.PageURL,
 	}
 	return svc.store.UpsertRecording(ctx, rec)
 }

--- a/web/src/components/sessions/SessionReplay.tsx
+++ b/web/src/components/sessions/SessionReplay.tsx
@@ -35,11 +35,17 @@ export function SessionReplay({ projectId, recording, onClose }: Props) {
       if (!playerRef.current) return
       try {
         const allEvents: unknown[] = []
-        for (let i = 0; i < recording.chunk_count; i++) {
-          setProgress(Math.round((i / recording.chunk_count) * 100))
-          const chunk = await api.getRecordingChunk(projectId, recording.id, i)
-          if (cancelled) return
-          allEvents.push(...chunk)
+        const start = recording.first_chunk_index ?? 0
+        const end = start + recording.chunk_count
+        for (let i = start; i < end; i++) {
+          setProgress(Math.round(((i - start) / recording.chunk_count) * 100))
+          try {
+            const chunk = await api.getRecordingChunk(projectId, recording.id, i)
+            if (cancelled) return
+            allEvents.push(...chunk)
+          } catch {
+            // chunk missing in storage — skip and continue
+          }
         }
         setProgress(100)
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -593,6 +593,7 @@ export interface Recording {
   project_id: string
   session_id: string
   environment: string
+  first_chunk_index: number
   chunk_count: number
   duration_ms: number
   started_at: string


### PR DESCRIPTION
## Summary

- **Root cause**: chunk 0 was dropped silently by the SDK when R2 wasn't configured yet (before #156 was deployed). The upsert was setting `chunk_count = max_chunk_index + 1`, so a recording with only chunk 1 stored would have `chunk_count = 2` — causing the player to request chunk 0 which doesn't exist in R2.
- **Migration 00021**: adds `first_chunk_index` column; set from the first successfully ingested chunk and never overwritten on conflict.
- **Upsert change**: `chunk_count` now increments by 1 per ingested chunk instead of being forced to `chunk_index + 1`.
- **Frontend**: replay loop starts at `first_chunk_index` and catches 404s per-chunk so a missing chunk doesn't abort playback.
- **Structured logging**: `handleIngestRecordingChunk` and `handleGetRecordingChunk` now log via `slog.ErrorContext` with `"handled": false` so R2 errors surface in bugbarn.

## Test plan
- [ ] Deploy to testing; existing recordings with `first_chunk_index=0` and a missing chunk 0 will now play from chunk 1
- [ ] New recordings will correctly start from whatever chunk was first successfully uploaded
- [ ] R2 errors on ingest/fetch will now appear as error events in bugbarn