### PR TITLE
feat(integrations): dedicated Integration Health page with copy-paste agent prompt

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import Dashboard from './pages/Dashboard'
 import Funnels from './pages/Funnels'
 import Live from './pages/Live'
 import Settings from './pages/Settings'
+import IntegrationHealth from './pages/IntegrationHealth'
 import Flags from './pages/Flags'
 import Insights from './pages/Insights'
 import Flows from './pages/Flows'
@@ -211,6 +212,10 @@ function AppRoutes() {
         <Route
           path="/sessions/:projectId"
           element={<ProtectedRoute><Sessions /></ProtectedRoute>}
+        />
+        <Route
+          path="/integrations"
+          element={<ProtectedRoute><IntegrationHealth /></ProtectedRoute>}
         />
         <Route
           path="/settings"

--- a/web/src/components/integrations/AgentInstructions.test.tsx
+++ b/web/src/components/integrations/AgentInstructions.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { buildAgentPrompt, FEATURES } from './features'
+import { Project, ProjectHealth } from '../../lib/api'
+
+const project: Project = { id: 'p1', name: 'Acme', slug: 'acme', status: 'active' }
+
+function health(overrides: Partial<ProjectHealth>): ProjectHealth {
+  return {
+    project_id: 'p1',
+    setup_called: false,
+    events_received: false,
+    flags_evaluated: false,
+    recordings_received: false,
+    updated_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+const ORIGIN = 'https://funnelbarn.example.com'
+
+describe('buildAgentPrompt', () => {
+  it('includes the setup URL with the project slug', () => {
+    const prompt = buildAgentPrompt(health({}), project, ORIGIN)
+    expect(prompt).toContain(`${ORIGIN}/api/v1/setup/acme`)
+  })
+
+  it('lists only the missing capabilities as numbered tasks', () => {
+    // setup + events done, flags + recordings missing.
+    const prompt = buildAgentPrompt(
+      health({ setup_called: true, events_received: true }),
+      project,
+      ORIGIN,
+    )
+
+    const flagsTask = FEATURES.find((f) => f.key === 'flags_evaluated')!.agentTask
+    const recordingsTask = FEATURES.find((f) => f.key === 'recordings_received')!.agentTask
+    const eventsTask = FEATURES.find((f) => f.key === 'events_received')!.agentTask
+
+    expect(prompt).toContain(`1. ${flagsTask}`)
+    expect(prompt).toContain(`2. ${recordingsTask}`)
+    // Completed capabilities must not appear as a to-do.
+    expect(prompt).not.toContain(eventsTask)
+  })
+
+  it('shows a ✅/❌ status line for every capability', () => {
+    const prompt = buildAgentPrompt(
+      health({ setup_called: true }),
+      project,
+      ORIGIN,
+    )
+    expect(prompt).toContain('✅ Setup guide fetched')
+    expect(prompt).toContain('❌ Events received')
+  })
+
+  it('falls back to a placeholder slug when no project is selected', () => {
+    const prompt = buildAgentPrompt(null, null, ORIGIN)
+    expect(prompt).toContain(`${ORIGIN}/api/v1/setup/your-project`)
+  })
+})

--- a/web/src/components/integrations/AgentInstructions.tsx
+++ b/web/src/components/integrations/AgentInstructions.tsx
@@ -1,0 +1,91 @@
+import { Sparkles, CheckCircle } from 'lucide-react'
+import { Project, ProjectHealth } from '../../lib/api'
+import { CopyButton } from '../ui/CopyButton'
+import { FEATURES, buildAgentPrompt } from './features'
+
+const C = {
+  bg: '#0f1117',
+  surface: '#1a1d27',
+  border: '#2a2d3a',
+  amber: '#f59e0b',
+  text: '#e2e8f0',
+  muted: '#94a3b8',
+  success: '#10b981',
+}
+
+interface AgentInstructionsProps {
+  health: ProjectHealth | null
+  project: Project | null
+}
+
+export function AgentInstructions({ health, project }: AgentInstructionsProps) {
+  const allDone =
+    health !== null && FEATURES.every((f) => health[f.key] as boolean)
+
+  const prompt = buildAgentPrompt(health, project, window.location.origin)
+
+  return (
+    <div style={{
+      background: C.surface,
+      border: `1px solid ${C.border}`,
+      borderRadius: 12,
+      overflow: 'hidden',
+      marginBottom: '2rem',
+    }}>
+      {/* Header */}
+      <div style={{ padding: '1.25rem 1.5rem', borderBottom: `1px solid ${C.border}` }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Sparkles size={16} color={C.amber} />
+          <div style={{ fontWeight: 700, fontSize: 15 }}>Agent instructions</div>
+        </div>
+        <div style={{ fontSize: 13, color: C.muted, marginTop: 2 }}>
+          Copy this prompt into an LLM coding agent (Claude Code, Cursor, …) to finish the
+          steps this project hasn't completed yet.
+        </div>
+      </div>
+
+      <div style={{ padding: '1.25rem 1.5rem' }}>
+        {allDone ? (
+          <div style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            background: 'rgba(16,185,129,0.08)',
+            border: `1px solid rgba(16,185,129,0.25)`,
+            borderRadius: 10,
+            padding: '1rem',
+            color: C.success,
+            fontSize: 14,
+            fontWeight: 600,
+          }}>
+            <CheckCircle size={18} />
+            All capabilities integrated — nothing left to hand to an agent.
+          </div>
+        ) : (
+          <>
+            <div style={{
+              background: C.bg,
+              border: `1px solid ${C.border}`,
+              borderRadius: 10,
+              padding: '1rem',
+              marginBottom: '0.75rem',
+              fontFamily: '"SF Mono", "Fira Code", monospace',
+              fontSize: 12.5,
+              lineHeight: 1.6,
+              color: '#a5f3fc',
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+              maxHeight: 360,
+              overflowY: 'auto',
+            }}>
+              {prompt}
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+              <CopyButton value={prompt} />
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/integrations/features.ts
+++ b/web/src/components/integrations/features.ts
@@ -1,0 +1,88 @@
+import { Project, ProjectHealth } from '../../lib/api'
+
+// The four capabilities Integration Health tracks. Each maps to a boolean flag
+// on ProjectHealth that flips to true the first time the implementing agent
+// actually exercises that part of the FunnelBarn API.
+//
+// `description` is the wire-level endpoint shown in the checklist UI.
+// `agentTask` is a one-line instruction handed to an integrating LLM agent,
+// pointing it at the relevant section of the setup guide.
+export interface HealthFeature {
+  key: keyof ProjectHealth
+  label: string
+  description: string
+  agentTask: string
+}
+
+export const FEATURES: HealthFeature[] = [
+  {
+    key: 'setup_called',
+    label: 'Setup guide fetched',
+    description: 'GET /api/v1/setup/{slug}',
+    agentTask: 'Fetch the setup guide (the URL above) and use it as the source of truth for the API key, endpoint and headers.',
+  },
+  {
+    key: 'events_received',
+    label: 'Events received',
+    description: 'POST /api/v1/events',
+    agentTask: 'Send analytics events to POST /api/v1/events (page views + key user actions) — see the "Event body schema" and SDK sections of the setup guide.',
+  },
+  {
+    key: 'flags_evaluated',
+    label: 'Flag evaluations',
+    description: 'POST /api/v1/evaluate',
+    agentTask: 'Evaluate feature flags at runtime via POST /api/v1/evaluate, passing a `context.targeting_key` for sticky bucketing — see the "Feature Flags" section.',
+  },
+  {
+    key: 'recordings_received',
+    label: 'Session recordings',
+    description: 'POST /api/v1/recordings/chunk',
+    agentTask: 'Enable rrweb session recording (`recording: true` in the JS SDK, or `data-recording="true"` on the script tag) — see the "Session Recording" section.',
+  },
+]
+
+/**
+ * Build a concise, copy-pasteable prompt for an LLM coding agent that is
+ * integrating FunnelBarn. It points the agent at the authoritative (public,
+ * idempotent) setup guide and lists ONLY the capabilities not yet detected, so
+ * the agent skips work that's already done.
+ *
+ * Pure + exported so it can be unit-tested without rendering.
+ */
+export function buildAgentPrompt(
+  health: ProjectHealth | null,
+  project: Project | null,
+  origin: string,
+): string {
+  const slug = project?.slug ?? 'your-project'
+  const setupURL = `${origin}/api/v1/setup/${slug}`
+  const done = (key: HealthFeature['key']) =>
+    health ? (health[key] as boolean) : false
+
+  const missing = FEATURES.filter((f) => !done(f.key))
+
+  const statusList = FEATURES.map(
+    (f) => `${done(f.key) ? '✅' : '❌'} ${f.label}`,
+  ).join('\n')
+
+  const todoList = missing
+    .map((f, i) => `${i + 1}. ${f.agentTask}`)
+    .join('\n')
+
+  return [
+    `You are integrating FunnelBarn (analytics, feature flags and session recording) into this codebase.`,
+    ``,
+    `Authoritative setup guide — fetch this first and treat it as the source of truth. It is idempotent and includes the project's API key, the required request headers, and ready-to-paste SDK snippets for JavaScript/TypeScript, Python, Go and raw HTTP:`,
+    `  ${setupURL}`,
+    ``,
+    `Integration status so far (auto-detected by FunnelBarn from real traffic):`,
+    statusList,
+    ``,
+    `Complete ONLY the steps that are still missing:`,
+    todoList,
+    ``,
+    `Notes:`,
+    `- Wire each capability where it genuinely belongs in the app. Do NOT fabricate calls just to flip a check — the dashboard ticks each item automatically once real traffic arrives.`,
+    `- Reuse the same API key and project across dev/staging/prod; tag events with an "environment" field so the dashboard can filter them.`,
+  ].join('\n')
+}

--- a/web/src/components/settings/ProjectHealthCard.tsx
+++ b/web/src/components/settings/ProjectHealthCard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { CheckCircle, Circle, RotateCcw } from 'lucide-react'
 import { api, Project, ProjectHealth } from '../../lib/api'
 import { reportError } from '../../lib/bugbarn'
+import { FEATURES } from '../integrations/features'
 
 const C = {
   bg: '#0f1117',
@@ -14,19 +15,15 @@ const C = {
   success: '#10b981',
 }
 
-const FEATURES: { key: keyof ProjectHealth; label: string; description: string }[] = [
-  { key: 'setup_called', label: 'Setup guide fetched', description: 'GET /api/v1/setup/{slug}' },
-  { key: 'events_received', label: 'Events received', description: 'POST /api/v1/events' },
-  { key: 'flags_evaluated', label: 'Flag evaluations', description: 'POST /api/v1/evaluate' },
-  { key: 'recordings_received', label: 'Session recordings', description: 'POST /api/v1/recordings/chunk' },
-]
-
 interface ProjectHealthCardProps {
   projects: Project[]
   defaultProjectId: string | null
+  /** Notified whenever the loaded health / selected project changes, so a
+   *  sibling (e.g. the agent-instruction generator) can share the same data. */
+  onHealthChange?: (health: ProjectHealth | null, project: Project | null) => void
 }
 
-export function ProjectHealthCard({ projects, defaultProjectId }: ProjectHealthCardProps) {
+export function ProjectHealthCard({ projects, defaultProjectId, onHealthChange }: ProjectHealthCardProps) {
   const [selectedId, setSelectedId] = useState<string>('')
   const [health, setHealth] = useState<ProjectHealth | null>(null)
   const [loading, setLoading] = useState(false)
@@ -45,9 +42,13 @@ export function ProjectHealthCard({ projects, defaultProjectId }: ProjectHealthC
     setLoading(true)
     setError(null)
     api.getProjectHealth(selectedId)
-      .then(setHealth)
+      .then((h) => {
+        setHealth(h)
+        onHealthChange?.(h, projects.find((p) => p.id === selectedId) ?? null)
+      })
       .catch((e) => { reportError(e, { source: 'ProjectHealthCard.getProjectHealth' }); setError(String(e)) })
       .finally(() => setLoading(false))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedId])
 
   const handleReset = async () => {
@@ -58,6 +59,7 @@ export function ProjectHealthCard({ projects, defaultProjectId }: ProjectHealthC
       await api.resetProjectHealth(selectedId)
       const updated = await api.getProjectHealth(selectedId)
       setHealth(updated)
+      onHealthChange?.(updated, projects.find((p) => p.id === selectedId) ?? null)
     } catch (e) {
       reportError(e, { source: 'ProjectHealthCard.resetProjectHealth' })
       setError(String(e))

--- a/web/src/components/shell/MoreSheet.tsx
+++ b/web/src/components/shell/MoreSheet.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from 'react-router-dom'
-import { Settings, LogOut, User, ExternalLink, Flag, Radio, Lightbulb } from 'lucide-react'
+import { Settings, LogOut, User, ExternalLink, Flag, Radio, Lightbulb, PlugZap } from 'lucide-react'
 import { useAuth } from '../../lib/auth'
 import { ProjectPicker } from '../ui/ProjectPicker'
 import { type Project } from '../../lib/api'
@@ -111,6 +111,7 @@ export function MoreSheet({ projectId, projects, iambarnProfileURL, onClose, onL
           { to: projectId ? `/flags/${projectId}` : '/flags', label: 'Flags', icon: Flag },
           { to: projectId ? `/live/${projectId}` : '/live', label: 'Live', icon: Radio },
           { to: projectId ? `/insights/${projectId}` : '/insights', label: 'Insights', icon: Lightbulb },
+          { to: '/integrations', label: 'Integrations', icon: PlugZap },
         ].map(({ to, label, icon: Icon }) => (
           <Link
             key={to}

--- a/web/src/components/shell/Shell.tsx
+++ b/web/src/components/shell/Shell.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useEffect, useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
-import { BarChart2, Layers, Radio, Settings, Flag, Lightbulb, GitBranch, Video } from 'lucide-react'
+import { BarChart2, Layers, Radio, Settings, Flag, Lightbulb, GitBranch, Video, PlugZap } from 'lucide-react'
 import { useAuth } from '../../lib/auth'
 import { useProjects } from '../../lib/projects'
 import { LAST_PROJECT_ID_KEY } from '../ui/ProjectPicker'
@@ -80,6 +80,7 @@ export default function Shell({ children, projectId, projectName, projects: proj
     { to: projectId ? `/insights/${projectId}` : '/insights', label: 'Insights', icon: <Lightbulb size={16} /> },
     { to: projectId ? `/live/${projectId}` : '/live', label: 'Live', icon: <Radio size={16} /> },
     { to: projectId ? `/sessions/${projectId}` : '/sessions', label: 'Sessions', icon: <Video size={16} /> },
+    { to: '/integrations', label: 'Integrations', icon: <PlugZap size={16} /> },
     { to: '/settings', label: 'Settings', icon: <Settings size={16} /> },
   ]
 

--- a/web/src/pages/IntegrationHealth.tsx
+++ b/web/src/pages/IntegrationHealth.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react'
+import Shell from '../components/shell/Shell'
+import { useProjects } from '../lib/projects'
+import { Project, ProjectHealth } from '../lib/api'
+import { ProjectHealthCard } from '../components/settings/ProjectHealthCard'
+import { AgentInstructions } from '../components/integrations/AgentInstructions'
+
+const C = {
+  muted: '#94a3b8',
+  text: '#e2e8f0',
+}
+
+export default function IntegrationHealth() {
+  const { projects, defaultProjectId } = useProjects()
+  const [health, setHealth] = useState<ProjectHealth | null>(null)
+  const [project, setProject] = useState<Project | null>(null)
+
+  return (
+    <Shell>
+      <h1 style={{ fontSize: 24, fontWeight: 800, letterSpacing: '-0.5px', marginBottom: '0.5rem' }}>
+        Integration Health
+      </h1>
+      <p style={{ fontSize: 14, color: C.muted, marginBottom: '2rem', maxWidth: 680, lineHeight: 1.6 }}>
+        FunnelBarn auto-detects which parts of the integration each project has actually exercised.
+        Hand the generated prompt below to an LLM coding agent to finish whatever's still missing.
+      </p>
+
+      {projects.length === 0 ? (
+        <div style={{ fontSize: 14, color: C.text }}>
+          Create a project first — integration health is tracked per project.
+        </div>
+      ) : (
+        <>
+          <ProjectHealthCard
+            projects={projects}
+            defaultProjectId={defaultProjectId}
+            onHealthChange={(h, p) => { setHealth(h); setProject(p) }}
+          />
+          <AgentInstructions health={health} project={project} />
+        </>
+      )}
+    </Shell>
+  )
+}

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -7,7 +7,6 @@ import { CopyButton } from '../components/ui/CopyButton'
 import { reportError } from '../lib/bugbarn'
 import { ProjectSettings } from '../components/settings/ProjectSettings'
 import { ApiKeySettings } from '../components/settings/ApiKeySettings'
-import { ProjectHealthCard } from '../components/settings/ProjectHealthCard'
 
 const C = {
   bg: '#0f1117',
@@ -210,11 +209,6 @@ export default function Settings() {
         loading={loading}
         projects={projects}
         onError={setError}
-      />
-
-      <ProjectHealthCard
-        projects={projects}
-        defaultProjectId={defaultProjectId}
       />
 
       {/* Event retention info */}


### PR DESCRIPTION
## What

Promotes the **Integration Health** checklist off the Settings page into its own dedicated `/integrations` page, and adds a **copy-pasteable prompt for an LLM coding agent** that lists only the integration steps a project hasn't completed yet.

## Why

Integration Health was a card buried at the bottom of Settings. Giving it its own page makes it discoverable, and the generated agent prompt lets you hand an LLM agent (e.g. Cursor) exactly the steps still missing — it points the agent at the existing public, idempotent setup guide (`/api/v1/setup/{slug}`), which already carries the API key, headers and SDK snippets.

## How

- **New page** `web/src/pages/IntegrationHealth.tsx` (route `/integrations`) owns the shared health/project state and renders the checklist + the new agent-instruction card.
- **`web/src/components/integrations/`** — `features.ts` is the single source of truth for the four tracked capabilities (now with an `agentTask` each) plus the pure, unit-tested `buildAgentPrompt()`; `AgentInstructions.tsx` renders the prompt with a copy button (or an "all integrated" state).
- `ProjectHealthCard` gains an optional `onHealthChange` callback and shares the `FEATURES` module; otherwise unchanged.
- Nav: added an **Integrations** link to the desktop top nav and the mobile More sheet — deliberately **not** to the bottom tab bar, which is at the 5-item PWA limit.
- Removed the card from Settings.

No backend changes — the prompt is derived entirely client-side from existing `ProjectHealth` data.

## Verification

- `tsc --noEmit` clean, `eslint` clean (no new warnings)
- `vitest run` — 144 tests pass, including 4 new tests for `buildAgentPrompt`
- `vite build` succeeds