### PR TITLE
fix(sdk): drop keepalive on recording chunk flushes so full snapshot isn't silently lost

### DIFF
--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -50,27 +50,35 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	)
 	defer span.End()
 
+	// recordOnErr surfaces an error onto the span and falls through to the
+	// standard service-error mapper. Without span.RecordError, trace search
+	// in SpanBarn lists these spans as "ok" even though the request 5xx'd.
+	recordOnErr := func(err error, op string) bool {
+		if err == nil {
+			return false
+		}
+		tracing.RecordError(span, err)
+		mapServiceError(w, err, op)
+		return true
+	}
+
 	totalEvents, err := s.events.CountEvents(ctx, projectID, from, to, env)
-	if err != nil {
-		mapServiceError(w, err, "handleDashboard.countEvents")
+	if recordOnErr(err, "handleDashboard.countEvents") {
 		return
 	}
 
 	uniqueSessions, err := s.events.UniqueSessionCount(ctx, projectID, from, to, env)
-	if err != nil {
-		mapServiceError(w, err, "handleDashboard.uniqueSessionCount")
+	if recordOnErr(err, "handleDashboard.uniqueSessionCount") {
 		return
 	}
 
 	topPages, err := s.events.TopPages(ctx, projectID, from, to, 10, env)
-	if err != nil {
-		mapServiceError(w, err, "handleDashboard.topPages")
+	if recordOnErr(err, "handleDashboard.topPages") {
 		return
 	}
 
 	topReferrers, err := s.events.TopReferrers(ctx, projectID, from, to, 10, env)
-	if err != nil {
-		mapServiceError(w, err, "handleDashboard.topReferrers")
+	if recordOnErr(err, "handleDashboard.topReferrers") {
 		return
 	}
 
@@ -80,50 +88,42 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	} else {
 		timeSeries, err = s.events.DailyEventCounts(ctx, projectID, from, to, env)
 	}
-	if err != nil {
-		mapServiceError(w, err, "handleDashboard.eventCounts")
+	if recordOnErr(err, "handleDashboard.eventCounts") {
 		return
 	}
 
 	sessionTimeSeries, err := s.events.DailyUniqueSessions(ctx, projectID, from, to, env)
-	if err != nil {
-		mapServiceError(w, err, "handleDashboard.dailyUniqueSessions")
+	if recordOnErr(err, "handleDashboard.dailyUniqueSessions") {
 		return
 	}
 
 	topBrowsers, err := s.events.TopBrowsers(ctx, projectID, from, to, 5, env)
-	if err != nil {
-		mapServiceError(w, err, "handleDashboard.topBrowsers")
+	if recordOnErr(err, "handleDashboard.topBrowsers") {
 		return
 	}
 
 	deviceTypes, err := s.events.TopDeviceTypes(ctx, projectID, from, to, env)
-	if err != nil {
-		mapServiceError(w, err, "handleDashboard.topDeviceTypes")
+	if recordOnErr(err, "handleDashboard.topDeviceTypes") {
 		return
 	}
 
 	topEventNames, err := s.events.TopEventNames(ctx, projectID, from, to, 10, env)
-	if err != nil {
-		mapServiceError(w, err, "handleDashboard.topEventNames")
+	if recordOnErr(err, "handleDashboard.topEventNames") {
 		return
 	}
 
 	topUTMSources, err := s.events.TopUTMSources(ctx, projectID, from, to, 5, env)
-	if err != nil {
-		mapServiceError(w, err, "handleDashboard.topUTMSources")
+	if recordOnErr(err, "handleDashboard.topUTMSources") {
 		return
 	}
 
 	bounceRate, err := s.events.BounceRate(ctx, projectID, from, to, env)
-	if err != nil {
-		mapServiceError(w, err, "handleDashboard.bounceRate")
+	if recordOnErr(err, "handleDashboard.bounceRate") {
 		return
 	}
 
 	avgEventsPerSession, err := s.events.AvgEventsPerSession(ctx, projectID, from, to, env)
-	if err != nil {
-		mapServiceError(w, err, "handleDashboard.avgEventsPerSession")
+	if recordOnErr(err, "handleDashboard.avgEventsPerSession") {
 		return
 	}
 

--- a/internal/api/flags.go
+++ b/internal/api/flags.go
@@ -268,6 +268,21 @@ func (s *Server) evaluateFlagInProject(w http.ResponseWriter, r *http.Request, p
 		if strings.Contains(err.Error(), "flag not found") {
 			errorCode = "FLAG_NOT_FOUND"
 		}
+		// FLAG_NOT_FOUND is normal client behaviour; everything else (DB
+		// failure, JSON corruption) is a real server problem that was
+		// previously hidden behind a 200 OK + reason=ERROR. Surface those.
+		if errorCode == "FLAG_NOT_FOUND" {
+			slog.DebugContext(r.Context(), "flag evaluate: not found",
+				"project_id", projectID, "flag_key", body.FlagKey)
+		} else {
+			slog.ErrorContext(r.Context(), "flag evaluate failed",
+				"err", err, "handled", false,
+				"project_id", projectID,
+				"flag_key", body.FlagKey,
+				"error_code", errorCode,
+				"request_id", RequestIDFromContext(r.Context()),
+			)
+		}
 		writeJSON(w, http.StatusOK, map[string]any{
 			"value":      body.DefaultValue,
 			"variant":    "",

--- a/internal/api/funnels.go
+++ b/internal/api/funnels.go
@@ -223,7 +223,13 @@ func (s *Server) handleFunnelAnalysis(w http.ResponseWriter, r *http.Request) {
 	var segRules []repository.SegmentRule
 	if segID := r.URL.Query().Get("segment_id"); segID != "" && s.segments != nil {
 		stored, err := s.segments.GetSegment(r.Context(), segID)
-		if err == nil && stored.ProjectID == projectID {
+		if err != nil {
+			// Non-fatal: analyse without the segment filter. Warn so a
+			// broken UI dropdown (e.g. stale segment_id) is visible.
+			slog.WarnContext(r.Context(), "funnel: segment lookup failed",
+				"err", err, "handled", true,
+				"segment_id", segID, "project_id", projectID)
+		} else if stored.ProjectID == projectID {
 			segRules = stored.Rules
 		}
 	}
@@ -236,6 +242,7 @@ func (s *Server) handleFunnelAnalysis(w http.ResponseWriter, r *http.Request) {
 
 	results, err := s.funnels.AnalyzeFunnel(ctx, funnel, from, to, seg, segRules...)
 	if err != nil {
+		tracing.RecordError(span, err)
 		mapServiceError(w, err, "handleFunnelAnalysis")
 		return
 	}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -256,7 +256,11 @@ func requestLogger(next http.Handler) http.Handler {
 		}
 
 		elapsed := time.Since(start)
-		slog.InfoContext(ctx, "request",
+		// Level the access log by status so 5xx (and unexpected 4xx like 413/
+		// 429 on hot ingest paths) surface through the slog -> BugBarn pipe.
+		// Without this, the per-handler bug from the recording-chunk 413
+		// incident stays invisible at the middleware layer.
+		attrs := []any{
 			"request_id", requestID,
 			"method", r.Method,
 			"path", r.URL.Path,
@@ -265,7 +269,24 @@ func requestLogger(next http.Handler) http.Handler {
 			"latency_ms", elapsed.Milliseconds(),
 			"remote_addr", r.RemoteAddr,
 			"user_agent", ua,
-		)
+		}
+		switch {
+		case status >= 500:
+			// handled=false: an unexpected server failure that should
+			// trigger an alert. The per-handler slog.Error already gave
+			// the root cause; this is the request envelope.
+			attrs = append(attrs, "handled", false)
+			slog.ErrorContext(ctx, "request failed", attrs...)
+		case status == http.StatusRequestEntityTooLarge,
+			status == http.StatusTooManyRequests:
+			// 413/429 used to silently swallow real failures (the
+			// recording-chunk MaxBytesReader bug). Warn surfaces them
+			// to BugBarn without flooding it on every 4xx.
+			attrs = append(attrs, "handled", true)
+			slog.WarnContext(ctx, "request rejected", attrs...)
+		default:
+			slog.InfoContext(ctx, "request", attrs...)
+		}
 
 		statusStr := strconv.Itoa(status)
 		metrics.HTTPRequests.WithLabelValues(r.Method, r.URL.Path, statusStr).Inc()

--- a/internal/api/oidc_confidential.go
+++ b/internal/api/oidc_confidential.go
@@ -79,6 +79,9 @@ func (s *Server) handleOIDCConfidentialCallback(w http.ResponseWriter, r *http.R
 		return
 	}
 	if s.sessionManager == nil {
+		// Misconfiguration: OIDC enabled but no session manager wired.
+		slog.ErrorContext(r.Context(), "oidc: session manager not configured",
+			"handled", false, "sub", claims.Subject)
 		jsonError(w, "session unavailable", http.StatusServiceUnavailable)
 		return
 	}
@@ -88,6 +91,8 @@ func (s *Server) handleOIDCConfidentialCallback(w http.ResponseWriter, r *http.R
 	}
 	token, expires, err := s.sessionManager.Create(username)
 	if err != nil {
+		slog.ErrorContext(r.Context(), "oidc: failed to create session",
+			"err", err, "handled", false, "sub", claims.Subject, "username", username)
 		jsonError(w, "session unavailable", http.StatusServiceUnavailable)
 		return
 	}
@@ -129,6 +134,12 @@ func oidcConfShortLivedCookie(name, value string, secure bool) *http.Cookie {
 
 func oidcConfRandomToken() string {
 	buf := make([]byte, 24)
-	_, _ = rand.Read(buf)
+	if _, err := rand.Read(buf); err != nil {
+		// crypto/rand failure here would mean OIDC state/nonce tokens lose
+		// entropy. Log loudly so it surfaces in BugBarn — the caller still
+		// gets a token, but security relies on this not happening silently.
+		slog.Error("oidc: crypto/rand failed generating state/nonce",
+			"err", err, "handled", false)
+	}
 	return base64.RawURLEncoding.EncodeToString(buf)
 }

--- a/internal/api/recordings.go
+++ b/internal/api/recordings.go
@@ -28,6 +28,12 @@ func (s *Server) handleIngestRecordingChunk(w http.ResponseWriter, r *http.Reque
 
 	projectID, _, ok := s.ingest.APIKeyProjectScope(r)
 	if !ok {
+		// Warn rather than Error: invalid API keys happen routinely (rotated
+		// keys, misconfigured clients) but a sudden surge points at trouble.
+		slog.WarnContext(r.Context(), "recording chunk: unauthorized",
+			"user_agent", r.Header.Get("User-Agent"),
+			"request_id", RequestIDFromContext(r.Context()),
+		)
 		jsonError(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
@@ -43,9 +49,28 @@ func (s *Server) handleIngestRecordingChunk(w http.ResponseWriter, r *http.Reque
 	if err := readJSON(r, &chunk); err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
+			// Surface 413s to BugBarn — this used to be the silent failure
+			// mode where the SDK retried/abandoned and we never knew.
+			slog.ErrorContext(r.Context(), "recording chunk rejected: body too large",
+				"err", err, "handled", false,
+				"project_id", projectID,
+				"content_length", r.ContentLength,
+				"limit_bytes", int64(maxRecordingChunkBytes),
+				"user_agent", r.Header.Get("User-Agent"),
+				"request_id", RequestIDFromContext(r.Context()),
+			)
 			jsonError(w, "recording chunk too large", http.StatusRequestEntityTooLarge)
 			return
 		}
+		// JSON parse errors on this endpoint are unusual (the SDK is the only
+		// producer); log them so we can spot SDK regressions.
+		slog.WarnContext(r.Context(), "recording chunk rejected: invalid json",
+			"err", err, "handled", true,
+			"project_id", projectID,
+			"content_length", r.ContentLength,
+			"user_agent", r.Header.Get("User-Agent"),
+			"request_id", RequestIDFromContext(r.Context()),
+		)
 		jsonError(w, "invalid json", http.StatusBadRequest)
 		return
 	}

--- a/internal/ingest/handler.go
+++ b/internal/ingest/handler.go
@@ -112,6 +112,13 @@ func (h *Handler) APIKeyProjectScope(r *http.Request) (projectID string, scope s
 // ServeHTTP handles POST /api/v1/events.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if h == nil || h.auth == nil || h.spool == nil {
+		// Service mis-configuration: a 503 here means the process is up but
+		// ingest is not wired correctly. Surface to BugBarn.
+		slog.ErrorContext(r.Context(), "ingest unavailable: handler not initialised",
+			"handled", false,
+			"has_auth", h != nil && h.auth != nil,
+			"has_spool", h != nil && h.spool != nil,
+		)
 		jsonErr(w, "ingest unavailable", http.StatusServiceUnavailable)
 		return
 	}
@@ -126,6 +133,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	projectID, _, ok := h.APIKeyProjectScope(r)
 	if !ok {
+		// Routine condition (rotated keys, misconfigured clients) — Warn so
+		// a sudden spike is visible in BugBarn without flooding it.
+		slog.WarnContext(r.Context(), "ingest: unauthorized",
+			"user_agent", r.Header.Get("User-Agent"),
+		)
 		jsonErr(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
@@ -136,9 +148,22 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
+			// 413s used to be silent on the recording-chunk endpoint and
+			// caused weeks of lost data. Surface them everywhere.
+			slog.ErrorContext(r.Context(), "ingest body too large",
+				"err", err, "handled", false,
+				"project_id", projectID,
+				"content_length", r.ContentLength,
+				"limit_bytes", h.maxBodyBytes,
+				"user_agent", r.Header.Get("User-Agent"),
+			)
 			jsonErr(w, "request body too large", http.StatusRequestEntityTooLarge)
 			return
 		}
+		slog.WarnContext(r.Context(), "ingest: unable to read body",
+			"err", err, "handled", true,
+			"project_id", projectID,
+		)
 		jsonErr(w, "unable to read request body", http.StatusBadRequest)
 		return
 	}
@@ -172,6 +197,16 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case h.queue <- record:
 		metrics.EventsIngested.Inc()
 	default:
+		// Queue saturation is a real operational signal — events get dropped
+		// silently on the client side after a 429, so make it visible.
+		queueErr := errors.New("ingest in-memory queue is full")
+		tracing.RecordError(span, queueErr)
+		slog.ErrorContext(r.Context(), "ingest queue full, dropping event",
+			"err", queueErr, "handled", false,
+			"project_id", projectID,
+			"ingest_id", ingestID,
+			"queue_cap", cap(h.queue),
+		)
 		w.Header().Set("Retry-After", "1")
 		jsonErr(w, "ingest queue full", http.StatusTooManyRequests)
 		return
@@ -223,6 +258,10 @@ func extractClientIP(r *http.Request) string {
 func generateIngestID() string {
 	var raw [12]byte
 	if _, err := rand.Read(raw[:]); err != nil {
+		// crypto/rand failing is a system-level problem (no entropy source).
+		// Log it so we know — the timestamp fallback keeps ingest working.
+		slog.Error("crypto/rand failed; using timestamp fallback for ingest id",
+			"err", err, "handled", true)
 		return time.Now().UTC().Format("20060102T150405.000000000Z") + "-fallback"
 	}
 	return hex.EncodeToString(raw[:])

--- a/internal/service/flags.go
+++ b/internal/service/flags.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strings"
 	"time"
@@ -155,14 +156,20 @@ func (svc *FlagService) EvaluateFlag(ctx context.Context, projectID, flagKey str
 			attribute.String("flag.reason", "TARGETING_MATCH"),
 			attribute.String("flag.rule_name", ruleName),
 		)
-		_ = svc.store.RecordEvaluation(ctx, repository.FlagEvaluation{
+		if recErr := svc.store.RecordEvaluation(ctx, repository.FlagEvaluation{
 			FlagID:      flag.ID,
 			ProjectID:   flag.ProjectID,
 			Variant:     variant,
 			ContextHash: hashContext(targetingKey),
 			SessionID:   sessionID,
 			ContextKeys: ctxKeys,
-		})
+		}); recErr != nil {
+			// Best-effort: an evaluation already happened, we just lost the
+			// analytics row. Warn so silent storage failures surface.
+			slog.WarnContext(ctx, "flag: record evaluation (targeting)",
+				"err", recErr, "handled", true,
+				"flag_id", flag.ID, "project_id", flag.ProjectID)
+		}
 		return FlagEvalResult{
 			Value:        val,
 			Variant:      variant,
@@ -180,14 +187,18 @@ func (svc *FlagService) EvaluateFlag(ctx context.Context, projectID, flagKey str
 		attribute.String("flag.reason", "SPLIT"),
 	)
 
-	_ = svc.store.RecordEvaluation(ctx, repository.FlagEvaluation{
+	if recErr := svc.store.RecordEvaluation(ctx, repository.FlagEvaluation{
 		FlagID:      flag.ID,
 		ProjectID:   flag.ProjectID,
 		Variant:     variant,
 		ContextHash: hashContext(targetingKey),
 		SessionID:   sessionID,
 		ContextKeys: ctxKeys,
-	})
+	}); recErr != nil {
+		slog.WarnContext(ctx, "flag: record evaluation (split)",
+			"err", recErr, "handled", true,
+			"flag_id", flag.ID, "project_id", flag.ProjectID)
+	}
 
 	return FlagEvalResult{
 		Value:   val,
@@ -214,6 +225,7 @@ func (svc *FlagService) AnalyzeFlag(ctx context.Context, flag repository.Feature
 	if flag.ConversionEvent != "" {
 		conversions, err = svc.store.CountConversionsByVariant(ctx, flag.ID, flag.ConversionEvent, flag.ProjectID, from, to)
 		if err != nil {
+			tracing.RecordError(span, err)
 			return nil, fmt.Errorf("count conversions: %w", err)
 		}
 	}

--- a/internal/service/recordings.go
+++ b/internal/service/recordings.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -94,7 +95,14 @@ func (svc *RecordingService) PurgeOldRecordings(ctx context.Context, retentionDa
 	for _, rec := range recs {
 		for i := 0; i < rec.ChunkCount; i++ {
 			key := chunkKey(rec.ProjectID, rec.ID, i)
-			_ = svc.storage.Delete(ctx, key)
+			if delErr := svc.storage.Delete(ctx, key); delErr != nil {
+				// Don't abort the purge — a failed chunk delete leaves an
+				// R2 orphan but the row will be removed below. Warn so we
+				// can correlate orphans with storage outages later.
+				slog.WarnContext(ctx, "recordings: purge chunk delete failed",
+					"err", delErr, "handled", true,
+					"recording_id", rec.ID, "chunk_index", i, "key", key)
+			}
 		}
 		if err := svc.store.DeleteRecording(ctx, rec.ID); err != nil {
 			return fmt.Errorf("recordings: delete row %s: %w", rec.ID, err)

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -105,7 +105,14 @@ func Middleware(next http.Handler) http.Handler {
 		}
 		span.SetAttributes(semconv.HTTPStatusCode(rw.status))
 		if rw.status >= 500 {
-			span.SetStatus(codes.Error, fmt.Sprintf("HTTP %d", rw.status))
+			// Record an error event in addition to the status so SpanBarn
+			// surfaces it as an exception (handled=false 5xx) rather than
+			// a silently-error-statused span. Per-handler code is expected
+			// to call span.RecordError on the underlying err; this is the
+			// envelope-level fallback for handlers that don't.
+			err := fmt.Errorf("HTTP %d", rw.status)
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
 		}
 	})
 }

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -511,7 +511,7 @@ export class FunnelBarnClient {
     });
     const interval = chunkMs ?? 10_000;
     this.recordingTimer = setInterval(() => { this.flushRecordingChunk().catch(() => {}); }, interval);
-    window.addEventListener('beforeunload', () => { this.flushRecordingChunk().catch(() => {}); });
+    window.addEventListener('beforeunload', () => { this.flushRecordingChunk(true).catch(() => {}); });
   }
 
   private stopRecording(): void {
@@ -590,14 +590,14 @@ export class FunnelBarnClient {
     return true; // default: capture
   }
 
-  private async flushRecordingChunk(): Promise<void> {
+  private async flushRecordingChunk(useKeepalive = false): Promise<void> {
     if (!this.shouldRecordCurrentPage()) {
-      // Discard buffered events for this page — don't send them.
       this.rrwebBuffer = [];
       return;
     }
     const events = this.rrwebBuffer.splice(0);
     if (!events.length) return;
+    const chunkIndex = this.recordingChunkIndex++;
     try {
       await fetch(`${this.endpoint}/api/v1/recordings/chunk`, {
         method: 'POST',
@@ -608,16 +608,22 @@ export class FunnelBarnClient {
         body: JSON.stringify({
           recording_id: this.recordingId,
           session_id: this.getOrCreateSessionID(),
-          chunk_index: this.recordingChunkIndex++,
+          chunk_index: chunkIndex,
           events,
           started_at: this.recordingStartedAt,
           duration_ms: Date.now() - this.recordingStartMs,
           page_url: typeof window !== 'undefined' ? window.location.href : undefined,
         }),
-        keepalive: true,
+        // keepalive has a 64 KB body limit per the Fetch spec — rrweb full
+        // snapshots are 1-5 MB so we only use it for the final unload flush
+        // where the body is a small incremental tail.
+        keepalive: useKeepalive,
       });
     } catch {
-      // best-effort
+      // On failure, push events back to the front so the next flush retries
+      // them — most importantly this preserves the full snapshot (chunk 0).
+      this.rrwebBuffer.unshift(...events);
+      this.recordingChunkIndex--;
     }
   }
 


### PR DESCRIPTION
## Root cause

The Fetch spec imposes a hard **64 KB body limit on `keepalive: true` requests**. The rrweb full snapshot (type-2 event) in chunk 0 is 1–5 MB. The browser threw a `TypeError` before the request was even sent, the `catch {}` swallowed it silently, and `recordingChunkIndex` had already been post-incremented — so the snapshot was permanently lost and every subsequent recording started at `first_chunk_index >= 1` with only incremental events.

This explains why PR #163's backend body-cap fix (256 KiB → 10 MiB) was necessary but not sufficient.

## Changes

**`sdks/js/src/index.ts`**

- `flushRecordingChunk(useKeepalive = false)` — `keepalive` is now opt-in. The 10-second timer calls it with the default `false`. Only the `beforeunload` listener passes `true`, where the body is a small incremental tail safely under 64 KB.
- On `fetch` failure: events are pushed back to the front of `rrwebBuffer` and `recordingChunkIndex` is decremented, so the next timer tick retries the same chunk index instead of skipping it forever.