### PR TITLE
fix(recordings): surface errors instead of black screen when chunks are missing

### DIFF
--- a/e2e/recording-verify.spec.ts
+++ b/e2e/recording-verify.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Verify the session replay player renders content and is not clipped.
+ *
+ * Run locally against the test env:
+ *   FUNNELBARN_API_URL=https://funnelbarn-test.nijmegen.wiebe.xyz \
+ *   npx playwright test e2e/recording-verify.spec.ts --project=chromium --headed
+ */
+import { test, expect } from '@playwright/test'
+
+const PROJECT_ID = 'e7af9de5-04d3-4e00-a552-5fa49baca192'
+
+test.beforeEach(async ({ page }) => {
+  const res = await page.request.post('/api/v1/login', {
+    data: { username: 'wiebe', password: 'wiebe' },
+  })
+  expect(res.ok(), `Login failed: ${res.status()}`).toBeTruthy()
+})
+
+test('sessions list shows recordings', async ({ page }) => {
+  await page.goto(`/sessions/${PROJECT_ID}`)
+
+  // Wait for the "X shown" counter to appear (replaces "Loading…")
+  await expect(page.getByText(/\d+ shown/)).toBeVisible({ timeout: 15000 })
+
+  // At least one recording row must be present — each row has cursor:pointer
+  const row = page.locator('div[style*="cursor: pointer"]').first()
+  await expect(row).toBeVisible({ timeout: 5000 })
+})
+
+test('replay player is scaled and visible — not a black screen', async ({ page }) => {
+  await page.goto(`/sessions/${PROJECT_ID}`)
+
+  // Wait for recordings to load
+  await expect(page.getByText(/\d+ shown/)).toBeVisible({ timeout: 15000 })
+
+  // Click the first recording row
+  const row = page.locator('div[style*="cursor: pointer"]').first()
+  await expect(row).toBeVisible({ timeout: 5000 })
+  await row.click()
+
+  // The modal + rrweb wrapper must appear
+  const wrapper = page.locator('.replayer-wrapper').first()
+  await expect(wrapper).toBeVisible({ timeout: 20000 })
+
+  // 1. CSS scaling must be applied (transform should be a matrix, not 'none')
+  const transform = await wrapper.evaluate((el) => getComputedStyle(el).transform)
+  console.log('transform:', transform)
+  expect(transform, 'replayer-wrapper should have a CSS scale transform applied').not.toBe('none')
+
+  // 2. The iframe must be within the player container bounds (not pushed below by overflow)
+  const container = wrapper.locator('..')
+  const containerBox = await container.boundingBox()
+  const iframe = wrapper.locator('iframe').first()
+  const iframeBox = await iframe.boundingBox()
+  console.log('container:', containerBox)
+  console.log('iframe:', iframeBox)
+  if (containerBox && iframeBox) {
+    expect(
+      iframeBox.y,
+      'iframe top must be within the container (not clipped below)',
+    ).toBeLessThan(containerBox.y + containerBox.height)
+  }
+
+  // 3. The iframe body must contain child elements (actual recorded DOM)
+  const hasContent = await iframe.evaluate((el) => {
+    const body = (el as HTMLIFrameElement).contentDocument?.body
+    return (body?.children.length ?? 0) > 0
+  })
+  console.log('iframe has content:', hasContent)
+  expect(hasContent, 'iframe body should have child elements from the recording').toBeTruthy()
+})

