### PR TITLE
feat(recording): player controls + cross-page recording continuity

### DIFF
--- a/internal/api/dashboard.go
+++ b/internal/api/dashboard.go
@@ -50,27 +50,35 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	)
 	defer span.End()
 
+	// recordOnErr surfaces an error onto the span and falls through to the
+	// standard service-error mapper. Without span.RecordError, trace search
+	// in SpanBarn lists these spans as "ok" even though the request 5xx'd.
+	recordOnErr := func(err error, op string) bool {
+		if err == nil {
+			return false
+		}
+		tracing.RecordError(span, err)
+		mapServiceError(w, err, op)
+		return true
+	}
+
 	totalEvents, err := s.events.CountEvents(ctx, projectID, from, to, env)
-	if err != nil {
-		mapServiceError(w, err, "handleDashboard.countEvents")
+	if recordOnErr(err, "handleDashboard.countEvents") {
 		return
 	}
 
 	uniqueSessions, err := s.events.UniqueSessionCount(ctx, projectID, from, to, env)
-	if err != nil {
-		mapServiceError(w, err, "handleDashboard.uniqueSessionCount")
+	if recordOnErr(err, "handleDashboard.uniqueSessionCount") {
 		return
 	}
 
 	topPages, err := s.events.TopPages(ctx, projectID, from, to, 10, env)
-	if err != nil {
-		mapServiceError(w, err, "handleDashboard.topPages")
+	if recordOnErr(err, "handleDashboard.topPages") {
 		return
 	}
 
 	topReferrers, err := s.events.TopReferrers(ctx, projectID, from, to, 10, env)
-	if err != nil {
-		mapServiceError(w, err, "handleDashboard.topReferrers")
+	if recordOnErr(err, "handleDashboard.topReferrers") {
 		return
 	}
 
@@ -80,50 +88,42 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	} else {
 		timeSeries, err = s.events.DailyEventCounts(ctx, projectID, from, to, env)
 	}
-	if err != nil {
-		mapServiceError(w, err, "handleDashboard.eventCounts")
+	if recordOnErr(err, "handleDashboard.eventCounts") {
 		return
 	}
 
 	sessionTimeSeries, err := s.events.DailyUniqueSessions(ctx, projectID, from, to, env)
-	if err != nil {
-		mapServiceError(w, err, "handleDashboard.dailyUniqueSessions")
+	if recordOnErr(err, "handleDashboard.dailyUniqueSessions") {
 		return
 	}
 
 	topBrowsers, err := s.events.TopBrowsers(ctx, projectID, from, to, 5, env)
-	if err != nil {
-		mapServiceError(w, err, "handleDashboard.topBrowsers")
+	if recordOnErr(err, "handleDashboard.topBrowsers") {
 		return
 	}
 
 	deviceTypes, err := s.events.TopDeviceTypes(ctx, projectID, from, to, env)
-	if err != nil {
-		mapServiceError(w, err, "handleDashboard.topDeviceTypes")
+	if recordOnErr(err, "handleDashboard.topDeviceTypes") {
 		return
 	}
 
 	topEventNames, err := s.events.TopEventNames(ctx, projectID, from, to, 10, env)
-	if err != nil {
-		mapServiceError(w, err, "handleDashboard.topEventNames")
+	if recordOnErr(err, "handleDashboard.topEventNames") {
 		return
 	}
 
 	topUTMSources, err := s.events.TopUTMSources(ctx, projectID, from, to, 5, env)
-	if err != nil {
-		mapServiceError(w, err, "handleDashboard.topUTMSources")
+	if recordOnErr(err, "handleDashboard.topUTMSources") {
 		return
 	}
 
 	bounceRate, err := s.events.BounceRate(ctx, projectID, from, to, env)
-	if err != nil {
-		mapServiceError(w, err, "handleDashboard.bounceRate")
+	if recordOnErr(err, "handleDashboard.bounceRate") {
 		return
 	}
 
 	avgEventsPerSession, err := s.events.AvgEventsPerSession(ctx, projectID, from, to, env)
-	if err != nil {
-		mapServiceError(w, err, "handleDashboard.avgEventsPerSession")
+	if recordOnErr(err, "handleDashboard.avgEventsPerSession") {
 		return
 	}
 

--- a/internal/api/flags.go
+++ b/internal/api/flags.go
@@ -268,6 +268,21 @@ func (s *Server) evaluateFlagInProject(w http.ResponseWriter, r *http.Request, p
 		if strings.Contains(err.Error(), "flag not found") {
 			errorCode = "FLAG_NOT_FOUND"
 		}
+		// FLAG_NOT_FOUND is normal client behaviour; everything else (DB
+		// failure, JSON corruption) is a real server problem that was
+		// previously hidden behind a 200 OK + reason=ERROR. Surface those.
+		if errorCode == "FLAG_NOT_FOUND" {
+			slog.DebugContext(r.Context(), "flag evaluate: not found",
+				"project_id", projectID, "flag_key", body.FlagKey)
+		} else {
+			slog.ErrorContext(r.Context(), "flag evaluate failed",
+				"err", err, "handled", false,
+				"project_id", projectID,
+				"flag_key", body.FlagKey,
+				"error_code", errorCode,
+				"request_id", RequestIDFromContext(r.Context()),
+			)
+		}
 		writeJSON(w, http.StatusOK, map[string]any{
 			"value":      body.DefaultValue,
 			"variant":    "",

--- a/internal/api/funnels.go
+++ b/internal/api/funnels.go
@@ -223,7 +223,13 @@ func (s *Server) handleFunnelAnalysis(w http.ResponseWriter, r *http.Request) {
 	var segRules []repository.SegmentRule
 	if segID := r.URL.Query().Get("segment_id"); segID != "" && s.segments != nil {
 		stored, err := s.segments.GetSegment(r.Context(), segID)
-		if err == nil && stored.ProjectID == projectID {
+		if err != nil {
+			// Non-fatal: analyse without the segment filter. Warn so a
+			// broken UI dropdown (e.g. stale segment_id) is visible.
+			slog.WarnContext(r.Context(), "funnel: segment lookup failed",
+				"err", err, "handled", true,
+				"segment_id", segID, "project_id", projectID)
+		} else if stored.ProjectID == projectID {
 			segRules = stored.Rules
 		}
 	}
@@ -236,6 +242,7 @@ func (s *Server) handleFunnelAnalysis(w http.ResponseWriter, r *http.Request) {
 
 	results, err := s.funnels.AnalyzeFunnel(ctx, funnel, from, to, seg, segRules...)
 	if err != nil {
+		tracing.RecordError(span, err)
 		mapServiceError(w, err, "handleFunnelAnalysis")
 		return
 	}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -256,7 +256,11 @@ func requestLogger(next http.Handler) http.Handler {
 		}
 
 		elapsed := time.Since(start)
-		slog.InfoContext(ctx, "request",
+		// Level the access log by status so 5xx (and unexpected 4xx like 413/
+		// 429 on hot ingest paths) surface through the slog -> BugBarn pipe.
+		// Without this, the per-handler bug from the recording-chunk 413
+		// incident stays invisible at the middleware layer.
+		attrs := []any{
 			"request_id", requestID,
 			"method", r.Method,
 			"path", r.URL.Path,
@@ -265,7 +269,24 @@ func requestLogger(next http.Handler) http.Handler {
 			"latency_ms", elapsed.Milliseconds(),
 			"remote_addr", r.RemoteAddr,
 			"user_agent", ua,
-		)
+		}
+		switch {
+		case status >= 500:
+			// handled=false: an unexpected server failure that should
+			// trigger an alert. The per-handler slog.Error already gave
+			// the root cause; this is the request envelope.
+			attrs = append(attrs, "handled", false)
+			slog.ErrorContext(ctx, "request failed", attrs...)
+		case status == http.StatusRequestEntityTooLarge,
+			status == http.StatusTooManyRequests:
+			// 413/429 used to silently swallow real failures (the
+			// recording-chunk MaxBytesReader bug). Warn surfaces them
+			// to BugBarn without flooding it on every 4xx.
+			attrs = append(attrs, "handled", true)
+			slog.WarnContext(ctx, "request rejected", attrs...)
+		default:
+			slog.InfoContext(ctx, "request", attrs...)
+		}
 
 		statusStr := strconv.Itoa(status)
 		metrics.HTTPRequests.WithLabelValues(r.Method, r.URL.Path, statusStr).Inc()

--- a/internal/api/oidc_confidential.go
+++ b/internal/api/oidc_confidential.go
@@ -79,6 +79,9 @@ func (s *Server) handleOIDCConfidentialCallback(w http.ResponseWriter, r *http.R
 		return
 	}
 	if s.sessionManager == nil {
+		// Misconfiguration: OIDC enabled but no session manager wired.
+		slog.ErrorContext(r.Context(), "oidc: session manager not configured",
+			"handled", false, "sub", claims.Subject)
 		jsonError(w, "session unavailable", http.StatusServiceUnavailable)
 		return
 	}
@@ -88,6 +91,8 @@ func (s *Server) handleOIDCConfidentialCallback(w http.ResponseWriter, r *http.R
 	}
 	token, expires, err := s.sessionManager.Create(username)
 	if err != nil {
+		slog.ErrorContext(r.Context(), "oidc: failed to create session",
+			"err", err, "handled", false, "sub", claims.Subject, "username", username)
 		jsonError(w, "session unavailable", http.StatusServiceUnavailable)
 		return
 	}
@@ -129,6 +134,12 @@ func oidcConfShortLivedCookie(name, value string, secure bool) *http.Cookie {
 
 func oidcConfRandomToken() string {
 	buf := make([]byte, 24)
-	_, _ = rand.Read(buf)
+	if _, err := rand.Read(buf); err != nil {
+		// crypto/rand failure here would mean OIDC state/nonce tokens lose
+		// entropy. Log loudly so it surfaces in BugBarn — the caller still
+		// gets a token, but security relies on this not happening silently.
+		slog.Error("oidc: crypto/rand failed generating state/nonce",
+			"err", err, "handled", false)
+	}
 	return base64.RawURLEncoding.EncodeToString(buf)
 }

--- a/internal/api/recordings.go
+++ b/internal/api/recordings.go
@@ -28,6 +28,12 @@ func (s *Server) handleIngestRecordingChunk(w http.ResponseWriter, r *http.Reque
 
 	projectID, _, ok := s.ingest.APIKeyProjectScope(r)
 	if !ok {
+		// Warn rather than Error: invalid API keys happen routinely (rotated
+		// keys, misconfigured clients) but a sudden surge points at trouble.
+		slog.WarnContext(r.Context(), "recording chunk: unauthorized",
+			"user_agent", r.Header.Get("User-Agent"),
+			"request_id", RequestIDFromContext(r.Context()),
+		)
 		jsonError(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
@@ -43,9 +49,28 @@ func (s *Server) handleIngestRecordingChunk(w http.ResponseWriter, r *http.Reque
 	if err := readJSON(r, &chunk); err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
+			// Surface 413s to BugBarn — this used to be the silent failure
+			// mode where the SDK retried/abandoned and we never knew.
+			slog.ErrorContext(r.Context(), "recording chunk rejected: body too large",
+				"err", err, "handled", false,
+				"project_id", projectID,
+				"content_length", r.ContentLength,
+				"limit_bytes", int64(maxRecordingChunkBytes),
+				"user_agent", r.Header.Get("User-Agent"),
+				"request_id", RequestIDFromContext(r.Context()),
+			)
 			jsonError(w, "recording chunk too large", http.StatusRequestEntityTooLarge)
 			return
 		}
+		// JSON parse errors on this endpoint are unusual (the SDK is the only
+		// producer); log them so we can spot SDK regressions.
+		slog.WarnContext(r.Context(), "recording chunk rejected: invalid json",
+			"err", err, "handled", true,
+			"project_id", projectID,
+			"content_length", r.ContentLength,
+			"user_agent", r.Header.Get("User-Agent"),
+			"request_id", RequestIDFromContext(r.Context()),
+		)
 		jsonError(w, "invalid json", http.StatusBadRequest)
 		return
 	}

--- a/internal/ingest/handler.go
+++ b/internal/ingest/handler.go
@@ -112,6 +112,13 @@ func (h *Handler) APIKeyProjectScope(r *http.Request) (projectID string, scope s
 // ServeHTTP handles POST /api/v1/events.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if h == nil || h.auth == nil || h.spool == nil {
+		// Service mis-configuration: a 503 here means the process is up but
+		// ingest is not wired correctly. Surface to BugBarn.
+		slog.ErrorContext(r.Context(), "ingest unavailable: handler not initialised",
+			"handled", false,
+			"has_auth", h != nil && h.auth != nil,
+			"has_spool", h != nil && h.spool != nil,
+		)
 		jsonErr(w, "ingest unavailable", http.StatusServiceUnavailable)
 		return
 	}
@@ -126,6 +133,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	projectID, _, ok := h.APIKeyProjectScope(r)
 	if !ok {
+		// Routine condition (rotated keys, misconfigured clients) — Warn so
+		// a sudden spike is visible in BugBarn without flooding it.
+		slog.WarnContext(r.Context(), "ingest: unauthorized",
+			"user_agent", r.Header.Get("User-Agent"),
+		)
 		jsonErr(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
@@ -136,9 +148,22 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
+			// 413s used to be silent on the recording-chunk endpoint and
+			// caused weeks of lost data. Surface them everywhere.
+			slog.ErrorContext(r.Context(), "ingest body too large",
+				"err", err, "handled", false,
+				"project_id", projectID,
+				"content_length", r.ContentLength,
+				"limit_bytes", h.maxBodyBytes,
+				"user_agent", r.Header.Get("User-Agent"),
+			)
 			jsonErr(w, "request body too large", http.StatusRequestEntityTooLarge)
 			return
 		}
+		slog.WarnContext(r.Context(), "ingest: unable to read body",
+			"err", err, "handled", true,
+			"project_id", projectID,
+		)
 		jsonErr(w, "unable to read request body", http.StatusBadRequest)
 		return
 	}
@@ -172,6 +197,16 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case h.queue <- record:
 		metrics.EventsIngested.Inc()
 	default:
+		// Queue saturation is a real operational signal — events get dropped
+		// silently on the client side after a 429, so make it visible.
+		queueErr := errors.New("ingest in-memory queue is full")
+		tracing.RecordError(span, queueErr)
+		slog.ErrorContext(r.Context(), "ingest queue full, dropping event",
+			"err", queueErr, "handled", false,
+			"project_id", projectID,
+			"ingest_id", ingestID,
+			"queue_cap", cap(h.queue),
+		)
 		w.Header().Set("Retry-After", "1")
 		jsonErr(w, "ingest queue full", http.StatusTooManyRequests)
 		return
@@ -223,6 +258,10 @@ func extractClientIP(r *http.Request) string {
 func generateIngestID() string {
 	var raw [12]byte
 	if _, err := rand.Read(raw[:]); err != nil {
+		// crypto/rand failing is a system-level problem (no entropy source).
+		// Log it so we know — the timestamp fallback keeps ingest working.
+		slog.Error("crypto/rand failed; using timestamp fallback for ingest id",
+			"err", err, "handled", true)
 		return time.Now().UTC().Format("20060102T150405.000000000Z") + "-fallback"
 	}
 	return hex.EncodeToString(raw[:])

--- a/internal/service/flags.go
+++ b/internal/service/flags.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strings"
 	"time"
@@ -155,14 +156,20 @@ func (svc *FlagService) EvaluateFlag(ctx context.Context, projectID, flagKey str
 			attribute.String("flag.reason", "TARGETING_MATCH"),
 			attribute.String("flag.rule_name", ruleName),
 		)
-		_ = svc.store.RecordEvaluation(ctx, repository.FlagEvaluation{
+		if recErr := svc.store.RecordEvaluation(ctx, repository.FlagEvaluation{
 			FlagID:      flag.ID,
 			ProjectID:   flag.ProjectID,
 			Variant:     variant,
 			ContextHash: hashContext(targetingKey),
 			SessionID:   sessionID,
 			ContextKeys: ctxKeys,
-		})
+		}); recErr != nil {
+			// Best-effort: an evaluation already happened, we just lost the
+			// analytics row. Warn so silent storage failures surface.
+			slog.WarnContext(ctx, "flag: record evaluation (targeting)",
+				"err", recErr, "handled", true,
+				"flag_id", flag.ID, "project_id", flag.ProjectID)
+		}
 		return FlagEvalResult{
 			Value:        val,
 			Variant:      variant,
@@ -180,14 +187,18 @@ func (svc *FlagService) EvaluateFlag(ctx context.Context, projectID, flagKey str
 		attribute.String("flag.reason", "SPLIT"),
 	)
 
-	_ = svc.store.RecordEvaluation(ctx, repository.FlagEvaluation{
+	if recErr := svc.store.RecordEvaluation(ctx, repository.FlagEvaluation{
 		FlagID:      flag.ID,
 		ProjectID:   flag.ProjectID,
 		Variant:     variant,
 		ContextHash: hashContext(targetingKey),
 		SessionID:   sessionID,
 		ContextKeys: ctxKeys,
-	})
+	}); recErr != nil {
+		slog.WarnContext(ctx, "flag: record evaluation (split)",
+			"err", recErr, "handled", true,
+			"flag_id", flag.ID, "project_id", flag.ProjectID)
+	}
 
 	return FlagEvalResult{
 		Value:   val,
@@ -214,6 +225,7 @@ func (svc *FlagService) AnalyzeFlag(ctx context.Context, flag repository.Feature
 	if flag.ConversionEvent != "" {
 		conversions, err = svc.store.CountConversionsByVariant(ctx, flag.ID, flag.ConversionEvent, flag.ProjectID, from, to)
 		if err != nil {
+			tracing.RecordError(span, err)
 			return nil, fmt.Errorf("count conversions: %w", err)
 		}
 	}

--- a/internal/service/recordings.go
+++ b/internal/service/recordings.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -94,7 +95,14 @@ func (svc *RecordingService) PurgeOldRecordings(ctx context.Context, retentionDa
 	for _, rec := range recs {
 		for i := 0; i < rec.ChunkCount; i++ {
 			key := chunkKey(rec.ProjectID, rec.ID, i)
-			_ = svc.storage.Delete(ctx, key)
+			if delErr := svc.storage.Delete(ctx, key); delErr != nil {
+				// Don't abort the purge — a failed chunk delete leaves an
+				// R2 orphan but the row will be removed below. Warn so we
+				// can correlate orphans with storage outages later.
+				slog.WarnContext(ctx, "recordings: purge chunk delete failed",
+					"err", delErr, "handled", true,
+					"recording_id", rec.ID, "chunk_index", i, "key", key)
+			}
 		}
 		if err := svc.store.DeleteRecording(ctx, rec.ID); err != nil {
 			return fmt.Errorf("recordings: delete row %s: %w", rec.ID, err)

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -105,7 +105,14 @@ func Middleware(next http.Handler) http.Handler {
 		}
 		span.SetAttributes(semconv.HTTPStatusCode(rw.status))
 		if rw.status >= 500 {
-			span.SetStatus(codes.Error, fmt.Sprintf("HTTP %d", rw.status))
+			// Record an error event in addition to the status so SpanBarn
+			// surfaces it as an exception (handled=false 5xx) rather than
+			// a silently-error-statused span. Per-handler code is expected
+			// to call span.RecordError on the underlying err; this is the
+			// envelope-level fallback for handlers that don't.
+			err := fmt.Errorf("HTTP %d", rw.status)
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
 		}
 	})
 }

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -494,15 +494,15 @@ export class FunnelBarnClient {
 
   private startRecording(chunkMs?: number): void {
     if (this.rrwebStop) return; // already running
-    this.recordingId = this.generateSessionID();
-    this.recordingStartedAt = new Date().toISOString();
-    this.recordingStartMs = Date.now();
-    // Reset per-recording state. A new recording always starts at chunk 0
-    // with an empty buffer so the rrweb full snapshot (the first emitted
-    // event) lands in chunk_index=0. Without this, a stop→start cycle would
-    // leave recordingChunkIndex at its previous value and the new recording
-    // would lose its snapshot at the server (first_chunk_index >= 1).
-    this.recordingChunkIndex = 0;
+    // Resume an in-progress recording from a previous page in this tab, or
+    // start fresh. rrweb always emits a full snapshot at record() time, so
+    // the new page's snapshot lands in the next chunk of the same recording.
+    if (!this.resumeRecordingState()) {
+      this.recordingId = this.generateSessionID();
+      this.recordingStartedAt = new Date().toISOString();
+      this.recordingStartMs = Date.now();
+      this.recordingChunkIndex = 0;
+    }
     this.rrwebBuffer = [];
     this.rrwebStop = record({
       emit: (event) => { this.rrwebBuffer.push(event); },
@@ -511,7 +511,50 @@ export class FunnelBarnClient {
     });
     const interval = chunkMs ?? 10_000;
     this.recordingTimer = setInterval(() => { this.flushRecordingChunk().catch(() => {}); }, interval);
-    window.addEventListener('beforeunload', () => { this.flushRecordingChunk(true).catch(() => {}); });
+    window.addEventListener('beforeunload', () => {
+      // Persist state so the next page can continue this recording.
+      this.saveRecordingState();
+      this.flushRecordingChunk(true).catch(() => {});
+    });
+  }
+
+  // Returns true and restores recording state if a valid in-progress recording
+  // exists in sessionStorage (cleared automatically when the tab closes).
+  private resumeRecordingState(): boolean {
+    try {
+      const raw = sessionStorage.getItem('funnelbarn_rec');
+      if (!raw) return false;
+      const state = JSON.parse(raw) as {
+        recordingId: string;
+        chunkIndex: number;
+        startedAt: string;
+        elapsedMs: number;
+      };
+      if (state.elapsedMs > 30 * 60 * 1000) {
+        sessionStorage.removeItem('funnelbarn_rec');
+        return false;
+      }
+      this.recordingId = state.recordingId;
+      this.recordingChunkIndex = state.chunkIndex;
+      this.recordingStartedAt = state.startedAt;
+      this.recordingStartMs = Date.now() - state.elapsedMs;
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private saveRecordingState(): void {
+    try {
+      sessionStorage.setItem('funnelbarn_rec', JSON.stringify({
+        recordingId: this.recordingId,
+        chunkIndex: this.recordingChunkIndex,
+        startedAt: this.recordingStartedAt,
+        elapsedMs: Date.now() - this.recordingStartMs,
+      }));
+    } catch {
+      // sessionStorage unavailable (e.g. some private-browsing configurations)
+    }
   }
 
   private stopRecording(): void {
@@ -525,6 +568,7 @@ export class FunnelBarnClient {
     }
     this.rrwebBuffer = [];
     this.recordingChunkIndex = 0;
+    try { sessionStorage.removeItem('funnelbarn_rec'); } catch {}
   }
 
   private async applyServerRecordingConfig(chunkMs?: number): Promise<void> {

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -511,7 +511,7 @@ export class FunnelBarnClient {
     });
     const interval = chunkMs ?? 10_000;
     this.recordingTimer = setInterval(() => { this.flushRecordingChunk().catch(() => {}); }, interval);
-    window.addEventListener('beforeunload', () => { this.flushRecordingChunk().catch(() => {}); });
+    window.addEventListener('beforeunload', () => { this.flushRecordingChunk(true).catch(() => {}); });
   }
 
   private stopRecording(): void {
@@ -590,14 +590,14 @@ export class FunnelBarnClient {
     return true; // default: capture
   }
 
-  private async flushRecordingChunk(): Promise<void> {
+  private async flushRecordingChunk(useKeepalive = false): Promise<void> {
     if (!this.shouldRecordCurrentPage()) {
-      // Discard buffered events for this page — don't send them.
       this.rrwebBuffer = [];
       return;
     }
     const events = this.rrwebBuffer.splice(0);
     if (!events.length) return;
+    const chunkIndex = this.recordingChunkIndex++;
     try {
       await fetch(`${this.endpoint}/api/v1/recordings/chunk`, {
         method: 'POST',
@@ -608,16 +608,22 @@ export class FunnelBarnClient {
         body: JSON.stringify({
           recording_id: this.recordingId,
           session_id: this.getOrCreateSessionID(),
-          chunk_index: this.recordingChunkIndex++,
+          chunk_index: chunkIndex,
           events,
           started_at: this.recordingStartedAt,
           duration_ms: Date.now() - this.recordingStartMs,
           page_url: typeof window !== 'undefined' ? window.location.href : undefined,
         }),
-        keepalive: true,
+        // keepalive has a 64 KB body limit per the Fetch spec — rrweb full
+        // snapshots are 1-5 MB so we only use it for the final unload flush
+        // where the body is a small incremental tail.
+        keepalive: useKeepalive,
       });
     } catch {
-      // best-effort
+      // On failure, push events back to the front so the next flush retries
+      // them — most importantly this preserves the full snapshot (chunk 0).
+      this.rrwebBuffer.unshift(...events);
+      this.recordingChunkIndex--;
     }
   }
 

--- a/web/src/components/sessions/SessionReplay.tsx
+++ b/web/src/components/sessions/SessionReplay.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { X, Flag } from 'lucide-react'
+import { X, Flag, Play, Pause } from 'lucide-react'
 import { Replayer } from 'rrweb'
 import 'rrweb/dist/style.css'
 import { api, type Recording, type FlagEvaluationEntry } from '../../lib/api'
@@ -24,10 +24,14 @@ function formatTime(iso: string): string {
 export function SessionReplay({ projectId, recording, onClose }: Props) {
   const playerRef = useRef<HTMLDivElement>(null)
   const replayerRef = useRef<Replayer | null>(null)
+  const progressIntervalRef = useRef<ReturnType<typeof setInterval>>()
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [flags, setFlags] = useState<FlagEvaluationEntry[]>([])
   const [progress, setProgress] = useState(0)
+  const [isPlaying, setIsPlaying] = useState(false)
+  const [currentMs, setCurrentMs] = useState(0)
+  const [totalMs, setTotalMs] = useState(0)
 
   useEffect(() => {
     let cancelled = false
@@ -82,6 +86,16 @@ export function SessionReplay({ projectId, recording, onClose }: Props) {
         })
         replayerRef.current = replayer
 
+        const meta = replayer.getMetaData()
+        if (!cancelled) setTotalMs(meta.totalTime)
+
+        replayer.on('finish', () => {
+          if (cancelled) return
+          clearInterval(progressIntervalRef.current)
+          setIsPlaying(false)
+          setCurrentMs(meta.totalTime)
+        })
+
         function applyScale() {
           const container = playerRef.current
           if (!container) return
@@ -104,7 +118,13 @@ export function SessionReplay({ projectId, recording, onClose }: Props) {
         ro.observe(playerRef.current)
 
         replayer.play()
-        setLoading(false)
+        if (!cancelled) {
+          setIsPlaying(true)
+          setLoading(false)
+          progressIntervalRef.current = setInterval(() => {
+            setCurrentMs(replayerRef.current?.getCurrentTime() ?? 0)
+          }, 200)
+        }
       } catch {
         if (!cancelled) setError('Failed to load recording')
       }
@@ -120,8 +140,37 @@ export function SessionReplay({ projectId, recording, onClose }: Props) {
       cancelled = true
       replayerRef.current?.pause()
       ro?.disconnect()
+      clearInterval(progressIntervalRef.current)
     }
   }, [projectId, recording])
+
+  function togglePlayPause() {
+    const r = replayerRef.current
+    if (!r) return
+    if (isPlaying) {
+      r.pause()
+      setIsPlaying(false)
+      clearInterval(progressIntervalRef.current)
+    } else {
+      r.play(currentMs)
+      setIsPlaying(true)
+      progressIntervalRef.current = setInterval(() => {
+        setCurrentMs(replayerRef.current?.getCurrentTime() ?? 0)
+      }, 200)
+    }
+  }
+
+  function handleSeek(e: React.ChangeEvent<HTMLInputElement>) {
+    const ms = Number(e.target.value)
+    setCurrentMs(ms)
+    const r = replayerRef.current
+    if (!r) return
+    if (isPlaying) {
+      r.play(ms)
+    } else {
+      r.pause(ms)
+    }
+  }
 
   return (
     <div
@@ -168,30 +217,63 @@ export function SessionReplay({ projectId, recording, onClose }: Props) {
 
         {/* Body */}
         <div style={{ display: 'flex', flex: 1, overflow: 'hidden', minHeight: 0 }}>
-          {/* Player area */}
-          <div style={{ flex: 1, position: 'relative', background: '#000', overflow: 'hidden' }}>
-            {(loading || error) && (
-              <div style={{
-                position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column',
-                alignItems: 'center', justifyContent: 'center', gap: 16, color: C.muted,
-                zIndex: 1,
-              }}>
-                {!error && (
-                  <div style={{
-                    width: 200, height: 4, background: C.surface, borderRadius: 2, overflow: 'hidden',
-                  }}>
+          {/* Player column */}
+          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+            {/* Player area */}
+            <div style={{ flex: 1, position: 'relative', background: '#000', overflow: 'hidden' }}>
+              {(loading || error) && (
+                <div style={{
+                  position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column',
+                  alignItems: 'center', justifyContent: 'center', gap: 16, color: C.muted,
+                  zIndex: 1,
+                }}>
+                  {!error && (
                     <div style={{
-                      height: '100%', background: C.amber, borderRadius: 2,
-                      width: `${progress}%`, transition: 'width 0.2s',
-                    }} />
-                  </div>
-                )}
-                <span style={{ fontSize: 13, maxWidth: 320, textAlign: 'center' }}>
-                  {error ?? `Loading chunks… ${progress}%`}
+                      width: 200, height: 4, background: C.surface, borderRadius: 2, overflow: 'hidden',
+                    }}>
+                      <div style={{
+                        height: '100%', background: C.amber, borderRadius: 2,
+                        width: `${progress}%`, transition: 'width 0.2s',
+                      }} />
+                    </div>
+                  )}
+                  <span style={{ fontSize: 13, maxWidth: 320, textAlign: 'center' }}>
+                    {error ?? `Loading chunks… ${progress}%`}
+                  </span>
+                </div>
+              )}
+              <div ref={playerRef} style={{ width: '100%', height: '100%', position: 'relative' }} />
+            </div>
+
+            {/* Playback controls */}
+            {!loading && !error && (
+              <div style={{
+                display: 'flex', alignItems: 'center', gap: 10,
+                padding: '0.4rem 1rem', borderTop: `1px solid ${C.border}`,
+                background: C.surface, flexShrink: 0,
+              }}>
+                <button
+                  onClick={togglePlayPause}
+                  style={{
+                    background: 'none', border: 'none', cursor: 'pointer',
+                    color: C.text, padding: 4, flexShrink: 0, display: 'flex', alignItems: 'center',
+                  }}
+                >
+                  {isPlaying ? <Pause size={16} /> : <Play size={16} />}
+                </button>
+                <span style={{ fontSize: 12, color: C.muted, flexShrink: 0, minWidth: 90 }}>
+                  {formatDuration(currentMs)} / {formatDuration(totalMs)}
                 </span>
+                <input
+                  type="range"
+                  min={0}
+                  max={totalMs || 1}
+                  value={currentMs}
+                  onChange={handleSeek}
+                  style={{ flex: 1, cursor: 'pointer', accentColor: C.amber }}
+                />
               </div>
             )}
-            <div ref={playerRef} style={{ width: '100%', height: '100%', position: 'relative' }} />
           </div>
 
           {/* Sidebar — flag evaluations */}


### PR DESCRIPTION
## Summary

- **Player controls**: adds a play/pause button and timeline scrubber to the session replay modal. The scrubber shows position in the original recording timeline; dragging it seeks rrweb to that point. Progress updates at 200 ms intervals via `getCurrentTime()`.
- **Cross-page continuity**: the SDK now saves `{ recordingId, chunkIndex, startedAt, elapsedMs }` to `sessionStorage` on `beforeunload`. The next page load checks sessionStorage and resumes the same recording instead of starting a new one. rrweb naturally emits a new full snapshot on each `record()` call, so navigation appears in the replay as a new page load within the same session. sessionStorage is cleared when the tab closes (no cross-session bleed) and also when recording is explicitly stopped by server config.
- Max resume window: 30 minutes — recordings older than that start fresh.

## Test plan

- [ ] Open a session replay — play/pause button and scrubber are visible below the video
- [ ] Scrubber moves as the replay plays; dragging it seeks correctly
- [ ] Navigate between pages on a site with the SDK installed — check that both pages appear in the same recording (single recording entry with multiple type-2 snapshot events across chunks)
- [ ] Close the browser tab — confirm next session starts a fresh recording (no stale sessionStorage)