### PR TITLE
fix(deploy): geoip readable via init chmod (fsGroup no-op on local-path)

### DIFF
--- a/deploy/docker/service.Dockerfile
+++ b/deploy/docker/service.Dockerfile
@@ -26,8 +26,7 @@ FROM alpine:3.20
 WORKDIR /app
 
 RUN apk add --no-cache ca-certificates sqlite
-# Pin uid/gid so the Kubernetes pod securityContext.fsGroup (101) stays correct
-# across rebuilds — the shared data volume is made group-readable to this gid.
+# Pin a stable, predictable uid/gid for the non-root service user.
 RUN addgroup -g 101 -S funnelbarn && adduser -u 100 -S funnelbarn -G funnelbarn
 
 COPY --from=build /out/funnelbarn /usr/local/bin/funnelbarn

--- a/deploy/k8s/production/deployment.yaml
+++ b/deploy/k8s/production/deployment.yaml
@@ -17,11 +17,6 @@ spec:
         app.kubernetes.io/name: funnelbarn
         app.kubernetes.io/environment: production
     spec:
-      # The geoipupdate init container writes the GeoLite2 DBs as root; fsGroup
-      # makes the shared data volume group-readable by the funnelbarn user
-      # (uid 100 / gid 101) so geo enrichment can open them.
-      securityContext:
-        fsGroup: 101
       nodeSelector:
         kubernetes.io/hostname: layer7-prod
       imagePullSecrets:
@@ -44,6 +39,15 @@ spec:
               value: GeoLite2-City GeoLite2-ASN
             - name: GEOIPUPDATE_DB_DIR
               value: /var/lib/funnelbarn/geoip
+          volumeMounts:
+            - name: funnelbarn-data
+              mountPath: /var/lib/funnelbarn
+        # local-path PVCs do not honor pod-level fsGroup, so explicitly make the
+        # GeoLite2 dbs (written by geoipupdate as root, dir mode 0750) readable by
+        # the non-root service user. They are public MaxMind data, so a+r is fine.
+        - name: geoip-perms
+          image: ghcr.io/maxmind/geoipupdate:v7.1.1
+          command: ["chmod", "-R", "a+rX", "/var/lib/funnelbarn/geoip"]
           volumeMounts:
             - name: funnelbarn-data
               mountPath: /var/lib/funnelbarn

--- a/deploy/k8s/staging/deployment.yaml
+++ b/deploy/k8s/staging/deployment.yaml
@@ -17,11 +17,6 @@ spec:
         app.kubernetes.io/name: funnelbarn
         app.kubernetes.io/environment: staging
     spec:
-      # The geoipupdate init container writes the GeoLite2 DBs as root; fsGroup
-      # makes the shared data volume group-readable by the funnelbarn user
-      # (uid 100 / gid 101) so geo enrichment can open them.
-      securityContext:
-        fsGroup: 101
       imagePullSecrets:
         - name: ghcr-secret
       initContainers:
@@ -42,6 +37,15 @@ spec:
               value: GeoLite2-City GeoLite2-ASN
             - name: GEOIPUPDATE_DB_DIR
               value: /var/lib/funnelbarn/geoip
+          volumeMounts:
+            - name: funnelbarn-data
+              mountPath: /var/lib/funnelbarn
+        # local-path PVCs do not honor pod-level fsGroup, so explicitly make the
+        # GeoLite2 dbs (written by geoipupdate as root, dir mode 0750) readable by
+        # the non-root service user. They are public MaxMind data, so a+r is fine.
+        - name: geoip-perms
+          image: ghcr.io/maxmind/geoipupdate:v7.1.1
+          command: ["chmod", "-R", "a+rX", "/var/lib/funnelbarn/geoip"]
           volumeMounts:
             - name: funnelbarn-data
               mountPath: /var/lib/funnelbarn

--- a/deploy/k8s/testing/deployment.yaml
+++ b/deploy/k8s/testing/deployment.yaml
@@ -17,11 +17,6 @@ spec:
         app.kubernetes.io/name: funnelbarn
         app.kubernetes.io/environment: testing
     spec:
-      # The geoipupdate init container writes the GeoLite2 DBs as root; fsGroup
-      # makes the shared data volume group-readable by the funnelbarn user
-      # (uid 100 / gid 101) so geo enrichment can open them.
-      securityContext:
-        fsGroup: 101
       imagePullSecrets:
         - name: ghcr-secret
       initContainers:
@@ -42,6 +37,15 @@ spec:
               value: GeoLite2-City GeoLite2-ASN
             - name: GEOIPUPDATE_DB_DIR
               value: /var/lib/funnelbarn/geoip
+          volumeMounts:
+            - name: funnelbarn-data
+              mountPath: /var/lib/funnelbarn
+        # local-path PVCs do not honor pod-level fsGroup, so explicitly make the
+        # GeoLite2 dbs (written by geoipupdate as root, dir mode 0750) readable by
+        # the non-root service user. They are public MaxMind data, so a+r is fine.
+        - name: geoip-perms
+          image: ghcr.io/maxmind/geoipupdate:v7.1.1
+          command: ["chmod", "-R", "a+rX", "/var/lib/funnelbarn/geoip"]
           volumeMounts:
             - name: funnelbarn-data
               mountPath: /var/lib/funnelbarn


### PR DESCRIPTION
Follow-up to #177. That PR added `fsGroup: 101`, but verifying in **testing** showed it had no effect — the data volume is a **k3s local-path** (hostPath/local) PVC, and Kubernetes does not apply `fsGroup` ownership management to those volume types. The geoip dir stayed `root:root 0750` and the service still logged `geoip: failed to open database ... permission denied`.

## Fix
Drop the ineffective `fsGroup` and instead add a root `geoip-perms` init container that runs **after** `geoipupdate` and `chmod -R a+rX`s `/var/lib/funnelbarn/geoip`, making the public GeoLite2 City/ASN DBs readable by the non-root service user (uid 100) regardless of volume type. Reuses the already-pulled MaxMind image (verified it has `/bin/chmod`). Applied to production, staging and testing.

## Verify
Merge → testing auto-deploys → confirm the warning is gone, the City/ASN DBs are readable, and events get `country_code`. Then promote to production.

`kubectl kustomize` renders cleanly for all three envs with init order `geoipupdate` → `geoip-perms`.