### PR TITLE
Auto-register feature flags on evaluation

### DIFF
--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -272,6 +272,7 @@ func run() error {
 		Recordings:          recordingsSvc,
 		RecordingSettings:   store,
 		ProjectHealth:       healthSvc,
+		FlagAutoRegisterMax: cfg.AutoRegisterMaxFlags,
 	})
 	if cfg.MetricsToken != "" {
 		apiServer.SetMetricsToken(cfg.MetricsToken)
@@ -381,6 +382,15 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 					slog.Error("purge old evaluations", "err", err)
 				} else if ne > 0 {
 					slog.Info("purged old evaluations", "count", ne, "before", cutoff.Format(time.DateOnly))
+				}
+			}
+			if cfg.AutoRegisterTTLDays > 0 {
+				cutoff := time.Now().AddDate(0, 0, -cfg.AutoRegisterTTLDays)
+				nf, err := store.PurgeStaleAutoFlags(ctx, cutoff)
+				if err != nil {
+					slog.Error("purge stale auto flags", "err", err)
+				} else if nf > 0 {
+					slog.Info("purged stale auto flags", "count", nf, "before", cutoff.Format(time.DateOnly))
 				}
 			}
 			if recordings != nil {

--- a/internal/api/flags.go
+++ b/internal/api/flags.go
@@ -2,11 +2,13 @@ package api
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/wiebe-xyz/funnelbarn/internal/domain"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 	"github.com/wiebe-xyz/funnelbarn/internal/service"
 )
@@ -239,21 +241,24 @@ func (s *Server) handleEvaluateFlag(w http.ResponseWriter, r *http.Request) {
 			}
 		}()
 	}
-	s.evaluateFlagInProject(w, r, projectID)
+	// SDK callers auto-register unknown flags so they surface in the dashboard.
+	s.evaluateFlagInProject(w, r, projectID, true)
 }
 
 // handlePlaygroundEvaluateFlag is the session-authed dashboard counterpart of
 // handleEvaluateFlag. The project ID comes from the URL instead of the API key.
+// The dashboard playground never auto-registers — it's a testing surface, and a
+// typo there shouldn't create a flag.
 func (s *Server) handlePlaygroundEvaluateFlag(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
 	if projectID == "" {
 		jsonError(w, "project id required", http.StatusBadRequest)
 		return
 	}
-	s.evaluateFlagInProject(w, r, projectID)
+	s.evaluateFlagInProject(w, r, projectID, false)
 }
 
