### PR TITLE
fix(spool): reset stale cursor after rotation (ingestion stall)

### DIFF
--- a/internal/spool/spool.go
+++ b/internal/spool/spool.go
@@ -311,6 +311,19 @@ func ReadRecordsFrom(path string, offset int64) ([]RecordAtOffset, error) {
 	}
 	defer file.Close()
 
+	// Guard against a stale cursor after rotation: if the persisted offset is
+	// past the end of the active file, the file was rotated (renamed to an
+	// archive and recreated) or truncated since the cursor was written, so the
+	// offset points beyond the new, shorter file. Seeking there would silently
+	// read zero records forever and the consumer would never advance again.
+	// Restart from the beginning — the records in the active file are post-rotation
+	// and have not been processed yet, so this replays exactly the backlog.
+	if offset > 0 {
+		if fi, statErr := file.Stat(); statErr == nil && offset > fi.Size() {
+			offset = 0
+		}
+	}
+
 	if offset > 0 {
 		if _, err := file.Seek(offset, 0); err != nil {
 			return nil, err

--- a/internal/spool/spool_test.go
+++ b/internal/spool/spool_test.go
@@ -185,6 +185,38 @@ func TestReadRecordsFrom_Offset(t *testing.T) {
 	}
 }
 
+// TestReadRecordsFrom_ResetsStaleOffsetAfterRotation reproduces the production
+// stall where the worker's byte-offset cursor pointed past the end of the active
+// spool file after a rotation, causing it to read zero records forever. The read
+// must transparently reset to the start and return the backlog.
+func TestReadRecordsFrom_ResetsStaleOffsetAfterRotation(t *testing.T) {
+	dir := newTestDir(t)
+	sp, err := spool.New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer sp.Close()
+
+	// New active segment (as if just created by a rotation) with two records.
+	for _, r := range []spool.Record{makeRecord("a", `{"n":1}`), makeRecord("b", `{"n":2}`)} {
+		if err := sp.Append(r); err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+	}
+
+	// A cursor left over from a previous, larger segment points well past EOF.
+	got, err := spool.ReadRecordsFrom(spool.Path(dir), 1<<30)
+	if err != nil {
+		t.Fatalf("ReadRecordsFrom(stale offset): %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("stale offset should reset to start and return all records; want 2, got %d", len(got))
+	}
+	if got[0].Record.IngestID != "a" || got[1].Record.IngestID != "b" {
+		t.Errorf("unexpected records after reset: %q, %q", got[0].Record.IngestID, got[1].Record.IngestID)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // ErrFull / size limit
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Incident
Event ingestion silently stalled in production for ~5 days (since `2026-06-10 07:19:44Z`) **across all projects**: the API kept accepting events (HTTP 202) and appending them to the spool, but nothing was written to the database. Discovered while checking whether page-view/funnel events were flowing.

## Root cause
The worker drains the spool using a single persisted **byte offset** (`cursor.json`) into the active file. On rotation, `spool.Rotate()` renames the active `ingest.ndjson` to a timestamped archive and creates a fresh empty file — but the cursor is **not** reset. The offset (`67110266`, exactly the size of the rotated archive) then sits past the end of the new 2 MB file, so `ReadRecordsFrom` seeked beyond EOF and returned **0 records every tick**, forever. The consumer never advanced again.

## Fix
In `ReadRecordsFrom`, if the offset is past the end of the active file, treat the file as rotated/truncated and restart from offset 0. The active file's records are post-rotation and unprocessed, so this replays exactly the backlog with no duplicates. Added a regression test reproducing the stale-offset-after-rotation case.

## Production status
The stuck cursor was already **manually reset** to recover the ~5-day backlog — ingestion is flowing again now (verified: live events across all projects, `qr` page views landing). This PR prevents recurrence; once deployed, a stale offset self-heals automatically.

## Verification
`gofmt` clean, `go vet` clean, `go test ./...` → 18 packages ok, 0 fail (incl. new `TestReadRecordsFrom_ResetsStaleOffsetAfterRotation`).