### PR TITLE
fix(deploy): make GeoLite2 DBs readable by the service (geo enrichment was disabled)

### DIFF
--- a/deploy/docker/service.Dockerfile
+++ b/deploy/docker/service.Dockerfile
@@ -26,7 +26,9 @@ FROM alpine:3.20
 WORKDIR /app
 
 RUN apk add --no-cache ca-certificates sqlite
-RUN addgroup -S funnelbarn && adduser -S funnelbarn -G funnelbarn
+# Pin uid/gid so the Kubernetes pod securityContext.fsGroup (101) stays correct
+# across rebuilds — the shared data volume is made group-readable to this gid.
+RUN addgroup -g 101 -S funnelbarn && adduser -u 100 -S funnelbarn -G funnelbarn
 
 COPY --from=build /out/funnelbarn /usr/local/bin/funnelbarn
 COPY --from=litestream /usr/local/bin/litestream /usr/local/bin/litestream

--- a/deploy/k8s/production/deployment.yaml
+++ b/deploy/k8s/production/deployment.yaml
@@ -17,6 +17,11 @@ spec:
         app.kubernetes.io/name: funnelbarn
         app.kubernetes.io/environment: production
     spec:
+      # The geoipupdate init container writes the GeoLite2 DBs as root; fsGroup
+      # makes the shared data volume group-readable by the funnelbarn user
+      # (uid 100 / gid 101) so geo enrichment can open them.
+      securityContext:
+        fsGroup: 101
       nodeSelector:
         kubernetes.io/hostname: layer7-prod
       imagePullSecrets:

--- a/deploy/k8s/staging/deployment.yaml
+++ b/deploy/k8s/staging/deployment.yaml
@@ -17,6 +17,11 @@ spec:
         app.kubernetes.io/name: funnelbarn
         app.kubernetes.io/environment: staging
     spec:
+      # The geoipupdate init container writes the GeoLite2 DBs as root; fsGroup
+      # makes the shared data volume group-readable by the funnelbarn user
+      # (uid 100 / gid 101) so geo enrichment can open them.
+      securityContext:
+        fsGroup: 101
       imagePullSecrets:
         - name: ghcr-secret
       initContainers:

--- a/deploy/k8s/testing/deployment.yaml
+++ b/deploy/k8s/testing/deployment.yaml
@@ -17,6 +17,11 @@ spec:
         app.kubernetes.io/name: funnelbarn
         app.kubernetes.io/environment: testing
     spec:
+      # The geoipupdate init container writes the GeoLite2 DBs as root; fsGroup
+      # makes the shared data volume group-readable by the funnelbarn user
+      # (uid 100 / gid 101) so geo enrichment can open them.
+      securityContext:
+        fsGroup: 101
       imagePullSecrets:
         - name: ghcr-secret
       initContainers:


### PR DESCRIPTION
## Problem
Geo enrichment has been silently disabled in **every environment**. The service logs on startup:
`geoip: failed to open database, geo lookup disabled — open /var/lib/funnelbarn/geoip/GeoLite2-City.mmdb: permission denied`
so events never get a `country_code`.

## Root cause
The `geoipupdate` init container (MaxMind image) runs as **root** and writes the GeoLite2 DBs to the shared data volume; the `geoip` dir lands as `drwxr-x--- root:root` (0750). The `funnelbarn` service runs as **uid 100 / gid 101** — neither owner nor in group 0 — so it can't traverse/read the dir. No `securityContext`/`fsGroup` was set in any manifest.

## Fix
Add pod `securityContext.fsGroup: 101` to production, staging and testing. Kubernetes then makes the shared volume group-owned by gid 101 with group access, so the funnelbarn user can read both the existing root-owned dir and the files the init writes on future boots. Pin the image `uid 100 / gid 101` in the Dockerfile so the `fsGroup` value stays correct across rebuilds (matches the IDs Alpine already assigns).

## Verification plan
- Merge → testing auto-deploys; confirm the "permission denied" warning is gone and the City/ASN DBs are readable, then events get `country_code`.
- Then promote to production and re-verify.

`kubectl kustomize` renders cleanly for all three envs with `fsGroup: 101`.