### PR TITLE
fix(insights): guard against null API responses in AddWidgetModal

### DIFF
--- a/web/src/components/insights/AddWidgetModal.tsx
+++ b/web/src/components/insights/AddWidgetModal.tsx
@@ -20,7 +20,7 @@ export function AddWidgetModal({ projectId, onClose, onAdded }: {
 
   useEffect(() => {
     api.getEventNames(projectId)
-      .then((d) => setEventNames(d.event_names))
+      .then((d) => setEventNames(d.event_names ?? []))
       .catch(() => {})
       .finally(() => setLoadingEvents(false))
   }, [projectId])
@@ -33,7 +33,7 @@ export function AddWidgetModal({ projectId, onClose, onAdded }: {
     setLoadingProps(true)
     setSelectedProperty('')
     api.getEventProperties(projectId, selectedEvent)
-      .then((d) => setProperties(d.properties))
+      .then((d) => setProperties(d.properties ?? []))
       .catch(() => {})
       .finally(() => setLoadingProps(false))
   }, [projectId, selectedEvent])


### PR DESCRIPTION
## Summary
- `d.event_names` and `d.properties` can be `null` when the API returns no data for a project
- This caused `TypeError: Cannot read properties of null (reading 'map')` on prod at `AddWidgetModal.tsx:151`
- Fallback to `[]` with `?? []` in both `.then()` callbacks

## Test plan
- [ ] Open Add Widget modal on an insights page with no events tracked yet
- [ ] Verify the modal renders without crashing (event dropdown shows "Select an event..." only)
- [ ] Select an event and verify property dropdown renders without crashing when no properties exist