--- a/web/src/components/sessions/SessionReplay.tsx
+++ b/web/src/components/sessions/SessionReplay.tsx
@@ -30,6 +30,7 @@ export function SessionReplay({ projectId, recording, onClose }: Props) {
 
   useEffect(() => {
     let cancelled = false
+    let ro: ResizeObserver | null = null
 
     async function loadAndPlay() {
       if (!playerRef.current) return
@@ -51,6 +52,27 @@ export function SessionReplay({ projectId, recording, onClose }: Props) {
 
         if (!playerRef.current || cancelled) return
 
+        if (allEvents.length === 0) {
+          setError('Recording data not found — chunks may still be uploading or were never stored.')
+          return
+        }
+
+        // rrweb requires a full-snapshot event (type 2) to reconstruct the page
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const hasSnapshot = allEvents.some((e: any) => e?.type === 2)
+        if (!hasSnapshot) {
+          setError('Recording is incomplete — the initial page snapshot is missing.')
+          return
+        }
+
+        // Read recorded viewport dimensions from the meta event (type 4).
+        // rrweb v2's raw Replayer sets the iframe to these exact pixel dimensions
+        // with no built-in scaling, so we must scale manually.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const metaEvent = allEvents.find((e: any) => e?.type === 4) as any
+        const recordedWidth: number = metaEvent?.data?.width ?? 1280
+        const recordedHeight: number = metaEvent?.data?.height ?? 720
+
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const replayer = new Replayer(allEvents as any, {
           root: playerRef.current,
@@ -58,6 +80,28 @@ export function SessionReplay({ projectId, recording, onClose }: Props) {
           skipInactive: true,
         })
         replayerRef.current = replayer
+
+        function applyScale() {
+          const container = playerRef.current
+          if (!container) return
+          const wrapper = container.querySelector<HTMLElement>('.replayer-wrapper')
+          if (!wrapper) return
+          const scale = Math.min(
+            container.clientWidth / recordedWidth,
+            container.clientHeight / recordedHeight,
+          )
+          wrapper.style.transformOrigin = 'top left'
+          wrapper.style.transform = `scale(${scale})`
+          wrapper.style.position = 'absolute'
+          wrapper.style.top = '0'
+          wrapper.style.left = '0'
+        }
+
+        // Give rrweb one frame to build the .replayer-wrapper DOM before scaling
+        requestAnimationFrame(() => setTimeout(applyScale, 0))
+        ro = new ResizeObserver(applyScale)
+        ro.observe(playerRef.current)
+
         replayer.play()
         setLoading(false)
       } catch {
@@ -74,6 +118,7 @@ export function SessionReplay({ projectId, recording, onClose }: Props) {
     return () => {
       cancelled = true
       replayerRef.current?.pause()
+      ro?.disconnect()
     }
   }, [projectId, recording])
 
@@ -124,25 +169,28 @@ export function SessionReplay({ projectId, recording, onClose }: Props) {
         <div style={{ display: 'flex', flex: 1, overflow: 'hidden', minHeight: 0 }}>
           {/* Player area */}
           <div style={{ flex: 1, position: 'relative', background: '#000', overflow: 'hidden' }}>
-            {loading && (
+            {(loading || error) && (
               <div style={{
                 position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column',
                 alignItems: 'center', justifyContent: 'center', gap: 16, color: C.muted,
+                zIndex: 1,
               }}>
-                <div style={{
-                  width: 200, height: 4, background: C.surface, borderRadius: 2, overflow: 'hidden',
-                }}>
+                {!error && (
                   <div style={{
-                    height: '100%', background: C.amber, borderRadius: 2,
-                    width: `${progress}%`, transition: 'width 0.2s',
-                  }} />
-                </div>
-                <span style={{ fontSize: 13 }}>
+                    width: 200, height: 4, background: C.surface, borderRadius: 2, overflow: 'hidden',
+                  }}>
+                    <div style={{
+                      height: '100%', background: C.amber, borderRadius: 2,
+                      width: `${progress}%`, transition: 'width 0.2s',
+                    }} />
+                  </div>
+                )}
+                <span style={{ fontSize: 13, maxWidth: 320, textAlign: 'center' }}>
                   {error ?? `Loading chunks… ${progress}%`}
                 </span>
               </div>
             )}
-            <div ref={playerRef} style={{ width: '100%', height: '100%' }} />
+            <div ref={playerRef} style={{ width: '100%', height: '100%', position: 'relative' }} />
           </div>
 
           {/* Sidebar — flag evaluations */}

--- a/web/src/components/sessions/SessionReplay.tsx
+++ b/web/src/components/sessions/SessionReplay.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { X, Flag } from 'lucide-react'
 import { Replayer } from 'rrweb'
+import 'rrweb/dist/style.css'
 import { api, type Recording, type FlagEvaluationEntry } from '../../lib/api'
 import { C } from '../../lib/theme'
 


### PR DESCRIPTION
## Root cause

rrweb v2's raw `Replayer` sizes the recording iframe to the exact recorded viewport dimensions (e.g. 1280×720) with no CSS scaling. Inside the flex modal the iframe overflows and is fully clipped by `overflow: hidden`, producing a black screen.

## Changes

**`web/src/components/sessions/SessionReplay.tsx`**

- **Scaling fix**: After creating the `Replayer`, extracts the recorded width/height from the meta event (type 4) and applies `transform: scale()` with `transform-origin: top left` to `.replayer-wrapper`, fitting the iframe inside the player container. A `ResizeObserver` keeps the scale current when the modal resizes and is disconnected on unmount.
- **Error guards**: Returns a readable error message when the fetched events array is empty (chunks still uploading or never stored) or when no full-snapshot event (type 2) is present.

## Test

Test env: https://funnelbarn-test.nijmegen.wiebe.xyz — credentials wiebe/wiebe  
Working recording: `4aacd6239da49e2b1b76ebfb47821801` in project `e7af9de5-04d3-4e00-a552-5fa49baca192`