### PR TITLE
fix(recordings): reliable snapshot capture, cross-page continuity, playable list

### DIFF
--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -388,6 +388,11 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 				} else {
 					slog.Debug("recording retention purge complete", "retention_days", retentionDays)
 				}
+				if n, err := recordings.PurgeBrokenRecordings(ctx); err != nil {
+					slog.Error("purge broken recordings", "err", err)
+				} else if n > 0 {
+					slog.Info("purged unplayable recordings", "count", n)
+				}
 			}
 		case <-ticker.C:
 			entries, err := spool.ReadRecordsFrom(spool.Path(cfg.SpoolDir), offset)

--- a/e2e/recording-verify.spec.ts
+++ b/e2e/recording-verify.spec.ts
@@ -27,16 +27,30 @@ test('sessions list shows recordings', async ({ page }) => {
   await expect(row).toBeVisible({ timeout: 5000 })
 })
 
+test('sessions list exposes replay status and a delete control', async ({ page }) => {
+  await page.goto(`/sessions/${PROJECT_ID}`)
+  await expect(page.getByText(/\d+ shown/)).toBeVisible({ timeout: 15000 })
+
+  // The Replay column header and a per-row delete control must be present.
+  await expect(page.getByText('Replay', { exact: true })).toBeVisible({ timeout: 5000 })
+  await expect(page.locator('button[title="Delete recording"]').first()).toBeVisible({ timeout: 5000 })
+})
+
 test('replay player is scaled and visible — not a black screen', async ({ page }) => {
   await page.goto(`/sessions/${PROJECT_ID}`)
 
   // Wait for recordings to load
   await expect(page.getByText(/\d+ shown/)).toBeVisible({ timeout: 15000 })
 
-  // Click the first recording row
+  // Click the first playable recording row (cursor:pointer is only set when a
+  // snapshot exists, so this also skips unplayable rows).
   const row = page.locator('div[style*="cursor: pointer"]').first()
   await expect(row).toBeVisible({ timeout: 5000 })
   await row.click()
+
+  // The "snapshot missing" failure must never appear for a playable recording —
+  // this guards the chunk-span fix (first..last inclusive).
+  await expect(page.getByText(/initial page snapshot is missing/)).toHaveCount(0)
 
   // The modal + rrweb wrapper must appear
   const wrapper = page.locator('.replayer-wrapper').first()

--- a/internal/api/recordings.go
+++ b/internal/api/recordings.go
@@ -196,6 +196,35 @@ func (s *Server) handleGetRecordingChunk(w http.ResponseWriter, r *http.Request)
 	w.Write(data) //nolint:errcheck
 }
 
+func (s *Server) handleDeleteRecording(w http.ResponseWriter, r *http.Request) {
+	if s.recordings == nil {
+		jsonError(w, "session recording not configured", http.StatusServiceUnavailable)
+		return
+	}
+	projectID := r.PathValue("id")
+	recordingID := r.PathValue("rid")
+	if projectID == "" || recordingID == "" {
+		jsonError(w, "project id and recording id are required", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.recordings.DeleteRecording(r.Context(), projectID, recordingID); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			jsonError(w, "not found", http.StatusNotFound)
+			return
+		}
+		slog.ErrorContext(r.Context(), "delete recording failed",
+			"error", err, "handled", false,
+			"recording_id", recordingID,
+			"project_id", projectID,
+			"request_id", RequestIDFromContext(r.Context()),
+		)
+		jsonError(w, "failed to delete recording", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 func (s *Server) handleGetRecordingFlags(w http.ResponseWriter, r *http.Request) {
 	if s.recordings == nil {
 		jsonError(w, "session recording not configured", http.StatusServiceUnavailable)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -285,6 +285,7 @@ func (s *Server) registerRoutes() {
 	// Recordings
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/recordings", s.requireSession(s.handleListRecordings))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/recordings/{rid}/chunks/{index}", s.requireSession(s.handleGetRecordingChunk))
+	s.mux.HandleFunc("DELETE /api/v1/projects/{id}/recordings/{rid}", s.requireSession(s.handleDeleteRecording))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/recordings/{rid}/flags", s.requireSession(s.handleGetRecordingFlags))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/funnels/{fid}/steps/{step}/sessions", s.requireSession(s.handleFunnelStepSessions))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/flows/sessions", s.requireSession(s.handleFlowPageSessions))

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -132,6 +132,7 @@ type RecordingRepo interface {
 	GetRecording(ctx context.Context, id string) (repository.Recording, error)
 	ListRecordings(ctx context.Context, projectID string, opts repository.RecordingListOpts) ([]repository.Recording, error)
 	ListOldRecordings(ctx context.Context, before time.Time) ([]repository.Recording, error)
+	ListBrokenRecordings(ctx context.Context) ([]repository.Recording, error)
 	DeleteRecording(ctx context.Context, id string) error
 	FlagEvaluationsForSession(ctx context.Context, sessionID, projectID string) ([]repository.FlagEvaluationEntry, error)
 }

--- a/internal/repository/migrations/00022_recordings_snapshot.sql
+++ b/internal/repository/migrations/00022_recordings_snapshot.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+ALTER TABLE recordings ADD COLUMN last_chunk_index INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE recordings ADD COLUMN has_snapshot     INTEGER NOT NULL DEFAULT 0;
+
+-- Backfill existing rows. Before this change a recording's playable span was
+-- inferred from first_chunk_index + chunk_count, and the rrweb full snapshot
+-- always lands in chunk 0, so a surviving snapshot implies first_chunk_index = 0.
+UPDATE recordings SET has_snapshot = 1 WHERE first_chunk_index = 0;
+UPDATE recordings SET last_chunk_index = first_chunk_index + chunk_count - 1 WHERE chunk_count > 0;
+
+-- +goose Down
+-- SQLite does not support DROP COLUMN on older versions; migration is a no-op on rollback.

--- a/internal/repository/recordings.go
+++ b/internal/repository/recordings.go
@@ -15,7 +15,9 @@ type Recording struct {
 	SessionID       string     `json:"session_id"`
 	Environment     string     `json:"environment"`
 	FirstChunkIndex int        `json:"first_chunk_index"`
+	LastChunkIndex  int        `json:"last_chunk_index"`
 	ChunkCount      int        `json:"chunk_count"`
+	HasSnapshot     bool       `json:"has_snapshot"`
 	DurationMs      int64      `json:"duration_ms"`
 	StartedAt       time.Time  `json:"started_at"`
 	EndedAt         *time.Time `json:"ended_at,omitempty"`
@@ -44,20 +46,25 @@ type RecordingListOpts struct {
 	Offset      int
 }
 
-// UpsertRecording inserts a new recording or updates an existing one's
-// chunk count, duration, and ended_at timestamp. first_chunk_index and
-// metadata fields (device_type, user_agent, is_bot, page_url) are set
-// only on insert and never overwritten.
+// UpsertRecording inserts a new recording or folds another chunk into an
+// existing one. The playable span is tracked as first_chunk_index (the lowest
+// chunk index seen) and last_chunk_index (the highest); both use min/max so a
+// chunk arriving out of order can never strand the snapshot. has_snapshot is
+// sticky once any chunk carrying the rrweb full snapshot lands. Metadata fields
+// (device_type, user_agent, is_bot, page_url) are set only on insert.
 func (s *Store) UpsertRecording(ctx context.Context, r Recording) error {
 	const q = `
 		INSERT INTO recordings
-			(id, project_id, session_id, environment, first_chunk_index, chunk_count, duration_ms, started_at, ended_at,
-			 device_type, user_agent, is_bot, page_url)
-		VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?)
+			(id, project_id, session_id, environment, first_chunk_index, last_chunk_index, chunk_count, has_snapshot,
+			 duration_ms, started_at, ended_at, device_type, user_agent, is_bot, page_url)
+		VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
-			chunk_count = chunk_count + 1,
-			duration_ms = excluded.duration_ms,
-			ended_at    = excluded.ended_at`
+			first_chunk_index = min(first_chunk_index, excluded.first_chunk_index),
+			last_chunk_index  = max(last_chunk_index, excluded.last_chunk_index),
+			chunk_count       = chunk_count + 1,
+			has_snapshot      = max(has_snapshot, excluded.has_snapshot),
+			duration_ms       = max(duration_ms, excluded.duration_ms),
+			ended_at          = excluded.ended_at`
 	var endedAt interface{}
 	if r.EndedAt != nil {
 		endedAt = *r.EndedAt
@@ -66,9 +73,14 @@ func (s *Store) UpsertRecording(ctx context.Context, r Recording) error {
 	if r.IsBot {
 		isBot = 1
 	}
+	hasSnapshot := 0
+	if r.HasSnapshot {
+		hasSnapshot = 1
+	}
 	_, err := s.db.ExecContext(ctx, q,
 		r.ID, r.ProjectID, r.SessionID, r.Environment,
-		r.FirstChunkIndex, r.DurationMs, r.StartedAt, endedAt,
+		r.FirstChunkIndex, r.LastChunkIndex, hasSnapshot,
+		r.DurationMs, r.StartedAt, endedAt,
 		r.DeviceType, r.UserAgent, isBot, r.PageURL,
 	)
 	return err
@@ -77,7 +89,7 @@ func (s *Store) UpsertRecording(ctx context.Context, r Recording) error {
 // GetRecording fetches a single recording by ID.
 func (s *Store) GetRecording(ctx context.Context, id string) (Recording, error) {
 	const q = `
-		SELECT id, project_id, session_id, environment, first_chunk_index, chunk_count, duration_ms, started_at, ended_at, created_at,
+		SELECT id, project_id, session_id, environment, first_chunk_index, last_chunk_index, chunk_count, has_snapshot, duration_ms, started_at, ended_at, created_at,
 		       device_type, user_agent, is_bot, page_url
 		FROM recordings WHERE id = ?`
 	return scanRecording(s.db.QueryRowContext(ctx, q, id))
@@ -119,7 +131,7 @@ func (s *Store) ListRecordings(ctx context.Context, projectID string, opts Recor
 	offset := opts.Offset
 
 	q := fmt.Sprintf(`
-		SELECT id, project_id, session_id, environment, first_chunk_index, chunk_count, duration_ms, started_at, ended_at, created_at,
+		SELECT id, project_id, session_id, environment, first_chunk_index, last_chunk_index, chunk_count, has_snapshot, duration_ms, started_at, ended_at, created_at,
 		       device_type, user_agent, is_bot, page_url
 		FROM recordings
 		WHERE %s
@@ -167,6 +179,32 @@ func (s *Store) ListOldRecordings(ctx context.Context, before time.Time) ([]Reco
 	return out, rows.Err()
 }
 
+// ListBrokenRecordings returns recordings that can never play back — those
+// whose rrweb full snapshot never reached storage (has_snapshot = 0) or that
+// hold no chunks at all. last_chunk_index/chunk_count are returned so callers
+// can clean up any orphaned R2 chunks.
+func (s *Store) ListBrokenRecordings(ctx context.Context) ([]Recording, error) {
+	const q = `
+		SELECT id, project_id, last_chunk_index, chunk_count
+		FROM recordings
+		WHERE has_snapshot = 0 OR chunk_count = 0
+		LIMIT 500`
+	rows, err := s.db.QueryContext(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Recording
+	for rows.Next() {
+		var r Recording
+		if err := rows.Scan(&r.ID, &r.ProjectID, &r.LastChunkIndex, &r.ChunkCount); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
 // DeleteRecording deletes a recording row by ID.
 func (s *Store) DeleteRecording(ctx context.Context, id string) error {
 	_, err := s.db.ExecContext(ctx, `DELETE FROM recordings WHERE id = ?`, id)
@@ -200,33 +238,22 @@ func (s *Store) FlagEvaluationsForSession(ctx context.Context, sessionID, projec
 }
 
 func scanRecording(row *sql.Row) (Recording, error) {
-	var r Recording
-	var endedAt sql.NullTime
-	var isBot int
-	err := row.Scan(
-		&r.ID, &r.ProjectID, &r.SessionID, &r.Environment,
-		&r.FirstChunkIndex, &r.ChunkCount, &r.DurationMs, &r.StartedAt, &endedAt, &r.CreatedAt,
-		&r.DeviceType, &r.UserAgent, &isBot, &r.PageURL,
-	)
-	if endedAt.Valid {
-		r.EndedAt = &endedAt.Time
-	}
-	r.IsBot = isBot != 0
-	return r, err
+	return scanRecordingRow(row.Scan)
 }
 
 func scanRecordingRow(scan func(...any) error) (Recording, error) {
 	var r Recording
 	var endedAt sql.NullTime
-	var isBot int
+	var isBot, hasSnapshot int
 	err := scan(
 		&r.ID, &r.ProjectID, &r.SessionID, &r.Environment,
-		&r.FirstChunkIndex, &r.ChunkCount, &r.DurationMs, &r.StartedAt, &endedAt, &r.CreatedAt,
+		&r.FirstChunkIndex, &r.LastChunkIndex, &r.ChunkCount, &hasSnapshot, &r.DurationMs, &r.StartedAt, &endedAt, &r.CreatedAt,
 		&r.DeviceType, &r.UserAgent, &isBot, &r.PageURL,
 	)
 	if endedAt.Valid {
 		r.EndedAt = &endedAt.Time
 	}
 	r.IsBot = isBot != 0
+	r.HasSnapshot = hasSnapshot != 0
 	return r, err
 }

--- a/internal/repository/recordings_test.go
+++ b/internal/repository/recordings_test.go
@@ -100,6 +100,67 @@ func TestRecording_FirstChunkIndexPreserved(t *testing.T) {
 	assert.Equal(t, 2, got.ChunkCount)
 }
 
+func TestRecording_OutOfOrderChunksKeepSnapshotInSpan(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	p, err := s.CreateProject(ctx, "OOO Chunks", "ooo-chunks")
+	require.NoError(t, err)
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// A small later chunk (index 1) wins the upload race and inserts the row.
+	later := makeRecording(p.ID, "sess-ooo", now)
+	later.ID = "rec-ooo"
+	later.FirstChunkIndex = 1
+	later.LastChunkIndex = 1
+	later.HasSnapshot = false
+	require.NoError(t, s.UpsertRecording(ctx, later))
+
+	// The large snapshot chunk (index 0) lands afterwards.
+	snapshot := makeRecording(p.ID, "sess-ooo", now)
+	snapshot.ID = "rec-ooo"
+	snapshot.FirstChunkIndex = 0
+	snapshot.LastChunkIndex = 0
+	snapshot.HasSnapshot = true
+	require.NoError(t, s.UpsertRecording(ctx, snapshot))
+
+	got, err := s.GetRecording(ctx, "rec-ooo")
+	require.NoError(t, err)
+	assert.Equal(t, 0, got.FirstChunkIndex, "first_chunk_index must track the lowest index, not arrival order")
+	assert.Equal(t, 1, got.LastChunkIndex, "last_chunk_index must track the highest index")
+	assert.True(t, got.HasSnapshot, "has_snapshot must stick once the snapshot chunk lands")
+	assert.Equal(t, 2, got.ChunkCount)
+}
+
+func TestRecording_ListBrokenRecordings(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	p, err := s.CreateProject(ctx, "Broken", "broken")
+	require.NoError(t, err)
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	good := makeRecording(p.ID, "sess-good", now)
+	good.ID = "rec-good"
+	good.HasSnapshot = true
+	require.NoError(t, s.UpsertRecording(ctx, good))
+
+	broken := makeRecording(p.ID, "sess-broken", now)
+	broken.ID = "rec-broken"
+	broken.FirstChunkIndex = 1
+	broken.LastChunkIndex = 1
+	broken.HasSnapshot = false
+	require.NoError(t, s.UpsertRecording(ctx, broken))
+
+	recs, err := s.ListBrokenRecordings(ctx)
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	assert.Equal(t, "rec-broken", recs[0].ID)
+	assert.Equal(t, p.ID, recs[0].ProjectID)
+}
+
 func TestRecording_ListRecordings(t *testing.T) {
 	ctx := context.Background()
 	s := newTestStore(t)

--- a/internal/service/interfaces.go
+++ b/internal/service/interfaces.go
@@ -119,6 +119,8 @@ type Recordings interface {
 	SessionsAtStep(ctx context.Context, funnelID, projectID string, stepOrder int, from, to time.Time) ([]string, error)
 	SessionsForPage(ctx context.Context, projectID, page string, from, to time.Time) ([]string, error)
 	PurgeOldRecordings(ctx context.Context, retentionDays int) error
+	PurgeBrokenRecordings(ctx context.Context) (int, error)
+	DeleteRecording(ctx context.Context, projectID, recordingID string) error
 }
 
 // APIKeys is the interface for API key-related operations.

--- a/internal/service/recordings.go
+++ b/internal/service/recordings.go
@@ -70,7 +70,9 @@ func (svc *RecordingService) IngestChunk(ctx context.Context, chunk RecordingChu
 		SessionID:       chunk.SessionID,
 		Environment:     chunk.Environment,
 		FirstChunkIndex: chunk.ChunkIndex,
+		LastChunkIndex:  chunk.ChunkIndex,
 		ChunkCount:      1,
+		HasSnapshot:     containsFullSnapshot(chunk.Events),
 		DurationMs:      chunk.DurationMs,
 		StartedAt:       chunk.StartedAt,
 		EndedAt:         &endedAt,
@@ -111,9 +113,81 @@ func (svc *RecordingService) PurgeOldRecordings(ctx context.Context, retentionDa
 	return nil
 }
 
+// PurgeBrokenRecordings deletes recordings that can never play back (no full
+// snapshot ever stored, or no chunks) from both R2 and SQLite. It is idempotent
+// and safe to run on every retention cycle. Returns the number of rows removed.
+func (svc *RecordingService) PurgeBrokenRecordings(ctx context.Context) (int, error) {
+	recs, err := svc.store.ListBrokenRecordings(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("recordings: list broken: %w", err)
+	}
+	for _, rec := range recs {
+		svc.deleteChunks(ctx, rec.ProjectID, rec.ID, rec.LastChunkIndex, rec.ChunkCount)
+		if err := svc.store.DeleteRecording(ctx, rec.ID); err != nil {
+			return 0, fmt.Errorf("recordings: delete broken row %s: %w", rec.ID, err)
+		}
+	}
+	return len(recs), nil
+}
+
+// DeleteRecording removes a single recording (R2 chunks + SQLite row) after
+// verifying it belongs to the given project.
+func (svc *RecordingService) DeleteRecording(ctx context.Context, projectID, recordingID string) error {
+	rec, err := svc.store.GetRecording(ctx, recordingID)
+	if err != nil {
+		return fmt.Errorf("recordings: get recording: %w", err)
+	}
+	if rec.ProjectID != projectID {
+		return fmt.Errorf("recordings: not found")
+	}
+	svc.deleteChunks(ctx, rec.ProjectID, rec.ID, rec.LastChunkIndex, rec.ChunkCount)
+	return svc.store.DeleteRecording(ctx, rec.ID)
+}
+
+// deleteChunks best-effort removes a recording's R2 chunk objects. It spans the
+// inclusive 0..lastChunkIndex range (falling back to chunkCount for legacy rows
+// without a recorded span) so out-of-order or sparse indices are still covered.
+// A failed delete is logged but never aborts the caller — a stray R2 orphan is
+// preferable to leaving the SQLite row behind.
+func (svc *RecordingService) deleteChunks(ctx context.Context, projectSlug, recordingID string, lastChunkIndex, chunkCount int) {
+	upper := lastChunkIndex
+	if upper < chunkCount-1 {
+		upper = chunkCount - 1
+	}
+	for i := 0; i <= upper; i++ {
+		key := chunkKey(projectSlug, recordingID, i)
+		if delErr := svc.storage.Delete(ctx, key); delErr != nil {
+			slog.WarnContext(ctx, "recordings: chunk delete failed",
+				"err", delErr, "handled", true,
+				"recording_id", recordingID, "chunk_index", i, "key", key)
+		}
+	}
+}
+
 // ListRecordings returns recordings for a project with optional filters.
 func (svc *RecordingService) ListRecordings(ctx context.Context, projectID string, opts repository.RecordingListOpts) ([]repository.Recording, error) {
 	return svc.store.ListRecordings(ctx, projectID, opts)
+}
+
+// containsFullSnapshot reports whether the raw rrweb event array holds a
+// full-snapshot event (type 2) — the event the player needs to reconstruct the
+// page. Used to mark a recording playable as soon as its snapshot lands.
+func containsFullSnapshot(events json.RawMessage) bool {
+	if len(events) == 0 {
+		return false
+	}
+	var decoded []struct {
+		Type int `json:"type"`
+	}
+	if err := json.Unmarshal(events, &decoded); err != nil {
+		return false
+	}
+	for _, e := range decoded {
+		if e.Type == 2 {
+			return true
+		}
+	}
+	return false
 }
 
 // GetChunk fetches, decompresses, and returns the raw JSON event array for one chunk.

--- a/internal/service/recordings_test.go
+++ b/internal/service/recordings_test.go
@@ -149,6 +149,116 @@ func TestRecordingService_IngestChunk_BotDetection(t *testing.T) {
 	assert.Equal(t, "desktop", rec.DeviceType)
 }
 
+func TestRecordingService_IngestChunk_SnapshotDetection(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	storage := newMemStorage()
+
+	projSvc := service.NewProjectService(store)
+	p, err := projSvc.CreateProject(ctx, "Snap", "snap")
+	require.NoError(t, err)
+
+	svc := service.NewRecordingService(store, store, store, storage)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// Chunk 0 carries only a meta event (type 4) — not yet playable.
+	require.NoError(t, svc.IngestChunk(ctx, service.RecordingChunk{
+		RecordingID: "rec-snap", SessionID: "sess-snap", ChunkIndex: 0,
+		Events:    json.RawMessage(`[{"type":4,"data":{"width":1280,"height":720}}]`),
+		StartedAt: now, DurationMs: 1000, ProjectSlug: "snap", ProjectID: p.ID, UserAgent: "Mozilla/5.0",
+	}))
+	rec, err := store.GetRecording(ctx, "rec-snap")
+	require.NoError(t, err)
+	assert.False(t, rec.HasSnapshot, "meta-only chunk must not mark the recording playable")
+
+	// Chunk 1 carries the full snapshot (type 2) — now playable, and the flag sticks.
+	require.NoError(t, svc.IngestChunk(ctx, service.RecordingChunk{
+		RecordingID: "rec-snap", SessionID: "sess-snap", ChunkIndex: 1,
+		Events:    json.RawMessage(`[{"type":2,"data":{"node":{}}},{"type":3,"data":{}}]`),
+		StartedAt: now, DurationMs: 11000, ProjectSlug: "snap", ProjectID: p.ID, UserAgent: "Mozilla/5.0",
+	}))
+	rec, err = store.GetRecording(ctx, "rec-snap")
+	require.NoError(t, err)
+	assert.True(t, rec.HasSnapshot, "a chunk with a type-2 event must mark the recording playable")
+	assert.Equal(t, 0, rec.FirstChunkIndex)
+	assert.Equal(t, 1, rec.LastChunkIndex)
+}
+
+func TestRecordingService_PurgeBrokenRecordings(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	storage := newMemStorage()
+
+	projSvc := service.NewProjectService(store)
+	p, err := projSvc.CreateProject(ctx, "PurgeBroken", "purgebroken")
+	require.NoError(t, err)
+
+	svc := service.NewRecordingService(store, store, store, storage)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// Playable recording (has a full snapshot).
+	require.NoError(t, svc.IngestChunk(ctx, service.RecordingChunk{
+		RecordingID: "rec-keep", SessionID: "sess-keep", ChunkIndex: 0,
+		Events:    json.RawMessage(`[{"type":2,"data":{}}]`),
+		StartedAt: now, DurationMs: 1000, ProjectSlug: "purgebroken", ProjectID: p.ID, UserAgent: "Mozilla/5.0",
+	}))
+	// Broken recording (snapshot never arrived).
+	require.NoError(t, svc.IngestChunk(ctx, service.RecordingChunk{
+		RecordingID: "rec-drop", SessionID: "sess-drop", ChunkIndex: 1,
+		Events:    json.RawMessage(`[{"type":3,"data":{}}]`),
+		StartedAt: now, DurationMs: 1000, ProjectSlug: "purgebroken", ProjectID: p.ID, UserAgent: "Mozilla/5.0",
+	}))
+
+	n, err := svc.PurgeBrokenRecordings(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+
+	_, err = store.GetRecording(ctx, "rec-drop")
+	assert.Error(t, err, "broken recording row should be deleted")
+	_, err = store.GetRecording(ctx, "rec-keep")
+	assert.NoError(t, err, "playable recording must be preserved")
+
+	// The broken recording's chunk should be gone from storage; the good one stays.
+	n2, err := svc.PurgeBrokenRecordings(ctx) // idempotent — second run finds nothing
+	require.NoError(t, err)
+	assert.Equal(t, 0, n2)
+	keys := storage.keys()
+	for _, k := range keys {
+		assert.NotContains(t, k, "rec-drop", "broken recording chunks should be purged from storage")
+	}
+}
+
+func TestRecordingService_DeleteRecording_ProjectScope(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	storage := newMemStorage()
+
+	projSvc := service.NewProjectService(store)
+	p, err := projSvc.CreateProject(ctx, "DelScope", "delscope")
+	require.NoError(t, err)
+
+	svc := service.NewRecordingService(store, store, store, storage)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	require.NoError(t, svc.IngestChunk(ctx, service.RecordingChunk{
+		RecordingID: "rec-delscope", SessionID: "sess-delscope", ChunkIndex: 0,
+		Events:    json.RawMessage(`[{"type":2,"data":{}}]`),
+		StartedAt: now, DurationMs: 1000, ProjectSlug: "delscope", ProjectID: p.ID, UserAgent: "Mozilla/5.0",
+	}))
+
+	// Wrong project must not be able to delete.
+	err = svc.DeleteRecording(ctx, "some-other-project", "rec-delscope")
+	require.Error(t, err)
+	_, err = store.GetRecording(ctx, "rec-delscope")
+	require.NoError(t, err, "recording must survive a cross-project delete attempt")
+
+	// Correct project deletes the row and its chunks.
+	require.NoError(t, svc.DeleteRecording(ctx, p.ID, "rec-delscope"))
+	_, err = store.GetRecording(ctx, "rec-delscope")
+	assert.Error(t, err)
+	assert.Empty(t, storage.keys(), "chunk objects should be removed on delete")
+}
+
 func TestRecordingService_GetChunk(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore(t)

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -69,6 +69,19 @@ const SESSION_KEY = "funnelbarn_sid";
 const SESSION_EXPIRY_KEY = "funnelbarn_sid_exp";
 const SESSION_TIMEOUT_DEFAULT = 30 * 60 * 1000; // 30 min
 
+// Per-tab recording continuity. Persisted to sessionStorage on unload so a
+// full-page navigation resumes the same recording instead of starting a new
+// one — a visitor's whole journey becomes a single, continuous replay.
+const RECORDING_STATE_KEY = "funnelbarn_rec";
+
+interface RecordingState {
+  id: string;
+  chunkIndex: number;
+  startedAt: string;
+  elapsedMs: number;
+  savedAt: number;
+}
+
 /**
  * FunnelBarnClient is the main analytics client.
  */
@@ -107,6 +120,7 @@ export class FunnelBarnClient {
   private recordingStartedAt = '';
   private recordingStartMs = 0;
   private recordingTimer?: ReturnType<typeof setInterval>;
+  private recordingSnapshotFlushed = false;
   private recordingOptions: FunnelBarnOptions;
   private serverRecordingRules: RecordingRule[] = [];
 
@@ -494,24 +508,103 @@ export class FunnelBarnClient {
 
   private startRecording(chunkMs?: number): void {
     if (this.rrwebStop) return; // already running
-    this.recordingId = this.generateSessionID();
-    this.recordingStartedAt = new Date().toISOString();
-    this.recordingStartMs = Date.now();
-    // Reset per-recording state. A new recording always starts at chunk 0
-    // with an empty buffer so the rrweb full snapshot (the first emitted
-    // event) lands in chunk_index=0. Without this, a stop→start cycle would
-    // leave recordingChunkIndex at its previous value and the new recording
-    // would lose its snapshot at the server (first_chunk_index >= 1).
-    this.recordingChunkIndex = 0;
-    this.rrwebBuffer = [];
+
+    // Resume the same recording across a full-page navigation when a recent
+    // state was persisted on the previous page's unload. This keeps a visitor's
+    // journey as one continuous replay (same recording_id, monotonically
+    // increasing chunk_index). The rrweb full snapshot emitted on the new page
+    // becomes a later chunk of the same recording, which the player re-anchors
+    // on. When there is nothing to resume we start fresh at chunk 0.
+    const resumed = this.resumeRecordingState();
+    if (resumed) {
+      this.recordingId = resumed.id;
+      this.recordingChunkIndex = resumed.chunkIndex;
+      this.recordingStartedAt = resumed.startedAt;
+      this.recordingStartMs = Date.now() - resumed.elapsedMs;
+    } else {
+      this.recordingId = this.generateSessionID();
+      this.recordingStartedAt = new Date().toISOString();
+      this.recordingStartMs = Date.now();
+      // A fresh recording always starts at chunk 0 with an empty buffer so the
+      // rrweb full snapshot (the first emitted event) lands in chunk_index=0.
+      this.recordingChunkIndex = 0;
+      this.rrwebBuffer = [];
+    }
+    this.recordingSnapshotFlushed = false;
+
     this.rrwebStop = record({
-      emit: (event) => { this.rrwebBuffer.push(event); },
+      emit: (event) => {
+        this.rrwebBuffer.push(event);
+        // The full snapshot (type 2) is the one event the player can't replay
+        // without. Flush it immediately via a normal fetch (no keepalive size
+        // cap) so short visits — ones that never reach the periodic tick or
+        // only fire beforeunload — don't silently drop it.
+        if (!this.recordingSnapshotFlushed && (event as { type?: number }).type === 2) {
+          this.recordingSnapshotFlushed = true;
+          this.flushRecordingChunk().catch(() => {});
+        }
+      },
       maskInputOptions: { password: true },
       blockClass: 'fb-block',
     });
     const interval = chunkMs ?? 10_000;
     this.recordingTimer = setInterval(() => { this.flushRecordingChunk().catch(() => {}); }, interval);
-    window.addEventListener('beforeunload', () => { this.flushRecordingChunk(true).catch(() => {}); });
+    window.addEventListener('beforeunload', this.handleRecordingUnload);
+  }
+
+  private handleRecordingUnload = (): void => {
+    // Persist continuity state first, then flush the incremental tail. The tail
+    // is small, so keepalive (64 KB cap) is safe here; the snapshot already left
+    // earlier via a normal fetch.
+    this.saveRecordingState();
+    this.flushRecordingChunk(true).catch(() => {});
+  };
+
+  private saveRecordingState(): void {
+    if (typeof sessionStorage === "undefined" || !this.recordingId) return;
+    const state: RecordingState = {
+      id: this.recordingId,
+      chunkIndex: this.recordingChunkIndex,
+      startedAt: this.recordingStartedAt,
+      elapsedMs: Date.now() - this.recordingStartMs,
+      savedAt: Date.now(),
+    };
+    try {
+      sessionStorage.setItem(RECORDING_STATE_KEY, JSON.stringify(state));
+    } catch {
+      // sessionStorage may be full or unavailable — continuity is best-effort.
+    }
+  }
+
+  private resumeRecordingState(): RecordingState | null {
+    if (typeof sessionStorage === "undefined") return null;
+    let raw: string | null;
+    try {
+      raw = sessionStorage.getItem(RECORDING_STATE_KEY);
+    } catch {
+      return null;
+    }
+    if (!raw) return null;
+    try {
+      const state = JSON.parse(raw) as RecordingState;
+      // Discard stale state so a tab left idle past the session window starts a
+      // new recording rather than stitching onto an abandoned one.
+      if (!state.id || Date.now() - state.savedAt > this.sessionTimeout) {
+        return null;
+      }
+      return state;
+    } catch {
+      return null;
+    }
+  }
+
+  private clearRecordingState(): void {
+    if (typeof sessionStorage === "undefined") return;
+    try {
+      sessionStorage.removeItem(RECORDING_STATE_KEY);
+    } catch {
+      // ignore
+    }
   }
 
   private stopRecording(): void {
@@ -523,8 +616,13 @@ export class FunnelBarnClient {
       clearInterval(this.recordingTimer);
       this.recordingTimer = undefined;
     }
+    if (typeof window !== "undefined") {
+      window.removeEventListener('beforeunload', this.handleRecordingUnload);
+    }
+    this.clearRecordingState();
     this.rrwebBuffer = [];
     this.recordingChunkIndex = 0;
+    this.recordingSnapshotFlushed = false;
   }
 
   private async applyServerRecordingConfig(chunkMs?: number): Promise<void> {

--- a/sdks/js/test/sdk.test.mjs
+++ b/sdks/js/test/sdk.test.mjs
@@ -233,8 +233,11 @@ describe('FunnelBarnClient', () => {
       client.page(); // second page — signals must NOT be re-sent
       await client.flush();
 
-      const firstBody = JSON.parse(requests[0].options.body);
-      const secondBody = JSON.parse(requests[1].options.body);
+      // With window defined, the constructor also fires a GET to
+      // /recording-config (no body), so select only the event POSTs.
+      const eventReqs = requests.filter((r) => r.url.endsWith('/api/v1/events'));
+      const firstBody = JSON.parse(eventReqs[0].options.body);
+      const secondBody = JSON.parse(eventReqs[1].options.body);
 
       // First page_view should carry session_signals.
       assert.ok(

--- a/web/src/components/sessions/SessionReplay.tsx
+++ b/web/src/components/sessions/SessionReplay.tsx
@@ -37,10 +37,15 @@ export function SessionReplay({ projectId, recording, onClose }: Props) {
       if (!playerRef.current) return
       try {
         const allEvents: unknown[] = []
+        // Iterate the explicit stored span [first, last] inclusive. Relying on
+        // first + chunk_count breaks when chunks arrive out of order, retry, or
+        // leave gaps; last_chunk_index is the true upper bound. Fall back to the
+        // count-based span for legacy rows predating last_chunk_index.
         const start = recording.first_chunk_index ?? 0
-        const end = start + recording.chunk_count
-        for (let i = start; i < end; i++) {
-          setProgress(Math.round(((i - start) / recording.chunk_count) * 100))
+        const end = recording.last_chunk_index || (start + recording.chunk_count - 1)
+        const span = Math.max(end - start + 1, 1)
+        for (let i = start; i <= end; i++) {
+          setProgress(Math.round(((i - start) / span) * 100))
           try {
             const chunk = await api.getRecordingChunk(projectId, recording.id, i)
             if (cancelled) return

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -361,6 +361,9 @@ export const api = {
   getRecordingChunk: (projectId: string, recordingId: string, index: number) =>
     request<unknown[]>(`/api/v1/projects/${projectId}/recordings/${recordingId}/chunks/${index}`),
 
+  deleteRecording: (projectId: string, recordingId: string) =>
+    request<void>(`/api/v1/projects/${projectId}/recordings/${recordingId}`, { method: 'DELETE' }),
+
   getRecordingFlags: (projectId: string, recordingId: string) =>
     request<{ evaluations: FlagEvaluationEntry[] }>(`/api/v1/projects/${projectId}/recordings/${recordingId}/flags`),
 
@@ -594,7 +597,9 @@ export interface Recording {
   session_id: string
   environment: string
   first_chunk_index: number
+  last_chunk_index: number
   chunk_count: number
+  has_snapshot: boolean
   duration_ms: number
   started_at: string
   ended_at?: string

--- a/web/src/pages/Sessions.tsx
+++ b/web/src/pages/Sessions.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useParams, useSearchParams } from 'react-router-dom'
-import { Video, ChevronLeft, ChevronRight, Monitor, Smartphone, Tablet, Bot, User } from 'lucide-react'
+import { Video, VideoOff, Trash2, ChevronLeft, ChevronRight, Monitor, Smartphone, Tablet, Bot, User } from 'lucide-react'
 import Shell from '../components/shell/Shell'
 import { SessionReplay } from '../components/sessions/SessionReplay'
 import { api, type Recording } from '../lib/api'
@@ -128,6 +128,19 @@ export default function Sessions() {
     void load(0, filters)
   }, [load, filters])
 
+  const handleDelete = useCallback(async (rec: Recording) => {
+    if (!projectId) return
+    if (!window.confirm('Delete this recording? This cannot be undone.')) return
+    // Optimistically drop the row; reload from the server on failure so the UI
+    // never lies about what's stored.
+    setRecordings((prev) => prev.filter((r) => r.id !== rec.id))
+    try {
+      await api.deleteRecording(projectId, rec.id)
+    } catch {
+      void load(offset, filters)
+    }
+  }, [projectId, load, offset, filters])
+
   const projectName = projects.find((p) => p.id === projectId)?.name
 
   const filterLabel = funnelId && stepParam
@@ -243,7 +256,7 @@ export default function Sessions() {
             {/* Table header */}
             <div style={{
               display: 'grid',
-              gridTemplateColumns: '1fr 90px 90px 110px 90px 40px',
+              gridTemplateColumns: '1fr 90px 90px 110px 90px 110px',
               padding: '0.5rem 1.5rem',
               fontSize: 11, fontWeight: 700, color: C.muted, textTransform: 'uppercase',
               borderBottom: `1px solid ${C.border}`,
@@ -253,19 +266,19 @@ export default function Sessions() {
               <span>Device</span>
               <span>Environment</span>
               <span>Traffic</span>
-              <span />
+              <span>Replay</span>
             </div>
 
             {recordings.map((rec) => (
               <div
                 key={rec.id}
-                onClick={() => setSelected(rec)}
+                onClick={() => { if (rec.has_snapshot) setSelected(rec) }}
                 style={{
                   display: 'grid',
-                  gridTemplateColumns: '1fr 90px 90px 110px 90px 40px',
+                  gridTemplateColumns: '1fr 90px 90px 110px 90px 110px',
                   padding: '0.75rem 1.5rem',
                   borderBottom: `1px solid ${C.border}`,
-                  cursor: 'pointer',
+                  cursor: rec.has_snapshot ? 'pointer' : 'default',
                   transition: 'background 0.1s',
                   alignItems: 'center',
                 }}
@@ -300,8 +313,31 @@ export default function Sessions() {
                   {rec.is_bot ? <Bot size={12} /> : <User size={12} />}
                   <span>{rec.is_bot ? 'Bot' : 'Human'}</span>
                 </div>
-                <div style={{ color: C.muted }}>
-                  <Video size={14} />
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  {rec.has_snapshot ? (
+                    <span style={{ display: 'flex', alignItems: 'center', gap: 4, color: C.muted, fontSize: 12 }}>
+                      <Video size={14} /> Play
+                    </span>
+                  ) : (
+                    <span
+                      title="No initial snapshot was captured — this recording can't be replayed."
+                      style={{ display: 'flex', alignItems: 'center', gap: 4, color: C.muted, fontSize: 11, opacity: 0.7 }}
+                    >
+                      <VideoOff size={14} /> No replay
+                    </span>
+                  )}
+                  <button
+                    onClick={(e) => { e.stopPropagation(); void handleDelete(rec) }}
+                    title="Delete recording"
+                    style={{
+                      background: 'none', border: 'none', cursor: 'pointer',
+                      color: C.muted, padding: 2, display: 'flex', alignItems: 'center',
+                    }}
+                    onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = C.error }}
+                    onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = C.muted }}
+                  >
+                    <Trash2 size={14} />
+                  </button>
                 </div>
               </div>
             ))}


### PR DESCRIPTION
## Problem
Session replay showed "Recording is incomplete — the initial page snapshot is missing." and the sessions list was full of short, unplayable recordings that stopped after a navigation.

## Root causes & fixes
- **Short visits lost the snapshot (SDK).** Only the 10s tick or `beforeunload` (keepalive, 64KB cap) flushed the 1–5MB rrweb snapshot. Now it flushes immediately on capture via a normal `fetch`.
- **Recording restarted on every navigation (SDK).** State now persists per-tab in `sessionStorage` and resumes, so a journey is one continuous replay.
- **`first_chunk_index` followed arrival order (backend).** Upsert now tracks `first`/`last` via `min`/`max` and a sticky `has_snapshot` flag (migration `00022`, with backfill).
- **Playback span was `start + chunk_count` (frontend).** Now iterates the explicit `first..last` inclusive range.

## List & cleanup
- Unplayable rows show a muted **"No replay"** badge and don't open the player.
- Per-row **delete** button → `DELETE /api/v1/projects/{id}/recordings/{rid}`.
- Retention ticker also purges historical broken recordings.

## Verification
- Go: gofmt, vet, staticcheck, `go test ./...` (new tests: out-of-order span, has_snapshot detection, purge, delete scope).
- Web: tsc, eslint (0 errors), vitest 140/140.
- SDK: build + `node --test` 18/18.
- e2e `recording-verify.spec.ts` extended (no "snapshot missing", Replay column + delete control) — runs against the deployed test env.