-func (s *Server) evaluateFlagInProject(w http.ResponseWriter, r *http.Request, projectID string) {
+func (s *Server) evaluateFlagInProject(w http.ResponseWriter, r *http.Request, projectID string, autoRegister bool) {
 	var body struct {
 		FlagKey      string         `json:"flag_key"`
 		DefaultValue any            `json:"default_value"`
@@ -271,19 +276,32 @@ func (s *Server) evaluateFlagInProject(w http.ResponseWriter, r *http.Request, p
 		body.Context = map[string]any{}
 	}
 
-	result, err := s.flags.EvaluateFlag(r.Context(), projectID, body.FlagKey, body.Context)
+	var result service.FlagEvalResult
+	var err error
+	if autoRegister {
+		result, err = s.flags.EvaluateOrRegisterFlag(r.Context(), projectID, body.FlagKey, body.Context, body.DefaultValue, s.flagAutoRegisterMax)
+	} else {
+		result, err = s.flags.EvaluateFlag(r.Context(), projectID, body.FlagKey, body.Context)
+	}
 	if err != nil {
 		errorCode := "GENERAL"
-		if strings.Contains(err.Error(), "flag not found") {
+		switch {
+		case errors.Is(err, domain.ErrAutoRegisterLimit):
+			errorCode = "AUTO_REGISTER_LIMIT"
+		case strings.Contains(err.Error(), "flag not found"):
 			errorCode = "FLAG_NOT_FOUND"
 		}
-		// FLAG_NOT_FOUND is normal client behaviour; everything else (DB
-		// failure, JSON corruption) is a real server problem that was
-		// previously hidden behind a 200 OK + reason=ERROR. Surface those.
-		if errorCode == "FLAG_NOT_FOUND" {
+		// FLAG_NOT_FOUND is normal client behaviour; AUTO_REGISTER_LIMIT is a
+		// possible-abuse signal worth a warning; everything else (DB failure,
+		// JSON corruption) is a real server problem to surface.
+		switch errorCode {
+		case "FLAG_NOT_FOUND":
 			slog.DebugContext(r.Context(), "flag evaluate: not found",
 				"project_id", projectID, "flag_key", body.FlagKey)
-		} else {
+		case "AUTO_REGISTER_LIMIT":
+			slog.WarnContext(r.Context(), "flag auto-register limit reached",
+				"handled", true, "project_id", projectID, "flag_key", body.FlagKey)
+		default:
 			slog.ErrorContext(r.Context(), "flag evaluate failed",
 				"err", err, "handled", false,
 				"project_id", projectID,

--- a/internal/api/flags_evaluate_test.go
+++ b/internal/api/flags_evaluate_test.go
@@ -1,7 +1,10 @@
 package api
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -251,5 +254,151 @@ func TestHandleClientConfig_ExposesBugbarnFields(t *testing.T) {
 	}
 	if resp["bugbarn_project"] != "funnelbarn" {
 		t.Errorf("bugbarn_project: got %v (expected dogfood routing slug)", resp["bugbarn_project"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// handleEvaluateFlag — API-key SDK endpoint, which auto-registers unknown flags.
+// ---------------------------------------------------------------------------
+
+// newSDKServer builds a server whose ingest authorizer maps a fixed API key to a
+// freshly-created project (scope "ingest"), so the SDK evaluate endpoint resolves
+// a concrete project ID and can auto-register flags.
+func newSDKServer(t *testing.T, maxAuto int) (*Server, *repository.Store, string, string) {
+	t.Helper()
+	store := openMemoryStore(t)
+	sp := newTestSpool(t)
+	p, err := store.CreateProject(context.Background(), "SDK", "sdk")
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	const apiKey = "proj-sdk-key"
+	sum := sha256.Sum256([]byte(apiKey))
+	wantHash := hex.EncodeToString(sum[:])
+	lookup := func(_ context.Context, keySHA256 string) (string, string, bool, error) {
+		if keySHA256 == wantHash {
+			return p.ID, "ingest", true, nil
+		}
+		return "", "", false, nil
+	}
+	authorizer := auth.New("").WithDBLookup(lookup, nil)
+	ingestHandler := ingest.NewHandler(authorizer, sp, 0)
+	sm := auth.NewSessionManager("test-secret", time.Hour)
+	userAuth, _ := auth.NewUserAuthenticator("", "", "")
+
+	srv := NewServer(ServerConfig{
+		Ingest:              ingestHandler,
+		Projects:            service.NewProjectService(store),
+		Funnels:             service.NewFunnelService(store),
+		ABTests:             service.NewABTestService(store),
+		Flags:               service.NewFlagService(store),
+		Events:              service.NewEventService(store),
+		Sessions:            service.NewSessionService(store),
+		APIKeys:             service.NewAPIKeyService(store),
+		Widgets:             service.NewWidgetService(store),
+		UserAuth:            userAuth,
+		SessionManager:      sm,
+		SessionSecret:       "test-secret",
+		PublicURL:           "http://localhost",
+		LoginRatePerMinute:  1000,
+		LoginRateBurst:      1000,
+		APIRatePerMinute:    1000,
+		APIRateBurst:        1000,
+		IngestRatePerMinute: 1000,
+		IngestRateBurst:     1000,
+		DB:                  store,
+		Version:             "test",
+		FlagAutoRegisterMax: maxAuto,
+	})
+	return srv, store, p.ID, apiKey
+}
+
+func postEvaluateSDK(t *testing.T, srv *Server, apiKey string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/evaluate", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(auth.HeaderAPIKey, apiKey)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	return w
+}
+
+func TestSDKEvaluate_AutoRegistersUnknownFlag(t *testing.T) {
+	srv, store, projectID, apiKey := newSDKServer(t, 100)
+
+	w := postEvaluateSDK(t, srv, apiKey, map[string]any{
+		"flag_key":      "anon_qr_limit",
+		"default_value": float64(3),
+		"context":       map[string]any{"targeting_key": "device-1"},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["reason"] != "DISABLED" {
+		t.Errorf("reason: want DISABLED for a freshly auto-created flag, got %v", resp["reason"])
+	}
+	if resp["value"] != float64(3) {
+		t.Errorf("value: want 3 (caller default), got %v", resp["value"])
+	}
+
+	flags, err := store.ListFlags(context.Background(), projectID)
+	if err != nil {
+		t.Fatalf("ListFlags: %v", err)
+	}
+	if len(flags) != 1 {
+		t.Fatalf("want 1 auto-registered flag, got %d", len(flags))
+	}
+	if flags[0].Origin != "auto" || flags[0].Status != "inactive" {
+		t.Errorf("auto flag should be origin=auto status=inactive, got origin=%q status=%q", flags[0].Origin, flags[0].Status)
+	}
+}
+
+func TestSDKEvaluate_AutoRegisterLimit(t *testing.T) {
+	srv, store, projectID, apiKey := newSDKServer(t, 1)
+
+	// First unknown flag registers fine.
+	if w := postEvaluateSDK(t, srv, apiKey, map[string]any{"flag_key": "flag_a", "default_value": true}); w.Code != http.StatusOK {
+		t.Fatalf("flag_a: want 200, got %d", w.Code)
+	}
+	// Second exceeds the cap of 1.
+	w := postEvaluateSDK(t, srv, apiKey, map[string]any{"flag_key": "flag_b", "default_value": true})
+	if w.Code != http.StatusOK {
+		t.Fatalf("flag_b: want 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["error_code"] != "AUTO_REGISTER_LIMIT" {
+		t.Errorf("error_code: want AUTO_REGISTER_LIMIT, got %v", resp["error_code"])
+	}
+	if resp["value"] != true {
+		t.Errorf("value: want true (caller default), got %v", resp["value"])
+	}
+
+	flags, _ := store.ListFlags(context.Background(), projectID)
+	if len(flags) != 1 {
+		t.Errorf("cap should hold the project at 1 auto flag, got %d", len(flags))
+	}
+}
+
+func TestPlaygroundEvaluate_DoesNotAutoRegister(t *testing.T) {
+	srv, store := newAuthedServer(t)
+	p, _, cookie, csrf := playgroundFlag(t, srv, store, "noauto")
+	// Remove the seeded flag so we can assert nothing new is created.
+	before, _ := store.ListFlags(context.Background(), p.ID)
+
+	w := postJSONWithCSRF(t, srv, "/api/v1/projects/"+p.ID+"/flags/evaluate", map[string]any{
+		"flag_key":      "never_created_by_playground",
+		"default_value": "x",
+		"context":       map[string]any{},
+	}, cookie, csrf)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", w.Code)
+	}
+	after, _ := store.ListFlags(context.Background(), p.ID)
+	if len(after) != len(before) {
+		t.Errorf("playground must not auto-register: flag count changed %d -> %d", len(before), len(after))
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -74,6 +74,10 @@ type ServerConfig struct {
 	Recordings        service.Recordings
 	RecordingSettings ProjectRecordingSettingsRepo
 	ProjectHealth     service.ProjectHealth
+
+	// FlagAutoRegisterMax caps auto-created flags per project on the SDK evaluate
+	// endpoint (0 disables auto-registration).
+	FlagAutoRegisterMax int
 }
 
 // DistributionRepo provides session field distribution data.
@@ -95,41 +99,42 @@ type GeoAnonymizer interface {
 
 // Server is the main HTTP API server.
 type Server struct {
-	mux                *http.ServeMux
-	db                 Pinger
-	projects           service.Projects
-	funnels            service.Funnels
-	abtests            service.ABTests
-	flags              service.Flags
-	events             service.Events
-	sessions           service.Sessions
-	apikeys            service.APIKeys
-	widgets            service.Widgets
-	ingest             *ingest.Handler
-	userAuth           *auth.UserAuthenticator
-	sessionManager     *auth.SessionManager
-	allowedOrigins     []string
-	sessionSecret      string
-	publicURL          string
-	metricsToken       string
-	version            string
-	bugbarnEndpoint    string
-	bugbarnIngestKey   string
-	bugbarnProject     string
-	dogfoodAPIKey      string
-	dogfoodProject     string
-	trustedProxies     []string
-	iambarnProvider    *iambarn.Provider
-	iambarnUsers       IAMBarnUserRepo
-	iambarnFlagProject string
-	oidc               *auth.OIDCClient
-	instanceSettings   InstanceSettingsRepo
-	geoAnonymizer      GeoAnonymizer
-	segments           service.Segments
-	distributions      DistributionRepo
-	recordings         service.Recordings
-	recordingSettings  ProjectRecordingSettingsRepo
-	projectHealth      service.ProjectHealth
+	mux                 *http.ServeMux
+	db                  Pinger
+	projects            service.Projects
+	funnels             service.Funnels
+	abtests             service.ABTests
+	flags               service.Flags
+	events              service.Events
+	sessions            service.Sessions
+	apikeys             service.APIKeys
+	widgets             service.Widgets
+	ingest              *ingest.Handler
+	userAuth            *auth.UserAuthenticator
+	sessionManager      *auth.SessionManager
+	allowedOrigins      []string
+	sessionSecret       string
+	publicURL           string
+	metricsToken        string
+	version             string
+	bugbarnEndpoint     string
+	bugbarnIngestKey    string
+	bugbarnProject      string
+	dogfoodAPIKey       string
+	dogfoodProject      string
+	trustedProxies      []string
+	iambarnProvider     *iambarn.Provider
+	iambarnUsers        IAMBarnUserRepo
+	iambarnFlagProject  string
+	oidc                *auth.OIDCClient
+	instanceSettings    InstanceSettingsRepo
+	geoAnonymizer       GeoAnonymizer
+	segments            service.Segments
+	distributions       DistributionRepo
+	recordings          service.Recordings
+	recordingSettings   ProjectRecordingSettingsRepo
+	projectHealth       service.ProjectHealth
+	flagAutoRegisterMax int
 
 	loginLimiter  *rateLimiter
 	eventsLimiter *rateLimiter
@@ -149,44 +154,45 @@ func NewServer(cfg ServerConfig) *Server {
 	}
 
 	s := &Server{
-		mux:                http.NewServeMux(),
-		db:                 cfg.DB,
-		version:            cfg.Version,
-		projects:           cfg.Projects,
-		funnels:            cfg.Funnels,
-		abtests:            cfg.ABTests,
-		flags:              cfg.Flags,
-		events:             cfg.Events,
-		sessions:           cfg.Sessions,
-		apikeys:            cfg.APIKeys,
-		widgets:            cfg.Widgets,
-		ingest:             cfg.Ingest,
-		userAuth:           cfg.UserAuth,
-		sessionManager:     cfg.SessionManager,
-		allowedOrigins:     cfg.AllowedOrigins,
-		sessionSecret:      cfg.SessionSecret,
-		publicURL:          cfg.PublicURL,
-		bugbarnEndpoint:    cfg.BugbarnEndpoint,
-		bugbarnIngestKey:   cfg.BugbarnIngestKey,
-		bugbarnProject:     cfg.BugbarnProject,
-		dogfoodAPIKey:      cfg.DogfoodAPIKey,
-		dogfoodProject:     cfg.DogfoodProject,
-		trustedProxies:     cfg.TrustedProxies,
-		loginLimiter:       newRateLimiter(cfg.LoginRatePerMinute, cfg.LoginRateBurst),
-		eventsLimiter:      newRateLimiter(cfg.IngestRatePerMinute, cfg.IngestRateBurst),
-		apiLimiter:         newRateLimiter(cfg.APIRatePerMinute, cfg.APIRateBurst),
-		setupLimiter:       newRateLimiter(setupRate, setupBurst),
-		iambarnProvider:    cfg.IAMBarnProvider,
-		iambarnUsers:       cfg.IAMBarnUsers,
-		iambarnFlagProject: cfg.IAMBarnFlagProject,
-		oidc:               cfg.OIDC,
-		instanceSettings:   cfg.InstanceSettings,
-		geoAnonymizer:      cfg.GeoAnonymizer,
-		segments:           cfg.Segments,
-		distributions:      cfg.Distributions,
-		recordings:         cfg.Recordings,
-		recordingSettings:  cfg.RecordingSettings,
-		projectHealth:      cfg.ProjectHealth,
+		mux:                 http.NewServeMux(),
+		db:                  cfg.DB,
+		version:             cfg.Version,
+		projects:            cfg.Projects,
+		funnels:             cfg.Funnels,
+		abtests:             cfg.ABTests,
+		flags:               cfg.Flags,
+		events:              cfg.Events,
+		sessions:            cfg.Sessions,
+		apikeys:             cfg.APIKeys,
+		widgets:             cfg.Widgets,
+		ingest:              cfg.Ingest,
+		userAuth:            cfg.UserAuth,
+		sessionManager:      cfg.SessionManager,
+		allowedOrigins:      cfg.AllowedOrigins,
+		sessionSecret:       cfg.SessionSecret,
+		publicURL:           cfg.PublicURL,
+		bugbarnEndpoint:     cfg.BugbarnEndpoint,
+		bugbarnIngestKey:    cfg.BugbarnIngestKey,
+		bugbarnProject:      cfg.BugbarnProject,
+		dogfoodAPIKey:       cfg.DogfoodAPIKey,
+		dogfoodProject:      cfg.DogfoodProject,
+		trustedProxies:      cfg.TrustedProxies,
+		loginLimiter:        newRateLimiter(cfg.LoginRatePerMinute, cfg.LoginRateBurst),
+		eventsLimiter:       newRateLimiter(cfg.IngestRatePerMinute, cfg.IngestRateBurst),
+		apiLimiter:          newRateLimiter(cfg.APIRatePerMinute, cfg.APIRateBurst),
+		setupLimiter:        newRateLimiter(setupRate, setupBurst),
+		iambarnProvider:     cfg.IAMBarnProvider,
+		iambarnUsers:        cfg.IAMBarnUsers,
+		iambarnFlagProject:  cfg.IAMBarnFlagProject,
+		oidc:                cfg.OIDC,
+		instanceSettings:    cfg.InstanceSettings,
+		geoAnonymizer:       cfg.GeoAnonymizer,
+		segments:            cfg.Segments,
+		distributions:       cfg.Distributions,
+		recordings:          cfg.Recordings,
+		recordingSettings:   cfg.RecordingSettings,
+		projectHealth:       cfg.ProjectHealth,
+		flagAutoRegisterMax: cfg.FlagAutoRegisterMax,
 	}
 	s.registerRoutes()
 	return s

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,19 +33,26 @@ type Config struct {
 	DogfoodAPIKey       string
 	DogfoodProject      string
 	EventRetentionDays  int // 0 = disabled; default 90
-	LoginRatePerMinute  float64
-	LoginRateBurst      float64
-	APIRatePerMinute    float64
-	APIRateBurst        float64
-	MetricsToken        string
-	LogLevel            slog.Level
-	IngestRatePerMinute float64
-	IngestRateBurst     float64
-	SpanBarnEndpoint    string
-	SpanBarnAPIKey      string
-	TrustedProxies      []string
-	SetupRatePerMinute  float64
-	SetupRateBurst      float64
+
+	// AutoRegisterMaxFlags caps auto-created flags per project (0 disables
+	// auto-registration). AutoRegisterTTLDays is how long an auto-created,
+	// never-configured flag survives without evaluations before pruning (0
+	// disables pruning).
+	AutoRegisterMaxFlags int
+	AutoRegisterTTLDays  int
+	LoginRatePerMinute   float64
+	LoginRateBurst       float64
+	APIRatePerMinute     float64
+	APIRateBurst         float64
+	MetricsToken         string
+	LogLevel             slog.Level
+	IngestRatePerMinute  float64
+	IngestRateBurst      float64
+	SpanBarnEndpoint     string
+	SpanBarnAPIKey       string
+	TrustedProxies       []string
+	SetupRatePerMinute   float64
+	SetupRateBurst       float64
 
 	IAMBarnClientID string
 	IAMBarnIssuer   string
@@ -118,6 +125,21 @@ func Load() Config {
 	if raw := os.Getenv("FUNNELBARN_EVENT_RETENTION_DAYS"); raw != "" {
 		if parsed, err := strconv.Atoi(raw); err == nil && parsed >= 0 {
 			cfg.EventRetentionDays = parsed
+		}
+	}
+
+	// Flag auto-registration — default cap 100 per project, prune stale
+	// never-configured auto flags after 30 days.
+	cfg.AutoRegisterMaxFlags = 100
+	if raw := os.Getenv("FUNNELBARN_FLAG_AUTOREGISTER_MAX"); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed >= 0 {
+			cfg.AutoRegisterMaxFlags = parsed
+		}
+	}
+	cfg.AutoRegisterTTLDays = 30
+	if raw := os.Getenv("FUNNELBARN_FLAG_AUTOREGISTER_TTL_DAYS"); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed >= 0 {
+			cfg.AutoRegisterTTLDays = parsed
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -174,3 +174,27 @@ func TestApplyConfigFile_DoesNotOverrideExisting(t *testing.T) {
 		t.Errorf("existing env var should not be overridden: got %q", got)
 	}
 }
+
+func TestLoad_FlagAutoRegisterDefaults(t *testing.T) {
+	t.Setenv("FUNNELBARN_FLAG_AUTOREGISTER_MAX", "")
+	t.Setenv("FUNNELBARN_FLAG_AUTOREGISTER_TTL_DAYS", "")
+	cfg := Load()
+	if cfg.AutoRegisterMaxFlags != 100 {
+		t.Errorf("AutoRegisterMaxFlags default: want 100, got %d", cfg.AutoRegisterMaxFlags)
+	}
+	if cfg.AutoRegisterTTLDays != 30 {
+		t.Errorf("AutoRegisterTTLDays default: want 30, got %d", cfg.AutoRegisterTTLDays)
+	}
+}
+
+func TestLoad_FlagAutoRegisterOverrides(t *testing.T) {
+	t.Setenv("FUNNELBARN_FLAG_AUTOREGISTER_MAX", "0")
+	t.Setenv("FUNNELBARN_FLAG_AUTOREGISTER_TTL_DAYS", "7")
+	cfg := Load()
+	if cfg.AutoRegisterMaxFlags != 0 {
+		t.Errorf("AutoRegisterMaxFlags: want 0 (disabled), got %d", cfg.AutoRegisterMaxFlags)
+	}
+	if cfg.AutoRegisterTTLDays != 7 {
+		t.Errorf("AutoRegisterTTLDays: want 7, got %d", cfg.AutoRegisterTTLDays)
+	}
+}

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -9,6 +9,9 @@ var (
 	ErrConflict   = errors.New("already exists")
 	ErrForbidden  = errors.New("forbidden")
 	ErrValidation = errors.New("validation error")
+	// ErrAutoRegisterLimit is returned when a project has reached its cap on
+	// auto-created feature flags and a new key cannot be registered.
+	ErrAutoRegisterLimit = errors.New("auto-register limit reached")
 )
 
 // ValidationError wraps a field-level validation message.

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -51,6 +51,10 @@ type ABTestRepo interface {
 // FlagRepo is the persistence port for feature flags.
 type FlagRepo interface {
 	CreateFlag(ctx context.Context, f repository.FeatureFlag) (repository.FeatureFlag, error)
+	EnsureAutoFlag(ctx context.Context, f repository.FeatureFlag) (repository.FeatureFlag, error)
+	CountAutoFlags(ctx context.Context, projectID string) (int, error)
+	TouchFlagEvaluated(ctx context.Context, flagID string) error
+	PurgeStaleAutoFlags(ctx context.Context, cutoff time.Time) (int64, error)
 	FlagByID(ctx context.Context, id string) (repository.FeatureFlag, error)
 	FlagByKey(ctx context.Context, projectID, flagKey string) (repository.FeatureFlag, error)
 	ListFlags(ctx context.Context, projectID string) ([]repository.FeatureFlag, error)

--- a/internal/repository/flags.go
+++ b/internal/repository/flags.go
@@ -2,10 +2,36 @@ package repository
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"time"
 )
+
+// flagColumns is the shared SELECT column list for feature_flags, kept in one
+// place so every read path scans an identical row shape via scanFlag.
+const flagColumns = `id, project_id, flag_key, name, flag_type, variants, default_variant, split, COALESCE(conversion_event,''), COALESCE(targeting_rules,'[]'), status, created_at, COALESCE(origin,'manual'), last_evaluated_at`
+
+// rowScanner is satisfied by both *sql.Row and *sql.Rows.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanFlag(sc rowScanner) (FeatureFlag, error) {
+	var f FeatureFlag
+	var lastEval sql.NullTime
+	if err := sc.Scan(
+		&f.ID, &f.ProjectID, &f.FlagKey, &f.Name, &f.FlagType,
+		&f.Variants, &f.DefaultVariant, &f.Split, &f.ConversionEvent,
+		&f.TargetingRules, &f.Status, &f.CreatedAt, &f.Origin, &lastEval,
+	); err != nil {
+		return FeatureFlag{}, err
+	}
+	if lastEval.Valid {
+		f.LastEvaluatedAt = &lastEval.Time
+	}
+	return f, nil
+}
 
 // FeatureFlag represents an OpenFeature-compatible feature flag.
 type FeatureFlag struct {
@@ -21,6 +47,11 @@ type FeatureFlag struct {
 	TargetingRules  string    `json:"targeting_rules"`
 	Status          string    `json:"status"`
 	CreatedAt       time.Time `json:"created_at"`
+	// Origin is "manual" for human-created flags and "auto" for flags created on
+	// first evaluation. LastEvaluatedAt tracks the most recent evaluation of an
+	// auto flag so stale, never-configured ones can be pruned.
+	Origin          string     `json:"origin"`
+	LastEvaluatedAt *time.Time `json:"last_evaluated_at,omitempty"`
 }
 
 // FlagEvaluation records a single flag evaluation.
@@ -59,44 +90,91 @@ func (s *Store) CreateFlag(ctx context.Context, f FeatureFlag) (FeatureFlag, err
 	if f.TargetingRules == "" {
 		f.TargetingRules = "[]"
 	}
-	const q = `INSERT INTO feature_flags (id, project_id, flag_key, name, flag_type, variants, default_variant, split, conversion_event, targeting_rules, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	if f.Origin == "" {
+		f.Origin = "manual"
+	}
+	const q = `INSERT INTO feature_flags (id, project_id, flag_key, name, flag_type, variants, default_variant, split, conversion_event, targeting_rules, status, origin) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	if _, err := s.db.ExecContext(ctx, q,
 		f.ID, f.ProjectID, f.FlagKey, f.Name, f.FlagType,
-		f.Variants, f.DefaultVariant, f.Split, f.ConversionEvent, f.TargetingRules, f.Status,
+		f.Variants, f.DefaultVariant, f.Split, f.ConversionEvent, f.TargetingRules, f.Status, f.Origin,
 	); err != nil {
 		return FeatureFlag{}, fmt.Errorf("create flag: %w", err)
 	}
 	return s.FlagByID(ctx, f.ID)
 }
 
-func (s *Store) FlagByID(ctx context.Context, id string) (FeatureFlag, error) {
-	const q = `SELECT id, project_id, flag_key, name, flag_type, variants, default_variant, split, COALESCE(conversion_event,''), COALESCE(targeting_rules,'[]'), status, created_at FROM feature_flags WHERE id = ?`
-	var f FeatureFlag
-	if err := s.db.QueryRowContext(ctx, q, id).Scan(
-		&f.ID, &f.ProjectID, &f.FlagKey, &f.Name, &f.FlagType,
-		&f.Variants, &f.DefaultVariant, &f.Split, &f.ConversionEvent,
-		&f.TargetingRules, &f.Status, &f.CreatedAt,
-	); err != nil {
-		return FeatureFlag{}, err
+// EnsureAutoFlag inserts an auto-created flag if no flag with the same
+// (project_id, flag_key) exists yet, then returns the current row. It is
+// idempotent and race-safe: concurrent first-evaluations of the same key
+// converge on a single row via the UNIQUE(project_id, flag_key) constraint.
+func (s *Store) EnsureAutoFlag(ctx context.Context, f FeatureFlag) (FeatureFlag, error) {
+	id, err := generateUUID()
+	if err != nil {
+		return FeatureFlag{}, fmt.Errorf("generate uuid: %w", err)
 	}
-	return f, nil
+	if f.TargetingRules == "" {
+		f.TargetingRules = "[]"
+	}
+	if f.Origin == "" {
+		f.Origin = "auto"
+	}
+	const q = `INSERT INTO feature_flags (id, project_id, flag_key, name, flag_type, variants, default_variant, split, conversion_event, targeting_rules, status, origin)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(project_id, flag_key) DO NOTHING`
+	if _, err := s.db.ExecContext(ctx, q,
+		id, f.ProjectID, f.FlagKey, f.Name, f.FlagType,
+		f.Variants, f.DefaultVariant, f.Split, f.ConversionEvent, f.TargetingRules, f.Status, f.Origin,
+	); err != nil {
+		return FeatureFlag{}, fmt.Errorf("ensure auto flag: %w", err)
+	}
+	return s.FlagByKey(ctx, f.ProjectID, f.FlagKey)
+}
+
+// CountAutoFlags returns how many auto-created flags a project has. Manual flags
+// are not counted — only the auto-registration spam vector is bounded.
+func (s *Store) CountAutoFlags(ctx context.Context, projectID string) (int, error) {
+	const q = `SELECT COUNT(*) FROM feature_flags WHERE project_id = ? AND origin = 'auto'`
+	var n int
+	if err := s.db.QueryRowContext(ctx, q, projectID).Scan(&n); err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+// TouchFlagEvaluated records that an auto flag was just evaluated, so the
+// retention sweep can tell live unconfigured flags from abandoned ones.
+func (s *Store) TouchFlagEvaluated(ctx context.Context, flagID string) error {
+	_, err := s.db.ExecContext(ctx, `UPDATE feature_flags SET last_evaluated_at = CURRENT_TIMESTAMP WHERE id = ?`, flagID)
+	return err
+}
+
+// PurgeStaleAutoFlags deletes auto-created, never-configured (status='inactive')
+// flags whose most recent evaluation — or creation, if never evaluated — predates
+// the cutoff. Human-claimed flags (origin='manual') and activated/paused flags are
+// never touched.
+func (s *Store) PurgeStaleAutoFlags(ctx context.Context, cutoff time.Time) (int64, error) {
+	const q = `DELETE FROM feature_flags
+		WHERE origin = 'auto' AND status = 'inactive'
+		  AND COALESCE(last_evaluated_at, created_at) < ?`
+	result, err := s.db.ExecContext(ctx, q, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+func (s *Store) FlagByID(ctx context.Context, id string) (FeatureFlag, error) {
+	q := `SELECT ` + flagColumns + ` FROM feature_flags WHERE id = ?`
+	return scanFlag(s.db.QueryRowContext(ctx, q, id))
 }
 
 func (s *Store) FlagByKey(ctx context.Context, projectID, flagKey string) (FeatureFlag, error) {
-	const q = `SELECT id, project_id, flag_key, name, flag_type, variants, default_variant, split, COALESCE(conversion_event,''), COALESCE(targeting_rules,'[]'), status, created_at FROM feature_flags WHERE project_id = ? AND flag_key = ?`
-	var f FeatureFlag
-	if err := s.db.QueryRowContext(ctx, q, projectID, flagKey).Scan(
-		&f.ID, &f.ProjectID, &f.FlagKey, &f.Name, &f.FlagType,
-		&f.Variants, &f.DefaultVariant, &f.Split, &f.ConversionEvent,
-		&f.TargetingRules, &f.Status, &f.CreatedAt,
-	); err != nil {
-		return FeatureFlag{}, err
-	}
-	return f, nil
+	q := `SELECT ` + flagColumns + ` FROM feature_flags WHERE project_id = ? AND flag_key = ?`
+	return scanFlag(s.db.QueryRowContext(ctx, q, projectID, flagKey))
 }
 
 func (s *Store) ListFlags(ctx context.Context, projectID string) ([]FeatureFlag, error) {
-	const q = `SELECT id, project_id, flag_key, name, flag_type, variants, default_variant, split, COALESCE(conversion_event,''), COALESCE(targeting_rules,'[]'), status, created_at FROM feature_flags WHERE project_id = ? ORDER BY created_at DESC`
+	q := `SELECT ` + flagColumns + ` FROM feature_flags WHERE project_id = ? ORDER BY created_at DESC`
 	rows, err := s.db.QueryContext(ctx, q, projectID)
 	if err != nil {
 		return nil, err
@@ -105,12 +183,8 @@ func (s *Store) ListFlags(ctx context.Context, projectID string) ([]FeatureFlag,
 
 	var flags []FeatureFlag
 	for rows.Next() {
-		var f FeatureFlag
-		if err := rows.Scan(
-			&f.ID, &f.ProjectID, &f.FlagKey, &f.Name, &f.FlagType,
-			&f.Variants, &f.DefaultVariant, &f.Split, &f.ConversionEvent,
-			&f.TargetingRules, &f.Status, &f.CreatedAt,
-		); err != nil {
+		f, err := scanFlag(rows)
+		if err != nil {
 			return nil, err
 		}
 		flags = append(flags, f)
@@ -122,7 +196,9 @@ func (s *Store) UpdateFlag(ctx context.Context, f FeatureFlag) (FeatureFlag, err
 	if f.TargetingRules == "" {
 		f.TargetingRules = "[]"
 	}
-	const q = `UPDATE feature_flags SET name=?, flag_type=?, variants=?, default_variant=?, split=?, conversion_event=?, targeting_rules=?, status=? WHERE id=?`
+	// A human editing a flag claims it (origin='manual'): it now appears as a
+	// normal flag and is exempt from the stale-auto-flag sweep.
+	const q = `UPDATE feature_flags SET name=?, flag_type=?, variants=?, default_variant=?, split=?, conversion_event=?, targeting_rules=?, status=?, origin='manual' WHERE id=?`
 	if _, err := s.db.ExecContext(ctx, q,
 		f.Name, f.FlagType, f.Variants, f.DefaultVariant, f.Split,
 		f.ConversionEvent, f.TargetingRules, f.Status, f.ID,

--- a/internal/repository/flags_autoregister_test.go
+++ b/internal/repository/flags_autoregister_test.go
@@ -1,0 +1,140 @@
+package repository_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wiebe-xyz/funnelbarn/internal/repository"
+)
+
+func autoFlag(projectID, key string) repository.FeatureFlag {
+	return repository.FeatureFlag{
+		ProjectID:      projectID,
+		FlagKey:        key,
+		Name:           key,
+		FlagType:       "number",
+		Variants:       `{"default":3}`,
+		DefaultVariant: "default",
+		Split:          "{}",
+		TargetingRules: "[]",
+		Status:         "inactive",
+		Origin:         "auto",
+	}
+}
+
+func TestStore_EnsureAutoFlag_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	p, err := s.CreateProject(ctx, "AutoFlag", "auto-flag")
+	require.NoError(t, err)
+
+	f1, err := s.EnsureAutoFlag(ctx, autoFlag(p.ID, "anon_qr_limit"))
+	require.NoError(t, err)
+	require.Equal(t, "auto", f1.Origin)
+	require.Equal(t, "inactive", f1.Status)
+
+	// Same key again — must return the existing row, not a duplicate.
+	f2, err := s.EnsureAutoFlag(ctx, autoFlag(p.ID, "anon_qr_limit"))
+	require.NoError(t, err)
+	require.Equal(t, f1.ID, f2.ID)
+
+	flags, err := s.ListFlags(ctx, p.ID)
+	require.NoError(t, err)
+	require.Len(t, flags, 1)
+}
+
+func TestStore_CountAutoFlags_IgnoresManual(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	p, err := s.CreateProject(ctx, "CountAuto", "count-auto")
+	require.NoError(t, err)
+
+	_, err = s.EnsureAutoFlag(ctx, autoFlag(p.ID, "a1"))
+	require.NoError(t, err)
+	_, err = s.EnsureAutoFlag(ctx, autoFlag(p.ID, "a2"))
+	require.NoError(t, err)
+	// A manual flag must not count.
+	_, err = s.CreateFlag(ctx, repository.FeatureFlag{
+		ProjectID: p.ID, FlagKey: "manual", Name: "manual", FlagType: "boolean",
+		Variants: `{"on":true,"off":false}`, DefaultVariant: "off", Split: "{}", Status: "active",
+	})
+	require.NoError(t, err)
+
+	n, err := s.CountAutoFlags(ctx, p.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+}
+
+func TestStore_TouchFlagEvaluated(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	p, err := s.CreateProject(ctx, "Touch", "touch")
+	require.NoError(t, err)
+
+	f, err := s.EnsureAutoFlag(ctx, autoFlag(p.ID, "k"))
+	require.NoError(t, err)
+	require.Nil(t, f.LastEvaluatedAt)
+
+	require.NoError(t, s.TouchFlagEvaluated(ctx, f.ID))
+
+	got, err := s.FlagByKey(ctx, p.ID, "k")
+	require.NoError(t, err)
+	require.NotNil(t, got.LastEvaluatedAt, "last_evaluated_at should be set after touch")
+}
+
+func TestStore_PurgeStaleAutoFlags(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	p, err := s.CreateProject(ctx, "PurgeAuto", "purge-auto")
+	require.NoError(t, err)
+
+	// Stale auto+inactive — should be pruned.
+	_, err = s.EnsureAutoFlag(ctx, autoFlag(p.ID, "stale_auto"))
+	require.NoError(t, err)
+
+	// auto+active — kept (configured/activated).
+	activeAuto := autoFlag(p.ID, "active_auto")
+	activeAuto.Status = "active"
+	_, err = s.EnsureAutoFlag(ctx, activeAuto)
+	require.NoError(t, err)
+
+	// manual+inactive — kept (human-claimed).
+	_, err = s.CreateFlag(ctx, repository.FeatureFlag{
+		ProjectID: p.ID, FlagKey: "manual_inactive", Name: "m", FlagType: "boolean",
+		Variants: `{"on":true,"off":false}`, DefaultVariant: "off", Split: "{}", Status: "inactive",
+	})
+	require.NoError(t, err)
+
+	// Cutoff well in the future (wide enough to dwarf any DB/driver timezone
+	// skew): everything was created before it, so only the stale auto+inactive
+	// flag qualifies — status and origin filters protect the other two.
+	n, err := s.PurgeStaleAutoFlags(ctx, time.Now().Add(48*time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+
+	flags, err := s.ListFlags(ctx, p.ID)
+	require.NoError(t, err)
+	assert.Len(t, flags, 2)
+	_, err = s.FlagByKey(ctx, p.ID, "stale_auto")
+	assert.Error(t, err, "stale auto flag should be gone")
+}
+
+func TestStore_PurgeStaleAutoFlags_KeepsRecentlyEvaluated(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	p, err := s.CreateProject(ctx, "PurgeRecent", "purge-recent")
+	require.NoError(t, err)
+
+	f, err := s.EnsureAutoFlag(ctx, autoFlag(p.ID, "live_auto"))
+	require.NoError(t, err)
+	require.NoError(t, s.TouchFlagEvaluated(ctx, f.ID)) // last_evaluated_at = now
+
+	// Cutoff well in the past (wide enough to dwarf timezone skew): a flag last
+	// evaluated "now" is far newer than the cutoff, so it is kept.
+	n, err := s.PurgeStaleAutoFlags(ctx, time.Now().Add(-48*time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+}

--- a/internal/repository/migrations/00024_flag_origin.sql
+++ b/internal/repository/migrations/00024_flag_origin.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- origin distinguishes flags created by a human ('manual') from those auto-created
+-- on first evaluation ('auto'). last_evaluated_at tracks when an auto flag was last
+-- seen so the retention sweep can prune stale, never-configured ones.
+ALTER TABLE feature_flags ADD COLUMN origin TEXT NOT NULL DEFAULT 'manual';
+ALTER TABLE feature_flags ADD COLUMN last_evaluated_at DATETIME;
+
+-- +goose Down
+ALTER TABLE feature_flags DROP COLUMN last_evaluated_at;
+ALTER TABLE feature_flags DROP COLUMN origin;

--- a/internal/repository/mock/mock.go
+++ b/internal/repository/mock/mock.go
@@ -614,11 +614,72 @@ func (s *Store) CreateFlag(_ context.Context, f repository.FeatureFlag) (reposit
 	defer s.mu.Unlock()
 	f.ID = newMockID("flag")
 	f.CreatedAt = time.Now()
+	if f.Origin == "" {
+		f.Origin = "manual"
+	}
 	if s.flags == nil {
 		s.flags = make(map[string]repository.FeatureFlag)
 	}
 	s.flags[f.ID] = f
 	return f, nil
+}
+
+func (s *Store) EnsureAutoFlag(ctx context.Context, f repository.FeatureFlag) (repository.FeatureFlag, error) {
+	s.mu.Lock()
+	for _, existing := range s.flags {
+		if existing.ProjectID == f.ProjectID && existing.FlagKey == f.FlagKey {
+			s.mu.Unlock()
+			return existing, nil
+		}
+	}
+	s.mu.Unlock()
+	if f.Origin == "" {
+		f.Origin = "auto"
+	}
+	return s.CreateFlag(ctx, f)
+}
+
+func (s *Store) CountAutoFlags(_ context.Context, projectID string) (int, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	n := 0
+	for _, f := range s.flags {
+		if f.ProjectID == projectID && f.Origin == "auto" {
+			n++
+		}
+	}
+	return n, nil
+}
+
+func (s *Store) TouchFlagEvaluated(_ context.Context, flagID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if f, ok := s.flags[flagID]; ok {
+		now := time.Now()
+		f.LastEvaluatedAt = &now
+		s.flags[flagID] = f
+	}
+	return nil
+}
+
+func (s *Store) PurgeStaleAutoFlags(_ context.Context, cutoff time.Time) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var deleted int64
+	for id, f := range s.flags {
+		if f.Origin != "auto" || f.Status != "inactive" {
+			continue
+		}
+		seen := f.CreatedAt
+		if f.LastEvaluatedAt != nil {
+			seen = *f.LastEvaluatedAt
+		}
+		if seen.Before(cutoff) {
+			delete(s.flags, id)
+			deleted++
+		}
+	}
+	return deleted, nil
 }
 
 func (s *Store) FlagByID(_ context.Context, id string) (repository.FeatureFlag, error) {
@@ -665,6 +726,7 @@ func (s *Store) UpdateFlag(_ context.Context, f repository.FeatureFlag) (reposit
 	f.ProjectID = existing.ProjectID
 	f.FlagKey = existing.FlagKey
 	f.CreatedAt = existing.CreatedAt
+	f.Origin = "manual" // a human edit claims the flag
 	s.flags[f.ID] = f
 	return f, nil
 }

--- a/internal/service/flags.go
+++ b/internal/service/flags.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -223,6 +224,103 @@ func (svc *FlagService) EvaluateFlag(ctx context.Context, projectID, flagKey str
 		Reason:  "SPLIT",
 		FlagKey: flag.FlagKey,
 	}, nil
+}
+
+// flagKeyRe bounds auto-registration to sane keys so a spam caller can't create
+// rows with arbitrary/oversized garbage keys.
+var flagKeyRe = regexp.MustCompile(`^[A-Za-z0-9._:-]{1,64}$`)
+
+func validFlagKey(key string) bool { return flagKeyRe.MatchString(key) }
+
+// inferFlagType maps a JSON-decoded default value to a flag_type for the dashboard.
+func inferFlagType(v any) string {
+	switch v.(type) {
+	case bool:
+		return "boolean"
+	case float64, int, int64:
+		return "number"
+	case string, nil:
+		return "string"
+	default:
+		return "json"
+	}
+}
+
+// buildAutoFlag describes an inert, auto-created flag: a single "default" variant
+// holding the caller's default value, status "inactive" so evaluation returns that
+// default (reason DISABLED) until a human configures it.
+func buildAutoFlag(projectID, flagKey string, defaultValue any) repository.FeatureFlag {
+	variants := map[string]any{"default": defaultValue}
+	vb, err := json.Marshal(variants)
+	if err != nil {
+		vb = []byte(`{"default":null}`)
+	}
+	return repository.FeatureFlag{
+		ProjectID:      projectID,
+		FlagKey:        flagKey,
+		Name:           flagKey,
+		FlagType:       inferFlagType(defaultValue),
+		Variants:       string(vb),
+		DefaultVariant: "default",
+		Split:          "{}",
+		TargetingRules: "[]",
+		Status:         "inactive",
+		Origin:         "auto",
+	}
+}
+
+// EvaluateOrRegisterFlag evaluates a flag and, when it doesn't exist yet,
+// auto-registers an inert flag carrying the caller's default so it surfaces in
+// the dashboard ready to configure. The caller always gets its default back in
+// that case (reason DISABLED), so SDK behaviour is unchanged.
+//
+// maxAuto caps auto-created flags per project (0 disables auto-registration).
+// Invalid keys, a missing project, or hitting the cap fall back to the original
+// not-found behaviour (the cap case via domain.ErrAutoRegisterLimit).
+func (svc *FlagService) EvaluateOrRegisterFlag(ctx context.Context, projectID, flagKey string, evalContext map[string]any, defaultValue any, maxAuto int) (FlagEvalResult, error) {
+	res, err := svc.EvaluateFlag(ctx, projectID, flagKey, evalContext)
+	if err == nil {
+		// Keep auto, still-unconfigured flags alive in the retention sweep while
+		// they're actively evaluated. DISABLED covers inactive (auto) and paused
+		// (manual, never pruned) flags; touchIfAuto filters to origin='auto'.
+		if res.Reason == "DISABLED" {
+			svc.touchIfAuto(projectID, flagKey)
+		}
+		return res, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return FlagEvalResult{}, err // a real lookup failure, not a missing flag
+	}
+	if maxAuto <= 0 || projectID == "" || !validFlagKey(flagKey) {
+		return FlagEvalResult{}, err // fall through to FLAG_NOT_FOUND + default
+	}
+	if n, cerr := svc.store.CountAutoFlags(ctx, projectID); cerr == nil && n >= maxAuto {
+		return FlagEvalResult{}, fmt.Errorf("project %s: %w", projectID, domain.ErrAutoRegisterLimit)
+	}
+	if _, cerr := svc.store.EnsureAutoFlag(ctx, buildAutoFlag(projectID, flagKey, defaultValue)); cerr != nil {
+		slog.WarnContext(ctx, "flag: auto-register failed", "err", cerr, "handled", true,
+			"project_id", projectID, "flag_key", flagKey)
+		// Still hand the caller its default so the SDK is unaffected.
+		return FlagEvalResult{Value: defaultValue, Variant: "default", Reason: "DISABLED", FlagKey: flagKey}, nil
+	}
+	// Re-evaluate now that the inert flag exists (returns default, reason DISABLED).
+	return svc.EvaluateFlag(ctx, projectID, flagKey, evalContext)
+}
+
+// touchIfAuto best-effort bumps last_evaluated_at for an auto flag, off the
+// request path so it never adds latency or fails the evaluation.
+func (svc *FlagService) touchIfAuto(projectID, flagKey string) {
+	go func() {
+		ctx := context.Background()
+		f, err := svc.store.FlagByKey(ctx, projectID, flagKey)
+		if err != nil || f.Origin != "auto" {
+			return
+		}
+		if err := svc.store.TouchFlagEvaluated(ctx, f.ID); err != nil {
+			slog.WarnContext(ctx, "flag: touch last_evaluated_at", "err", err, "handled", true,
+				"flag_id", f.ID, "project_id", projectID)
+		}
+	}()
 }
 
 func (svc *FlagService) AnalyzeFlag(ctx context.Context, flag repository.FeatureFlag, from, to time.Time) ([]repository.FlagAnalysisResult, error) {

--- a/internal/service/flags_test.go
+++ b/internal/service/flags_test.go
@@ -2,10 +2,12 @@ package service_test
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/wiebe-xyz/funnelbarn/internal/domain"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository/mock"
 	"github.com/wiebe-xyz/funnelbarn/internal/service"
@@ -369,4 +371,123 @@ func TestFlagService_DeterministicSplit(t *testing.T) {
 	r2, err := svc.EvaluateFlag(context.Background(), "proj-1", "deterministic-flag", map[string]any{"targetingKey": "same-user"})
 	require.NoError(t, err)
 	require.Equal(t, r1.Variant, r2.Variant)
+}
+
+func TestEvaluateOrRegisterFlag_CreatesInactiveDefaultFlag(t *testing.T) {
+	store := mock.New()
+	svc := service.NewFlagService(store)
+
+	res, err := svc.EvaluateOrRegisterFlag(context.Background(), "proj-1", "anon_qr_limit",
+		map[string]any{"targeting_key": "device-1"}, float64(3), 100)
+	require.NoError(t, err)
+	require.Equal(t, "DISABLED", res.Reason)
+	require.Equal(t, float64(3), res.Value)
+	require.Equal(t, "anon_qr_limit", res.FlagKey)
+
+	flags, err := svc.ListFlags(context.Background(), "proj-1")
+	require.NoError(t, err)
+	require.Len(t, flags, 1)
+	require.Equal(t, "auto", flags[0].Origin)
+	require.Equal(t, "inactive", flags[0].Status)
+	require.Equal(t, "number", flags[0].FlagType)
+	require.JSONEq(t, `{"default":3}`, flags[0].Variants)
+}
+
+func TestEvaluateOrRegisterFlag_Idempotent(t *testing.T) {
+	store := mock.New()
+	svc := service.NewFlagService(store)
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		_, err := svc.EvaluateOrRegisterFlag(ctx, "proj-1", "pricing_default_billing",
+			map[string]any{"targeting_key": "s1"}, "monthly", 100)
+		require.NoError(t, err)
+	}
+	flags, err := svc.ListFlags(ctx, "proj-1")
+	require.NoError(t, err)
+	require.Len(t, flags, 1, "repeated evaluations must not create duplicate flags")
+}
+
+func TestEvaluateOrRegisterFlag_CapReached(t *testing.T) {
+	store := mock.New()
+	svc := service.NewFlagService(store)
+	ctx := context.Background()
+
+	_, err := svc.EvaluateOrRegisterFlag(ctx, "proj-1", "flag_a", nil, true, 1)
+	require.NoError(t, err)
+
+	_, err = svc.EvaluateOrRegisterFlag(ctx, "proj-1", "flag_b", nil, true, 1)
+	require.ErrorIs(t, err, domain.ErrAutoRegisterLimit)
+
+	flags, _ := svc.ListFlags(ctx, "proj-1")
+	require.Len(t, flags, 1, "cap must stop new auto flags from being created")
+}
+
+func TestEvaluateOrRegisterFlag_ManualFlagsNotCounted(t *testing.T) {
+	store := mock.New()
+	svc := service.NewFlagService(store)
+	ctx := context.Background()
+
+	// Three manual flags exist; with a cap of 1, auto-registration should still
+	// succeed because manual flags do not count toward the cap.
+	for _, k := range []string{"m1", "m2", "m3"} {
+		createTestFlag(t, svc, "proj-1", k, map[string]any{"on": true, "off": false}, map[string]int{"on": 100}, "off")
+	}
+	_, err := svc.EvaluateOrRegisterFlag(ctx, "proj-1", "auto_1", nil, true, 1)
+	require.NoError(t, err)
+
+	// A second auto key now hits the cap of 1 auto flag.
+	_, err = svc.EvaluateOrRegisterFlag(ctx, "proj-1", "auto_2", nil, true, 1)
+	require.ErrorIs(t, err, domain.ErrAutoRegisterLimit)
+}
+
+func TestEvaluateOrRegisterFlag_InvalidKeyNotCreated(t *testing.T) {
+	store := mock.New()
+	svc := service.NewFlagService(store)
+	ctx := context.Background()
+
+	bad := "has spaces & symbols!"
+	_, err := svc.EvaluateOrRegisterFlag(ctx, "proj-1", bad, nil, true, 100)
+	require.ErrorIs(t, err, sql.ErrNoRows, "invalid keys fall through to not-found, never created")
+
+	flags, _ := svc.ListFlags(ctx, "proj-1")
+	require.Empty(t, flags)
+}
+
+func TestEvaluateOrRegisterFlag_DisabledWhenMaxZero(t *testing.T) {
+	store := mock.New()
+	svc := service.NewFlagService(store)
+	ctx := context.Background()
+
+	_, err := svc.EvaluateOrRegisterFlag(ctx, "proj-1", "some_flag", nil, true, 0)
+	require.ErrorIs(t, err, sql.ErrNoRows, "maxAuto=0 disables auto-registration")
+
+	flags, _ := svc.ListFlags(ctx, "proj-1")
+	require.Empty(t, flags)
+}
+
+func TestEvaluateOrRegisterFlag_NoProjectSkips(t *testing.T) {
+	store := mock.New()
+	svc := service.NewFlagService(store)
+
+	_, err := svc.EvaluateOrRegisterFlag(context.Background(), "", "some_flag", nil, true, 100)
+	require.ErrorIs(t, err, sql.ErrNoRows, "an empty project (admin key) must not auto-register")
+}
+
+func TestUpdateFlag_ClaimsAutoFlagAsManual(t *testing.T) {
+	store := mock.New()
+	svc := service.NewFlagService(store)
+	ctx := context.Background()
+
+	_, err := svc.EvaluateOrRegisterFlag(ctx, "proj-1", "claim_me", nil, true, 100)
+	require.NoError(t, err)
+	flags, _ := svc.ListFlags(ctx, "proj-1")
+	require.Len(t, flags, 1)
+	require.Equal(t, "auto", flags[0].Origin)
+
+	f := flags[0]
+	f.Status = "active"
+	updated, err := svc.UpdateFlag(ctx, f)
+	require.NoError(t, err)
+	require.Equal(t, "manual", updated.Origin, "a human edit claims the flag")
 }

--- a/internal/service/interfaces.go
+++ b/internal/service/interfaces.go
@@ -53,6 +53,7 @@ type Flags interface {
 	UpdateFlag(ctx context.Context, f repository.FeatureFlag) (repository.FeatureFlag, error)
 	DeleteFlag(ctx context.Context, id string) error
 	EvaluateFlag(ctx context.Context, projectID, flagKey string, evalContext map[string]any) (FlagEvalResult, error)
+	EvaluateOrRegisterFlag(ctx context.Context, projectID, flagKey string, evalContext map[string]any, defaultValue any, maxAuto int) (FlagEvalResult, error)
 	AnalyzeFlag(ctx context.Context, flag repository.FeatureFlag, from, to time.Time) ([]repository.FlagAnalysisResult, error)
 	ContextKeySuggestions(ctx context.Context, projectID string) ([]repository.ContextKeySuggestion, error)
 }

--- a/web/src/components/flags/shared.test.tsx
+++ b/web/src/components/flags/shared.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { statusBadge, originBadge } from './shared'
+
+describe('statusBadge', () => {
+  it('renders the inactive status label', () => {
+    const { getByText } = render(<>{statusBadge('inactive')}</>)
+    expect(getByText('inactive')).toBeTruthy()
+  })
+})
+
+describe('originBadge', () => {
+  it('renders "auto-detected" for auto-created flags', () => {
+    const { getByText } = render(<>{originBadge('auto')}</>)
+    expect(getByText('auto-detected')).toBeTruthy()
+  })
+
+  it('renders nothing for manual flags', () => {
+    const { container } = render(<>{originBadge('manual')}</>)
+    expect(container.textContent).toBe('')
+  })
+})

--- a/web/src/components/flags/shared.tsx
+++ b/web/src/components/flags/shared.tsx
@@ -15,6 +15,7 @@ export function statusBadge(status: string) {
   const styles: Record<string, { bg: string; color: string }> = {
     active: { bg: 'rgba(16,185,129,0.1)', color: '#10b981' },
     paused: { bg: 'rgba(245,158,11,0.1)', color: '#f59e0b' },
+    inactive: { bg: 'rgba(148,163,184,0.12)', color: '#94a3b8' },
   }
   const s = styles[status] ?? styles.active
   return (
@@ -26,6 +27,23 @@ export function statusBadge(status: string) {
       textTransform: 'uppercase', letterSpacing: '0.05em',
     }}>
       {status}
+    </span>
+  )
+}
+
+// originBadge flags an auto-created (never-configured) flag so users know it was
+// seeded from an SDK evaluation and is waiting to be set up.
+export function originBadge(origin: string) {
+  if (origin !== 'auto') return null
+  return (
+    <span title="Created automatically from an SDK evaluation — configure it to start an experiment." style={{
+      fontSize: 11, fontWeight: 700,
+      background: 'rgba(99,102,241,0.12)', color: '#818cf8',
+      border: '1px solid rgba(99,102,241,0.3)',
+      borderRadius: 99, padding: '0.15rem 0.6rem',
+      textTransform: 'uppercase', letterSpacing: '0.05em',
+    }}>
+      auto-detected
     </span>
   )
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -525,6 +525,8 @@ export interface FeatureFlag {
   targeting_rules: string
   status: string
   created_at: string
+  origin: string // 'manual' | 'auto' — 'auto' flags were created on first evaluation
+  last_evaluated_at?: string
 }
 
 export interface FlagAnalysisVariant {

--- a/web/src/pages/Flags.tsx
+++ b/web/src/pages/Flags.tsx
@@ -8,7 +8,7 @@ import { useProjects } from '../lib/projects'
 import { reportError } from '../lib/bugbarn'
 import { trackEvent } from '../lib/analytics'
 import { Skeleton } from '../components/ui/Skeleton'
-import { C, statusBadge, StatCard } from '../components/flags/shared'
+import { C, statusBadge, originBadge, StatCard } from '../components/flags/shared'
 import { FlagFormModal } from '../components/flags/FlagFormModal'
 
 // alignBooleanSplit produces a new split where the *new default* is always
@@ -450,6 +450,7 @@ function FlagDetail({ flag, projectId, onUpdated, onDeleted }: {
           {flag.flag_type === 'boolean' && (
             <DefaultToggle value={flag.default_variant === 'on'} onChange={toggleDefault} disabled={togglingDefault} />
           )}
+          {originBadge(flag.origin)}
           {statusBadge(flag.status)}
           <button onClick={toggleStatus} disabled={toggling}
             title={flag.status === 'active'
@@ -644,7 +645,10 @@ export default function Flags() {
                 <div style={{ fontWeight: 700, fontSize: 14, color: C.text, marginBottom: 4 }}>{f.name}</div>
                 <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                   <code style={{ fontSize: 12, color: C.muted }}>{f.flag_key}</code>
-                  {statusBadge(f.status)}
+                  <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                    {originBadge(f.origin)}
+                    {statusBadge(f.status)}
+                  </div>
                 </div>
               </div>
             ))


### PR DESCRIPTION
Unknown flags evaluated via `POST /api/v1/evaluate` now auto-register so they appear in the dashboard instead of returning `FLAG_NOT_FOUND`.

## Behaviour
- On a not-found evaluation, create an **inert** flag: `status='inactive'`, a single `default` variant = the caller's `default_value`, `origin='auto'`. Re-evaluation returns that default (`reason: DISABLED`). SDK callers are unaffected.
- Applies to the **API-key SDK endpoint only** — the dashboard playground never auto-registers.
- A human edit claims the flag (`origin='manual'`), which surfaces it as a normal flag and exempts it from pruning.

## Abuse mitigation (the eval endpoint is public)
- Per-project cap on auto-created flags: `FUNNELBARN_FLAG_AUTOREGISTER_MAX` (default 100, `0` disables). Over the cap → returns the default with `error_code: AUTO_REGISTER_LIMIT` + a logged warning. Manual flags are never counted.
- Flag-key validation (`^[A-Za-z0-9._:-]{1,64}$`) — junk keys never create rows.
- Idempotent `INSERT ... ON CONFLICT DO NOTHING` (race-safe).
- Daily prune of stale, never-configured auto flags via `last_evaluated_at`: `FUNNELBARN_FLAG_AUTOREGISTER_TTL_DAYS` (default 30, `0` disables).

## Dashboard
`inactive` status badge + an "auto-detected" badge so users can spot flags awaiting configuration.

## Tests / verification
- New coverage: service (mock), repository (real SQLite + migration), API HTTP path (project-scoped key), config env parsing, web badge component.
- `gofmt` clean, `go vet` clean, `go test ./...` → 18 packages ok, 0 fail.
- Server boots against a fresh DB (migration `00024` applies; `feature_flags` gains `origin` + `last_evaluated_at`).
- Web `tsc` + `vite build` pass; 143 web tests pass.

Migration: `00024_flag_origin.sql` (adds `origin`, `last_evaluated_at`).