### PR TITLE
feat(observability): surface silent ingest/geo failures to BugBarn

### DIFF
--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/wiebe-xyz/funnelbarn/internal/storage"
 	"github.com/wiebe-xyz/funnelbarn/internal/tracing"
 	"github.com/wiebe-xyz/funnelbarn/internal/worker"
+	"github.com/wiebe-xyz/funnelbarn/internal/workerhealth"
 )
 
 // Version and BuildTime are injected at build time via -ldflags.
@@ -194,7 +195,11 @@ func run() error {
 		var geoErr error
 		geoLookup, geoErr = geoip.Open(cfg.GeoIPCityDB, cfg.GeoIPASNDB)
 		if geoErr != nil {
-			slog.Warn("geoip: failed to open database, geo lookup disabled", "err", geoErr)
+			// Error (not Warn) so a missing/unreadable geo DB raises a BugBarn
+			// issue instead of silently disabling geo enrichment.
+			slog.Error("geoip: failed to open database, geo enrichment disabled",
+				"err", geoErr, "handled", false,
+				"city_db", cfg.GeoIPCityDB, "asn_db", cfg.GeoIPASNDB)
 		} else {
 			defer geoLookup.Close()
 			slog.Info("geoip enabled", "city_db", cfg.GeoIPCityDB, "asn_db", cfg.GeoIPASNDB)
@@ -361,6 +366,10 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 		offset = 0
 	}
 
+	// Surface silent failure modes (stalled consumer, geo resolving nothing) as
+	// BugBarn issues via slog.Error.
+	health := workerhealth.New(workerhealth.Options{})
+
 	retryCounts := make(map[string]int)
 
 	for {
@@ -419,6 +428,23 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 			}
 			metrics.SpoolQueueDepth.Set(float64(len(entries)))
 
+			// Stall detection: if the spool has pending bytes the cursor isn't
+			// draining, raise an issue. This is the blindspot that hid a ~5-day
+			// ingestion outage.
+			if size, serr := spool.ActiveSize(cfg.SpoolDir); serr == nil {
+				pending := size - offset
+				if pending < 0 {
+					pending = 0
+				}
+				if stalled, since := health.CheckProgress(offset, pending); stalled {
+					slog.Error("ingest worker stalled: spool backlog not draining",
+						"handled", false,
+						"pending_bytes", pending,
+						"offset", offset,
+						"stalled_for", since.Round(time.Second).String())
+				}
+			}
+
 			// Check geo_enabled once per batch to avoid a DB round-trip per event.
 			geoEnabled := geoLookup != nil
 			if geoEnabled {
@@ -474,6 +500,13 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 				var geoResult *geoip.GeoResult
 				if geoEnabled {
 					geoResult = geoLookup.Lookup(event.ClientIP)
+					// Geo is on but resolving nothing usually means the real
+					// client IP isn't reaching us (proxy/forwarding config).
+					hit := geoResult != nil && geoResult.CountryCode != ""
+					if alert, n := health.RecordGeo(hit); alert {
+						slog.Error("geo enrichment resolved 0 countries over recent lookups; check FUNNELBARN_TRUSTED_PROXIES and client-IP forwarding",
+							"handled", false, "lookups", n)
+					}
 				}
 
 				persistErr := worker.PersistEvent(opCtx, store, event, geoResult)

--- a/internal/spool/spool.go
+++ b/internal/spool/spool.go
@@ -90,6 +90,19 @@ func Path(dir string) string {
 	return filepath.Join(dir, DefaultFileName)
 }
 
+// ActiveSize returns the size in bytes of the active spool file, or 0 if it does
+// not exist yet. Used to gauge how much data is pending consumption.
+func ActiveSize(dir string) (int64, error) {
+	fi, err := os.Stat(Path(dir))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	return fi.Size(), nil
+}
+
 // Append writes a single record to the spool.
 func (s *Spool) Append(record Record) error {
 	if s == nil {

--- a/internal/spool/spool_test.go
+++ b/internal/spool/spool_test.go
@@ -451,3 +451,23 @@ func TestAppendBatch_SizeLimit(t *testing.T) {
 		t.Errorf("want ErrFull for oversized batch, got %v", err)
 	}
 }
+
+func TestActiveSize(t *testing.T) {
+	dir := newTestDir(t)
+	// No file yet -> 0, no error.
+	if n, err := spool.ActiveSize(dir); err != nil || n != 0 {
+		t.Fatalf("empty dir: want 0,nil got %d,%v", n, err)
+	}
+	sp, err := spool.New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer sp.Close()
+	if err := sp.Append(makeRecord("a", `{"n":1}`)); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	n, err := spool.ActiveSize(dir)
+	if err != nil || n <= 0 {
+		t.Fatalf("after append: want >0,nil got %d,%v", n, err)
+	}
+}

--- a/internal/workerhealth/monitor.go
+++ b/internal/workerhealth/monitor.go
@@ -1,0 +1,135 @@
+// Package workerhealth detects silent failure modes in the ingest worker so they
+// surface instead of going unnoticed. Its methods are pure state machines that
+// report when something looks wrong; the caller decides how to react (typically a
+// slog.Error, which the bblog handler forwards to BugBarn as an issue).
+//
+// It covers two failure modes that previously produced no signal at all:
+//   - the spool consumer stalling (cursor frozen while a backlog accumulates),
+//     which once halted all ingestion for ~5 days unnoticed;
+//   - geo enrichment being enabled but resolving nothing (e.g. the real client
+//     IP never reaching the service), which left country_code empty for every
+//     event ever recorded.
+package workerhealth
+
+import "time"
+
+// Monitor tracks ingest-worker progress and geo-lookup outcomes. It is not safe
+// for concurrent use; the ingest worker drives it from a single goroutine.
+type Monitor struct {
+	stallAfter    time.Duration
+	geoSampleSize int
+	geoReAlert    time.Duration
+	now           func() time.Time
+
+	started    bool
+	lastOffset int64
+	progressAt time.Time
+	stalled    bool
+
+	geoAttempts  int
+	geoHits      int
+	lastGeoAlert time.Time
+}
+
+// Options configures a Monitor. Zero values fall back to sensible defaults.
+type Options struct {
+	StallAfter    time.Duration // offset may stay frozen with pending data this long before alerting (default 5m)
+	GeoSampleSize int           // lookups per geo evaluation window (default 200)
+	GeoReAlert    time.Duration // minimum gap between geo alerts (default 6h)
+	Now           func() time.Time
+}
+
+// New returns a Monitor with defaults applied for any unset option.
+func New(o Options) *Monitor {
+	if o.StallAfter <= 0 {
+		o.StallAfter = 5 * time.Minute
+	}
+	if o.GeoSampleSize <= 0 {
+		o.GeoSampleSize = 200
+	}
+	if o.GeoReAlert <= 0 {
+		o.GeoReAlert = 6 * time.Hour
+	}
+	if o.Now == nil {
+		o.Now = time.Now
+	}
+	return &Monitor{
+		stallAfter:    o.StallAfter,
+		geoSampleSize: o.GeoSampleSize,
+		geoReAlert:    o.GeoReAlert,
+		now:           o.Now,
+	}
+}
+
+// CheckProgress should be called once per worker tick with the current cursor
+// offset and the number of pending (unconsumed) bytes in the active spool file.
+// It reports a stall when there is pending data but the offset has not advanced
+// within StallAfter. It fires at most once per stall — it stays quiet until the
+// offset advances again, then re-arms. stalledFor is how long the offset had been
+// frozen when the alert fires.
+func (m *Monitor) CheckProgress(offset, pending int64) (alert bool, stalledFor time.Duration) {
+	t := m.now()
+
+	if !m.started {
+		m.started = true
+		m.lastOffset = offset
+		m.progressAt = t
+		return false, 0
+	}
+
+	if offset != m.lastOffset {
+		// Progress — the consumer is draining. Re-arm.
+		m.lastOffset = offset
+		m.progressAt = t
+		m.stalled = false
+		return false, 0
+	}
+
+	if pending <= 0 {
+		// Caught up / idle (offset == end of file). Not a stall; keep the timer
+		// fresh so an idle period doesn't count toward a future stall window.
+		m.progressAt = t
+		return false, 0
+	}
+
+	if m.stalled {
+		return false, 0 // already alerted for this stall
+	}
+
+	if d := t.Sub(m.progressAt); d >= m.stallAfter {
+		m.stalled = true
+		return true, d
+	}
+	return false, 0
+}
+
+// RecordGeo records the outcome of one geo lookup (hit = a country was resolved).
+// When a full window of GeoSampleSize lookups resolves zero countries it returns
+// true once, throttled by GeoReAlert, so a broken client-IP/proxy chain (geo
+// enabled but never matching) is surfaced. attempts is the window size that
+// produced zero hits.
+func (m *Monitor) RecordGeo(hit bool) (alert bool, attempts int) {
+	m.geoAttempts++
+	if hit {
+		m.geoHits++
+	}
+	if m.geoAttempts < m.geoSampleSize {
+		return false, 0
+	}
+
+	hits := m.geoHits
+	attempts = m.geoAttempts
+	m.geoAttempts = 0
+	m.geoHits = 0
+
+	if hits > 0 {
+		return false, 0
+	}
+
+	t := m.now()
+	if m.lastGeoAlert.IsZero() || t.Sub(m.lastGeoAlert) >= m.geoReAlert {
+		m.lastGeoAlert = t
+		return true, attempts
+	}
+	return false, 0
+}

--- a/internal/workerhealth/monitor_test.go
+++ b/internal/workerhealth/monitor_test.go
@@ -1,0 +1,135 @@
+package workerhealth
+
+import (
+	"testing"
+	"time"
+)
+
+// fakeClock is a controllable time source for the monitor.
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) now() time.Time      { return c.t }
+func (c *fakeClock) add(d time.Duration) { c.t = c.t.Add(d) }
+
+func newMonitor(clk *fakeClock, stallAfter time.Duration, geoSample int, geoReAlert time.Duration) *Monitor {
+	return New(Options{StallAfter: stallAfter, GeoSampleSize: geoSample, GeoReAlert: geoReAlert, Now: clk.now})
+}
+
+func TestCheckProgress_FiresOnceWhenBacklogNotDraining(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	m := newMonitor(clk, 5*time.Minute, 200, time.Hour)
+
+	// First observation just establishes a baseline.
+	if alert, _ := m.CheckProgress(100, 50); alert {
+		t.Fatal("first call must not alert")
+	}
+	// Offset frozen at 100 with pending data, but not yet past the window.
+	clk.add(4 * time.Minute)
+	if alert, _ := m.CheckProgress(100, 50); alert {
+		t.Fatal("must not alert before StallAfter elapses")
+	}
+	// Past the window — should alert exactly once.
+	clk.add(2 * time.Minute)
+	alert, since := m.CheckProgress(100, 50)
+	if !alert {
+		t.Fatal("expected stall alert after StallAfter with pending data")
+	}
+	if since < 6*time.Minute {
+		t.Errorf("stalledFor should reflect frozen duration, got %s", since)
+	}
+	// Still stalled, but must not re-alert.
+	clk.add(10 * time.Minute)
+	if alert, _ := m.CheckProgress(100, 50); alert {
+		t.Fatal("must not re-alert while still stalled")
+	}
+}
+
+func TestCheckProgress_NoAlertWhenIdle(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	m := newMonitor(clk, 1*time.Minute, 200, time.Hour)
+
+	m.CheckProgress(100, 0)
+	// Offset frozen but caught up (pending == 0) for a long time — not a stall.
+	for i := 0; i < 5; i++ {
+		clk.add(1 * time.Minute)
+		if alert, _ := m.CheckProgress(100, 0); alert {
+			t.Fatal("idle (no pending data) must never alert")
+		}
+	}
+}
+
+func TestCheckProgress_ReArmsAfterProgress(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	m := newMonitor(clk, 1*time.Minute, 200, time.Hour)
+
+	m.CheckProgress(100, 50)
+	clk.add(2 * time.Minute)
+	if alert, _ := m.CheckProgress(100, 50); !alert {
+		t.Fatal("expected first stall alert")
+	}
+	// Offset advances — re-arm.
+	clk.add(1 * time.Minute)
+	if alert, _ := m.CheckProgress(200, 50); alert {
+		t.Fatal("progress must clear the stall, not alert")
+	}
+	// Freeze again — should be able to alert a second time.
+	clk.add(2 * time.Minute)
+	if alert, _ := m.CheckProgress(200, 50); !alert {
+		t.Fatal("expected a fresh stall alert after re-arming")
+	}
+}
+
+func TestRecordGeo_AlertsOnAllMisses(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	m := newMonitor(clk, time.Minute, 10, 6*time.Hour)
+
+	var fired int
+	for i := 0; i < 10; i++ {
+		if alert, n := m.RecordGeo(false); alert {
+			fired++
+			if n != 10 {
+				t.Errorf("attempts: want 10, got %d", n)
+			}
+		}
+	}
+	if fired != 1 {
+		t.Fatalf("expected exactly one geo alert for a zero-hit window, got %d", fired)
+	}
+}
+
+func TestRecordGeo_NoAlertWhenSomeHits(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	m := newMonitor(clk, time.Minute, 10, 6*time.Hour)
+
+	for i := 0; i < 9; i++ {
+		if alert, _ := m.RecordGeo(false); alert {
+			t.Fatal("should not alert before the window completes")
+		}
+	}
+	// One hit in the window — no alert.
+	if alert, _ := m.RecordGeo(true); alert {
+		t.Fatal("a window with at least one hit must not alert")
+	}
+}
+
+func TestRecordGeo_ThrottlesReAlerts(t *testing.T) {
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	m := newMonitor(clk, time.Minute, 2, 6*time.Hour)
+
+	// Window 1: two misses -> alert.
+	m.RecordGeo(false)
+	if alert, _ := m.RecordGeo(false); !alert {
+		t.Fatal("expected alert on first zero-hit window")
+	}
+	// Window 2 immediately after: still all misses, but within re-alert window.
+	m.RecordGeo(false)
+	if alert, _ := m.RecordGeo(false); alert {
+		t.Fatal("must throttle re-alerts within GeoReAlert")
+	}
+	// After the re-alert window passes, it may alert again.
+	clk.add(7 * time.Hour)
+	m.RecordGeo(false)
+	if alert, _ := m.RecordGeo(false); !alert {
+		t.Fatal("expected a re-alert after GeoReAlert elapsed")
+	}
+}


### PR DESCRIPTION
Eliminates the blindspots behind the recent incidents — both failure modes produced **no signal**, so nothing reached BugBarn.

## What now raises a BugBarn issue
funnelbarn's logger already forwards `Warn+` to BugBarn (`bblog`). This adds the missing signals via `slog.Error`:

1. **Stalled ingest consumer** — new `internal/workerhealth.Monitor` checks each worker tick: if the spool has pending bytes but the cursor offset hasn't advanced within 5 minutes, it logs an error (fires once per stall, re-arms on progress). This is the exact condition that hid the ~5-day ingestion outage.
2. **Geo resolving nothing** — over a window of geo lookups, if zero resolve a country, it logs an error pointing at `FUNNELBARN_TRUSTED_PROXIES` / client-IP forwarding (throttled). This is why `country_code` was empty for all 109k events.
3. **GeoIP DB open failure** — promoted from `Warn` to a captured `Error` (with the `err`), so a missing/unreadable GeoLite2 db raises a grouped issue instead of silently disabling geo.

## Notes
- The monitor is a pure, clock-injectable state machine with unit tests (stall fire-once/re-arm, idle-never-fires, geo zero-hit alert + throttle).
- Idle systems (no pending data) never alert; processing errors that freeze the cursor with a backlog (e.g. DB down) will alert too — intentionally.
- Added `spool.ActiveSize` to measure pending bytes.

## Verification
`gofmt` clean, `go vet` clean, `go test ./...` → 19 packages ok, 0 fail.