### PR TITLE
fix(sdk): include page_url in recording chunk payload

### DIFF
--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -604,6 +604,7 @@ export class FunnelBarnClient {
           events,
           started_at: this.recordingStartedAt,
           duration_ms: Date.now() - this.recordingStartMs,
+          page_url: typeof window !== 'undefined' ? window.location.href : undefined,
         }),
         keepalive: true,
       });


### PR DESCRIPTION
## Summary

- `flushRecordingChunk()` was building the POST body without `page_url`, so every recording stored an empty page URL
- Filtering by page in the Sessions view would always return zero results
- Adds `page_url: window.location.href` to the chunk payload (guarded for non-browser environments)

## Test plan

- [ ] Verify a new recording's `page_url` is populated in the Sessions table after this change
- [ ] Confirm page URL filter in Sessions view returns matching recordings