### PR TITLE
feat(observability): correlate browser traces to session recordings

### DIFF
--- a/internal/api/recordings.go
+++ b/internal/api/recordings.go
@@ -268,6 +268,67 @@ func (s *Server) handleGetRecordingFlags(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, map[string]any{"evaluations": evals})
 }
 
+// handleLookupTrace resolves a W3C trace_id (as seen in SpanBarn/BugBarn) to the
+// FunnelBarn session + recording that captured it, plus the seek offset. This is
+// the cross-stack deep-link: given an error trace, find the replayable session.
+// Auth is by API key (project scope) so a trace only resolves within its project.
+func (s *Server) handleLookupTrace(w http.ResponseWriter, r *http.Request) {
+	if s.recordings == nil {
+		jsonError(w, "session recording not configured", http.StatusServiceUnavailable)
+		return
+	}
+	projectID, _, ok := s.ingest.APIKeyProjectScope(r)
+	if !ok {
+		jsonError(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	traceID := r.PathValue("trace_id")
+	if traceID == "" {
+		jsonError(w, "trace_id required", http.StatusBadRequest)
+		return
+	}
+
+	lookup, found, err := s.recordings.LookupTrace(r.Context(), projectID, traceID)
+	if err != nil {
+		mapServiceError(w, err, "handleLookupTrace")
+		return
+	}
+	if !found {
+		jsonError(w, "not found", http.StatusNotFound)
+		return
+	}
+	writeJSON(w, http.StatusOK, lookup)
+}
+
+// handleGetRecordingTraces returns the ordered trace timeline for a recording so
+// the replay UI can overlay trace markers on the scrubber.
+func (s *Server) handleGetRecordingTraces(w http.ResponseWriter, r *http.Request) {
+	if s.recordings == nil {
+		jsonError(w, "session recording not configured", http.StatusServiceUnavailable)
+		return
+	}
+	projectID := r.PathValue("id")
+	recordingID := r.PathValue("rid")
+	if projectID == "" || recordingID == "" {
+		jsonError(w, "project id and recording id are required", http.StatusBadRequest)
+		return
+	}
+
+	traces, err := s.recordings.TracesForRecording(r.Context(), projectID, recordingID)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			jsonError(w, "not found", http.StatusNotFound)
+			return
+		}
+		mapServiceError(w, err, "handleGetRecordingTraces")
+		return
+	}
+	if traces == nil {
+		traces = []repository.TraceLink{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"traces": traces})
+}
+
 func (s *Server) handleFunnelStepSessions(w http.ResponseWriter, r *http.Request) {
 	if s.recordings == nil {
 		writeJSON(w, http.StatusOK, map[string]any{"session_ids": []any{}})

--- a/internal/api/recordings.go
+++ b/internal/api/recordings.go
@@ -300,6 +300,53 @@ func (s *Server) handleLookupTrace(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, lookup)
 }
 
+// handleGetRecordingChunkByKey serves a recording chunk to an API-key client
+// (e.g. the replay CLI), scoped to the key's project. It mirrors the session-auth
+// chunk endpoint but lets a programmatic consumer fetch replay data with the same
+// credential it used for the trace lookup. GetChunk verifies project ownership.
+func (s *Server) handleGetRecordingChunkByKey(w http.ResponseWriter, r *http.Request) {
+	if s.recordings == nil {
+		jsonError(w, "session recording not configured", http.StatusServiceUnavailable)
+		return
+	}
+	projectID, _, ok := s.ingest.APIKeyProjectScope(r)
+	if !ok {
+		jsonError(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	recordingID := r.PathValue("rid")
+	indexStr := r.PathValue("index")
+	if recordingID == "" || indexStr == "" {
+		jsonError(w, "recording id and chunk index are required", http.StatusBadRequest)
+		return
+	}
+	index, err := strconv.Atoi(indexStr)
+	if err != nil || index < 0 {
+		jsonError(w, "invalid chunk index", http.StatusBadRequest)
+		return
+	}
+
+	data, err := s.recordings.GetChunk(r.Context(), projectID, recordingID, index)
+	if err != nil {
+		errStr := err.Error()
+		if strings.Contains(errStr, "not found") || strings.Contains(errStr, "NoSuchKey") || strings.Contains(errStr, "404") {
+			jsonError(w, "not found", http.StatusNotFound)
+			return
+		}
+		slog.ErrorContext(r.Context(), "fetch recording chunk (api key) failed",
+			"error", err, "handled", false,
+			"recording_id", recordingID, "project_id", projectID, "chunk_index", index,
+			"request_id", RequestIDFromContext(r.Context()),
+		)
+		jsonError(w, "failed to fetch chunk", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "private, max-age=3600")
+	w.WriteHeader(http.StatusOK)
+	w.Write(data) //nolint:errcheck
+}
+
 // handleGetRecordingTraces returns the ordered trace timeline for a recording so
 // the replay UI can overlay trace markers on the scrubber.
 func (s *Server) handleGetRecordingTraces(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/recordings_trace_test.go
+++ b/internal/api/recordings_trace_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -175,6 +176,69 @@ func TestLookupTrace_EndToEnd(t *testing.T) {
 	}
 	if got.OffsetMs != 4000 {
 		t.Errorf("offset: want 4000ms, got %d", got.OffsetMs)
+	}
+	// Chunk range + metadata travel with the lookup so a replay client can fetch
+	// without a second round-trip.
+	if got.ChunkCount != 1 || got.FirstChunkIndex != 0 || got.LastChunkIndex != 0 {
+		t.Errorf("chunk range: got first=%d last=%d count=%d", got.FirstChunkIndex, got.LastChunkIndex, got.ChunkCount)
+	}
+	if got.PageURL != "https://shop.example/checkout" {
+		t.Errorf("page_url: got %q", got.PageURL)
+	}
+
+	// The same API key can fetch the recording's chunks for replay.
+	wc := getChunkByKey(t, srv, key, "recE2E", 0)
+	if wc.Code != http.StatusOK {
+		t.Fatalf("chunk fetch: expected 200, got %d (body: %s)", wc.Code, wc.Body.String())
+	}
+	var events []map[string]any
+	if err := json.Unmarshal(wc.Body.Bytes(), &events); err != nil {
+		t.Fatalf("chunk unmarshal: %v (body: %s)", err, wc.Body.String())
+	}
+	if len(events) != 1 || events[0]["type"] != float64(2) {
+		t.Errorf("expected one full-snapshot event, got %v", events)
+	}
+}
+
+func getChunkByKey(t *testing.T, srv *Server, key, rid string, index int) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/recordings/"+rid+"/chunks/"+strconv.Itoa(index), nil)
+	if key != "" {
+		req.Header.Set(auth.HeaderAPIKey, key)
+	}
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	return w
+}
+
+func TestGetRecordingChunkByKey_CrossProjectDenied(t *testing.T) {
+	srv, store := newRecordingServer(t)
+	_, keyA := projectKey(t, store, "Owner", "owner-proj")
+	_, keyB := projectKey(t, store, "Other", "other-proj")
+
+	start := time.Now().UTC().Truncate(time.Second)
+	w := postChunk(t, srv, keyA, map[string]any{
+		"recording_id": "recOwned",
+		"session_id":   "sessOwned",
+		"chunk_index":  0,
+		"events":       json.RawMessage(`[{"type":2,"data":{}}]`),
+		"started_at":   start,
+		"duration_ms":  1000,
+	})
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("ingest: expected 202, got %d", w.Code)
+	}
+
+	// Project B must not read project A's recording chunk.
+	wc := getChunkByKey(t, srv, keyB, "recOwned", 0)
+	if wc.Code != http.StatusNotFound {
+		t.Errorf("cross-project chunk read: expected 404, got %d", wc.Code)
+	}
+
+	// No key at all -> 401.
+	wn := getChunkByKey(t, srv, "", "recOwned", 0)
+	if wn.Code != http.StatusUnauthorized {
+		t.Errorf("no key chunk read: expected 401, got %d", wn.Code)
 	}
 }
 

--- a/internal/api/recordings_trace_test.go
+++ b/internal/api/recordings_trace_test.go
@@ -1,0 +1,196 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/wiebe-xyz/funnelbarn/internal/auth"
+	"github.com/wiebe-xyz/funnelbarn/internal/ingest"
+	"github.com/wiebe-xyz/funnelbarn/internal/repository"
+	"github.com/wiebe-xyz/funnelbarn/internal/service"
+)
+
+// memStorage is an in-memory RecordingStorage for tests.
+type memStorage struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+func newMemStorage() *memStorage { return &memStorage{m: map[string][]byte{}} }
+
+func (s *memStorage) Put(_ context.Context, key string, data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	s.m[key] = cp
+	return nil
+}
+
+func (s *memStorage) Get(_ context.Context, key string) ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.m[key]
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+	return v, nil
+}
+
+func (s *memStorage) Delete(_ context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.m, key)
+	return nil
+}
+
+// newRecordingServer builds a server with session recording enabled and a
+// DB-backed API key authorizer (so a key can be bound to a real project).
+func newRecordingServer(t *testing.T) (*Server, *repository.Store) {
+	t.Helper()
+	store := openMemoryStore(t)
+	sp := newTestSpool(t)
+	authz := auth.New("").WithDBLookup(store.ValidAPIKeySHA256, store.TouchAPIKey)
+	ingestHandler := ingest.NewHandler(authz, sp, 0)
+	sm := auth.NewSessionManager("test-secret", time.Hour)
+	userAuth, _ := auth.NewUserAuthenticator("", "", "")
+	recSvc := service.NewRecordingService(store, store, store, newMemStorage())
+
+	srv := NewServer(ServerConfig{
+		Ingest:              ingestHandler,
+		Projects:            service.NewProjectService(store),
+		Funnels:             service.NewFunnelService(store),
+		ABTests:             service.NewABTestService(store),
+		Flags:               service.NewFlagService(store),
+		Events:              service.NewEventService(store),
+		Sessions:            service.NewSessionService(store),
+		APIKeys:             service.NewAPIKeyService(store),
+		Widgets:             service.NewWidgetService(store),
+		Recordings:          recSvc,
+		UserAuth:            userAuth,
+		SessionManager:      sm,
+		SessionSecret:       "test-secret",
+		PublicURL:           "http://localhost",
+		LoginRatePerMinute:  1000,
+		LoginRateBurst:      1000,
+		APIRatePerMinute:    1000,
+		APIRateBurst:        1000,
+		IngestRatePerMinute: 1000,
+		IngestRateBurst:     1000,
+		DB:                  store,
+		Version:             "test",
+	})
+	return srv, store
+}
+
+// projectKey creates a project and an ingest-scoped API key bound to it,
+// returning the project ID and the plaintext key.
+func projectKey(t *testing.T, store *repository.Store, name, slug string) (projectID, plaintextKey string) {
+	t.Helper()
+	ctx := context.Background()
+	p, err := store.CreateProject(ctx, name, slug)
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	plaintextKey = "key-" + slug
+	sum := sha256.Sum256([]byte(plaintextKey))
+	if _, err := store.CreateAPIKey(ctx, "test", p.ID, hex.EncodeToString(sum[:]), "ingest"); err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	return p.ID, plaintextKey
+}
+
+func postChunk(t *testing.T, srv *Server, key string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(body); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/recordings/chunk", &buf)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(auth.HeaderAPIKey, key)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	return w
+}
+
+func getTrace(t *testing.T, srv *Server, key, traceID string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/traces/"+traceID, nil)
+	if key != "" {
+		req.Header.Set(auth.HeaderAPIKey, key)
+	}
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	return w
+}
+
+func TestLookupTrace_EndToEnd(t *testing.T) {
+	srv, store := newRecordingServer(t)
+	projectID, key := projectKey(t, store, "Trace E2E", "trace-e2e")
+
+	start := time.Now().UTC().Truncate(time.Second)
+	traceTime := start.Add(4 * time.Second)
+
+	// Ingest a recording chunk carrying a trace link.
+	w := postChunk(t, srv, key, map[string]any{
+		"recording_id": "recE2E",
+		"session_id":   "sessE2E",
+		"chunk_index":  0,
+		"events":       json.RawMessage(`[{"type":2,"data":{}}]`),
+		"started_at":   start,
+		"duration_ms":  5000,
+		"page_url":     "https://shop.example/checkout",
+		"traces": []map[string]any{
+			{"trace_id": "trace-xyz", "span_id": "span-1", "url": "https://shop.example/api/pay", "occurred_at": traceTime},
+		},
+	})
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("chunk ingest: expected 202, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	// Resolve the trace back to the recording.
+	wl := getTrace(t, srv, key, "trace-xyz")
+	if wl.Code != http.StatusOK {
+		t.Fatalf("lookup: expected 200, got %d (body: %s)", wl.Code, wl.Body.String())
+	}
+	var got repository.TraceLookup
+	if err := json.Unmarshal(wl.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.RecordingID != "recE2E" || got.SessionID != "sessE2E" {
+		t.Errorf("lookup mismatch: %+v", got)
+	}
+	if got.ProjectID != projectID {
+		t.Errorf("project: want %s, got %s", projectID, got.ProjectID)
+	}
+	if got.OffsetMs != 4000 {
+		t.Errorf("offset: want 4000ms, got %d", got.OffsetMs)
+	}
+}
+
+func TestLookupTrace_Unauthorized(t *testing.T) {
+	srv, _ := newRecordingServer(t)
+	w := getTrace(t, srv, "", "anything")
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("no key: expected 401, got %d", w.Code)
+	}
+}
+
+func TestLookupTrace_NotFound(t *testing.T) {
+	srv, store := newRecordingServer(t)
+	_, key := projectKey(t, store, "Trace NF", "trace-nf")
+	w := getTrace(t, srv, key, "unknown-trace")
+	if w.Code != http.StatusNotFound {
+		t.Errorf("unknown trace: expected 404, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -223,6 +223,8 @@ func (s *Server) registerRoutes() {
 	// Cross-stack trace lookup (API key required): trace_id -> session/recording.
 	// Consumed by SpanBarn/BugBarn deep-links and the replay CLI.
 	s.mux.HandleFunc("GET /api/v1/traces/{trace_id}", s.handleLookupTrace)
+	// API-key-authed replay-read for programmatic consumers (the replay CLI).
+	s.mux.HandleFunc("GET /api/v1/recordings/{rid}/chunks/{index}", s.handleGetRecordingChunkByKey)
 
 	// Auth
 	s.mux.Handle("POST /api/v1/login", s.loginLimiter.middleware(http.HandlerFunc(s.handleLogin)))

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -220,6 +220,9 @@ func (s *Server) registerRoutes() {
 	// Ingest (API key required)
 	s.mux.Handle("POST /api/v1/events", s.eventsLimiter.middleware(s.ingest))
 	s.mux.Handle("POST /api/v1/recordings/chunk", s.eventsLimiter.middleware(http.HandlerFunc(s.handleIngestRecordingChunk)))
+	// Cross-stack trace lookup (API key required): trace_id -> session/recording.
+	// Consumed by SpanBarn/BugBarn deep-links and the replay CLI.
+	s.mux.HandleFunc("GET /api/v1/traces/{trace_id}", s.handleLookupTrace)
 
 	// Auth
 	s.mux.Handle("POST /api/v1/login", s.loginLimiter.middleware(http.HandlerFunc(s.handleLogin)))
@@ -296,6 +299,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/recordings/{rid}/chunks/{index}", s.requireSession(s.handleGetRecordingChunk))
 	s.mux.HandleFunc("DELETE /api/v1/projects/{id}/recordings/{rid}", s.requireSession(s.handleDeleteRecording))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/recordings/{rid}/flags", s.requireSession(s.handleGetRecordingFlags))
+	s.mux.HandleFunc("GET /api/v1/projects/{id}/recordings/{rid}/traces", s.requireSession(s.handleGetRecordingTraces))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/funnels/{fid}/steps/{step}/sessions", s.requireSession(s.handleFunnelStepSessions))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/flows/sessions", s.requireSession(s.handleFlowPageSessions))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/recording-settings", s.requireSession(s.handleGetProjectRecordingSettings))

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -139,6 +139,9 @@ type RecordingRepo interface {
 	ListBrokenRecordings(ctx context.Context) ([]repository.Recording, error)
 	DeleteRecording(ctx context.Context, id string) error
 	FlagEvaluationsForSession(ctx context.Context, sessionID, projectID string) ([]repository.FlagEvaluationEntry, error)
+	InsertTraceLinks(ctx context.Context, projectID, sessionID, recordingID string, links []repository.TraceLink) error
+	LookupTrace(ctx context.Context, projectID, traceID string) (repository.TraceLookup, bool, error)
+	TracesForRecording(ctx context.Context, recordingID string) ([]repository.TraceLink, error)
 }
 
 // ProjectHealthRepo is the persistence port for project integration health.

--- a/internal/repository/migrations/00025_recording_traces.sql
+++ b/internal/repository/migrations/00025_recording_traces.sql
@@ -1,0 +1,32 @@
+-- +goose Up
+-- recording_traces links a recording's timeline to the W3C trace_ids observed in
+-- the browser during that recording. It is the join key across the observability
+-- stack: SpanBarn (traces) and BugBarn (errors) carry a trace_id, and this table
+-- resolves that trace_id back to the FunnelBarn session + recording so the session
+-- can be replayed at the exact moment the trace fired.
+--
+-- A single recording can hold many trace_ids (one per instrumented request), each
+-- timestamped so the replay can seek. occurred_at is the wall-clock time the trace
+-- was observed in the browser; the seek offset is occurred_at - recordings.started_at.
+CREATE TABLE recording_traces (
+    project_id   TEXT NOT NULL,
+    session_id   TEXT NOT NULL,
+    recording_id TEXT NOT NULL,
+    trace_id     TEXT NOT NULL,
+    span_id      TEXT NOT NULL DEFAULT '',
+    url          TEXT NOT NULL DEFAULT '',
+    occurred_at  DATETIME NOT NULL,
+    created_at   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (recording_id, trace_id, occurred_at)
+);
+
+-- Reverse lookup (SpanBarn/BugBarn trace_id -> recording). Scoped by project so a
+-- leaked/guessed trace_id can only resolve within the owning project's key scope.
+CREATE INDEX idx_recording_traces_lookup ON recording_traces (project_id, trace_id);
+-- Forward lookup (recording -> ordered trace timeline) for the replay UI/CLI.
+CREATE INDEX idx_recording_traces_recording ON recording_traces (recording_id, occurred_at);
+-- Session-level rollup.
+CREATE INDEX idx_recording_traces_session ON recording_traces (session_id);
+
+-- +goose Down
+DROP TABLE recording_traces;

--- a/internal/repository/recording_traces.go
+++ b/internal/repository/recording_traces.go
@@ -1,0 +1,116 @@
+package repository
+
+import (
+	"context"
+	"time"
+)
+
+// TraceLink is a single W3C trace observed in the browser during a recording.
+// It is sent by the SDK alongside a recording chunk and stored so a trace_id from
+// SpanBarn/BugBarn can be resolved back to a session + recording (and seek offset).
+type TraceLink struct {
+	TraceID    string    `json:"trace_id"`
+	SpanID     string    `json:"span_id,omitempty"`
+	URL        string    `json:"url,omitempty"`
+	OccurredAt time.Time `json:"occurred_at"`
+}
+
+// TraceLookup resolves a trace_id to the recording that captured it, including the
+// seek offset (occurred_at - recording.started_at) so a replay can jump to the
+// moment the trace fired.
+type TraceLookup struct {
+	TraceID            string    `json:"trace_id"`
+	ProjectID          string    `json:"project_id"`
+	SessionID          string    `json:"session_id"`
+	RecordingID        string    `json:"recording_id"`
+	OccurredAt         time.Time `json:"occurred_at"`
+	OffsetMs           int64     `json:"offset_ms"`
+	URL                string    `json:"url,omitempty"`
+	RecordingStartedAt time.Time `json:"recording_started_at"`
+}
+
+// InsertTraceLinks persists the trace links observed during one recording chunk.
+// It is idempotent on (recording_id, trace_id, occurred_at): a retried chunk
+// upload re-inserts the same rows without duplicating them.
+func (s *Store) InsertTraceLinks(ctx context.Context, projectID, sessionID, recordingID string, links []TraceLink) error {
+	if len(links) == 0 {
+		return nil
+	}
+	const q = `
+		INSERT INTO recording_traces
+			(project_id, session_id, recording_id, trace_id, span_id, url, occurred_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(recording_id, trace_id, occurred_at) DO NOTHING`
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck
+	stmt, err := tx.PrepareContext(ctx, q)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+	for _, l := range links {
+		if l.TraceID == "" {
+			continue
+		}
+		if _, err := stmt.ExecContext(ctx, projectID, sessionID, recordingID, l.TraceID, l.SpanID, l.URL, l.OccurredAt); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// LookupTrace resolves a trace_id to its recording within a project. When a trace
+// spans multiple chunks it returns the earliest observation (the most useful seek
+// target). Returns sql.ErrNoRows-wrapped nil + found=false when the trace is unknown.
+func (s *Store) LookupTrace(ctx context.Context, projectID, traceID string) (TraceLookup, bool, error) {
+	const q = `
+		SELECT rt.project_id, rt.session_id, rt.recording_id, rt.trace_id, rt.url, rt.occurred_at, r.started_at
+		FROM recording_traces rt
+		JOIN recordings r ON r.id = rt.recording_id
+		WHERE rt.project_id = ? AND rt.trace_id = ?
+		ORDER BY rt.occurred_at ASC
+		LIMIT 1`
+	var out TraceLookup
+	err := s.db.QueryRowContext(ctx, q, projectID, traceID).Scan(
+		&out.ProjectID, &out.SessionID, &out.RecordingID, &out.TraceID,
+		&out.URL, &out.OccurredAt, &out.RecordingStartedAt,
+	)
+	if err != nil {
+		if isNoRows(err) {
+			return TraceLookup{}, false, nil
+		}
+		return TraceLookup{}, false, err
+	}
+	out.OffsetMs = out.OccurredAt.Sub(out.RecordingStartedAt).Milliseconds()
+	if out.OffsetMs < 0 {
+		out.OffsetMs = 0
+	}
+	return out, true, nil
+}
+
+// TracesForRecording returns the ordered trace timeline for a recording, for the
+// replay UI/CLI to overlay trace markers on the scrubber.
+func (s *Store) TracesForRecording(ctx context.Context, recordingID string) ([]TraceLink, error) {
+	const q = `
+		SELECT trace_id, span_id, url, occurred_at
+		FROM recording_traces
+		WHERE recording_id = ?
+		ORDER BY occurred_at ASC`
+	rows, err := s.db.QueryContext(ctx, q, recordingID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []TraceLink
+	for rows.Next() {
+		var l TraceLink
+		if err := rows.Scan(&l.TraceID, &l.SpanID, &l.URL, &l.OccurredAt); err != nil {
+			return nil, err
+		}
+		out = append(out, l)
+	}
+	return out, rows.Err()
+}

--- a/internal/repository/recording_traces.go
+++ b/internal/repository/recording_traces.go
@@ -27,6 +27,14 @@ type TraceLookup struct {
 	OffsetMs           int64     `json:"offset_ms"`
 	URL                string    `json:"url,omitempty"`
 	RecordingStartedAt time.Time `json:"recording_started_at"`
+	// Chunk range + metadata of the resolved recording, so a replay client can
+	// fetch the chunks and render without a second round-trip.
+	FirstChunkIndex int    `json:"first_chunk_index"`
+	LastChunkIndex  int    `json:"last_chunk_index"`
+	ChunkCount      int    `json:"chunk_count"`
+	DurationMs      int64  `json:"duration_ms"`
+	Environment     string `json:"environment,omitempty"`
+	PageURL         string `json:"page_url,omitempty"`
 }
 
 // InsertTraceLinks persists the trace links observed during one recording chunk.
@@ -67,7 +75,8 @@ func (s *Store) InsertTraceLinks(ctx context.Context, projectID, sessionID, reco
 // target). Returns sql.ErrNoRows-wrapped nil + found=false when the trace is unknown.
 func (s *Store) LookupTrace(ctx context.Context, projectID, traceID string) (TraceLookup, bool, error) {
 	const q = `
-		SELECT rt.project_id, rt.session_id, rt.recording_id, rt.trace_id, rt.url, rt.occurred_at, r.started_at
+		SELECT rt.project_id, rt.session_id, rt.recording_id, rt.trace_id, rt.url, rt.occurred_at,
+		       r.started_at, r.first_chunk_index, r.last_chunk_index, r.chunk_count, r.duration_ms, r.environment, r.page_url
 		FROM recording_traces rt
 		JOIN recordings r ON r.id = rt.recording_id
 		WHERE rt.project_id = ? AND rt.trace_id = ?
@@ -77,6 +86,7 @@ func (s *Store) LookupTrace(ctx context.Context, projectID, traceID string) (Tra
 	err := s.db.QueryRowContext(ctx, q, projectID, traceID).Scan(
 		&out.ProjectID, &out.SessionID, &out.RecordingID, &out.TraceID,
 		&out.URL, &out.OccurredAt, &out.RecordingStartedAt,
+		&out.FirstChunkIndex, &out.LastChunkIndex, &out.ChunkCount, &out.DurationMs, &out.Environment, &out.PageURL,
 	)
 	if err != nil {
 		if isNoRows(err) {

--- a/internal/repository/recording_traces_test.go
+++ b/internal/repository/recording_traces_test.go
@@ -1,0 +1,156 @@
+package repository_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wiebe-xyz/funnelbarn/internal/repository"
+)
+
+func TestRecordingTraces_InsertAndLookup(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	p, err := s.CreateProject(ctx, "Traces", "traces")
+	require.NoError(t, err)
+
+	start := time.Now().UTC().Truncate(time.Second)
+	rec := makeRecording(p.ID, "sess-tr", start)
+	rec.ID = "rec-tr"
+	require.NoError(t, s.UpsertRecording(ctx, rec))
+
+	// Trace fired 3.5s into the recording.
+	traceTime := start.Add(3500 * time.Millisecond)
+	links := []repository.TraceLink{
+		{TraceID: "abc123", SpanID: "span1", URL: "https://example.com/checkout", OccurredAt: traceTime},
+	}
+	require.NoError(t, s.InsertTraceLinks(ctx, p.ID, "sess-tr", "rec-tr", links))
+
+	got, found, err := s.LookupTrace(ctx, p.ID, "abc123")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "rec-tr", got.RecordingID)
+	assert.Equal(t, "sess-tr", got.SessionID)
+	assert.Equal(t, p.ID, got.ProjectID)
+	assert.Equal(t, "https://example.com/checkout", got.URL)
+	assert.Equal(t, int64(3500), got.OffsetMs, "offset = occurred_at - recording.started_at")
+}
+
+func TestRecordingTraces_LookupUnknownTrace(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	p, err := s.CreateProject(ctx, "Traces NF", "traces-nf")
+	require.NoError(t, err)
+
+	_, found, err := s.LookupTrace(ctx, p.ID, "does-not-exist")
+	require.NoError(t, err)
+	assert.False(t, found)
+}
+
+func TestRecordingTraces_LookupScopedByProject(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	p1, err := s.CreateProject(ctx, "Proj One", "proj-one")
+	require.NoError(t, err)
+	p2, err := s.CreateProject(ctx, "Proj Two", "proj-two")
+	require.NoError(t, err)
+
+	start := time.Now().UTC().Truncate(time.Second)
+	rec := makeRecording(p1.ID, "sess-sc", start)
+	rec.ID = "rec-sc"
+	require.NoError(t, s.UpsertRecording(ctx, rec))
+	require.NoError(t, s.InsertTraceLinks(ctx, p1.ID, "sess-sc", "rec-sc",
+		[]repository.TraceLink{{TraceID: "shared-trace", OccurredAt: start}}))
+
+	// A different project must not resolve another project's trace.
+	_, found, err := s.LookupTrace(ctx, p2.ID, "shared-trace")
+	require.NoError(t, err)
+	assert.False(t, found, "trace lookup must be scoped to the owning project")
+}
+
+func TestRecordingTraces_LookupReturnsEarliest(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	p, err := s.CreateProject(ctx, "Earliest", "earliest")
+	require.NoError(t, err)
+
+	start := time.Now().UTC().Truncate(time.Second)
+	rec := makeRecording(p.ID, "sess-e", start)
+	rec.ID = "rec-e"
+	require.NoError(t, s.UpsertRecording(ctx, rec))
+
+	// Same trace_id observed twice (e.g. across chunks); earliest wins as seek target.
+	require.NoError(t, s.InsertTraceLinks(ctx, p.ID, "sess-e", "rec-e", []repository.TraceLink{
+		{TraceID: "dup", OccurredAt: start.Add(8 * time.Second)},
+		{TraceID: "dup", OccurredAt: start.Add(2 * time.Second)},
+	}))
+
+	got, found, err := s.LookupTrace(ctx, p.ID, "dup")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, int64(2000), got.OffsetMs)
+}
+
+func TestRecordingTraces_InsertIdempotent(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	p, err := s.CreateProject(ctx, "Idem", "idem")
+	require.NoError(t, err)
+
+	start := time.Now().UTC().Truncate(time.Second)
+	rec := makeRecording(p.ID, "sess-i", start)
+	rec.ID = "rec-i"
+	require.NoError(t, s.UpsertRecording(ctx, rec))
+
+	link := repository.TraceLink{TraceID: "t1", SpanID: "s1", OccurredAt: start.Add(time.Second)}
+	// A retried chunk re-sends the same link; the PK conflict must be a no-op.
+	require.NoError(t, s.InsertTraceLinks(ctx, p.ID, "sess-i", "rec-i", []repository.TraceLink{link}))
+	require.NoError(t, s.InsertTraceLinks(ctx, p.ID, "sess-i", "rec-i", []repository.TraceLink{link}))
+
+	traces, err := s.TracesForRecording(ctx, "rec-i")
+	require.NoError(t, err)
+	assert.Len(t, traces, 1, "duplicate (recording_id, trace_id, occurred_at) must not double-insert")
+}
+
+func TestRecordingTraces_ForRecordingOrdered(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	p, err := s.CreateProject(ctx, "Timeline", "timeline")
+	require.NoError(t, err)
+
+	start := time.Now().UTC().Truncate(time.Second)
+	rec := makeRecording(p.ID, "sess-tl", start)
+	rec.ID = "rec-tl"
+	require.NoError(t, s.UpsertRecording(ctx, rec))
+
+	require.NoError(t, s.InsertTraceLinks(ctx, p.ID, "sess-tl", "rec-tl", []repository.TraceLink{
+		{TraceID: "c", OccurredAt: start.Add(3 * time.Second)},
+		{TraceID: "a", OccurredAt: start.Add(1 * time.Second)},
+		{TraceID: "b", OccurredAt: start.Add(2 * time.Second)},
+	}))
+
+	traces, err := s.TracesForRecording(ctx, "rec-tl")
+	require.NoError(t, err)
+	require.Len(t, traces, 3)
+	assert.Equal(t, "a", traces[0].TraceID)
+	assert.Equal(t, "b", traces[1].TraceID)
+	assert.Equal(t, "c", traces[2].TraceID)
+}
+
+func TestRecordingTraces_InsertEmptyNoop(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	p, err := s.CreateProject(ctx, "Empty", "empty")
+	require.NoError(t, err)
+
+	require.NoError(t, s.InsertTraceLinks(ctx, p.ID, "sess-x", "rec-x", nil))
+}

--- a/internal/service/interfaces.go
+++ b/internal/service/interfaces.go
@@ -132,6 +132,8 @@ type Recordings interface {
 	PurgeOldRecordings(ctx context.Context, retentionDays int) error
 	PurgeBrokenRecordings(ctx context.Context) (int, error)
 	DeleteRecording(ctx context.Context, projectID, recordingID string) error
+	LookupTrace(ctx context.Context, projectID, traceID string) (repository.TraceLookup, bool, error)
+	TracesForRecording(ctx context.Context, projectID, recordingID string) ([]repository.TraceLink, error)
 }
 
 // APIKeys is the interface for API key-related operations.

--- a/internal/service/recordings.go
+++ b/internal/service/recordings.go
@@ -23,10 +23,14 @@ type RecordingChunk struct {
 	StartedAt   time.Time       `json:"started_at"`
 	DurationMs  int64           `json:"duration_ms"`
 	PageURL     string          `json:"page_url"`
-	Environment string          `json:"-"` // set by the handler from the resolved project
-	ProjectSlug string          `json:"-"` // set by the handler
-	ProjectID   string          `json:"-"` // set by the handler after slug lookup
-	UserAgent   string          `json:"-"` // set by the handler from the request UA header
+	// Traces are the W3C trace links observed in the browser during this chunk's
+	// window. They are the cross-stack join key (SpanBarn/BugBarn trace_id ->
+	// session/recording). Optional: a chunk with no instrumented requests sends none.
+	Traces      []repository.TraceLink `json:"traces,omitempty"`
+	Environment string                 `json:"-"` // set by the handler from the resolved project
+	ProjectSlug string                 `json:"-"` // set by the handler
+	ProjectID   string                 `json:"-"` // set by the handler after slug lookup
+	UserAgent   string                 `json:"-"` // set by the handler from the request UA header
 }
 
 // RecordingStorage is the interface for chunk blob storage (R2).
@@ -81,7 +85,40 @@ func (svc *RecordingService) IngestChunk(ctx context.Context, chunk RecordingChu
 		IsBot:           DetectBot(chunk.UserAgent),
 		PageURL:         chunk.PageURL,
 	}
-	return svc.store.UpsertRecording(ctx, rec)
+	if err := svc.store.UpsertRecording(ctx, rec); err != nil {
+		return err
+	}
+	// Persist trace links last: the recording row must exist first (LookupTrace
+	// joins against it for the seek offset). A trace-link failure should not lose
+	// the chunk itself, so log and continue rather than returning an error.
+	if len(chunk.Traces) > 0 {
+		if err := svc.store.InsertTraceLinks(ctx, chunk.ProjectID, chunk.SessionID, chunk.RecordingID, chunk.Traces); err != nil {
+			slog.WarnContext(ctx, "recordings: persist trace links failed",
+				"err", err, "handled", true,
+				"recording_id", chunk.RecordingID, "project_id", chunk.ProjectID,
+				"trace_count", len(chunk.Traces))
+		}
+	}
+	return nil
+}
+
+// LookupTrace resolves a trace_id (from SpanBarn/BugBarn) to the recording that
+// captured it, scoped to the project. ok is false when the trace is unknown.
+func (svc *RecordingService) LookupTrace(ctx context.Context, projectID, traceID string) (repository.TraceLookup, bool, error) {
+	return svc.store.LookupTrace(ctx, projectID, traceID)
+}
+
+// TracesForRecording returns the ordered trace timeline for a recording, after
+// verifying it belongs to the given project.
+func (svc *RecordingService) TracesForRecording(ctx context.Context, projectID, recordingID string) ([]repository.TraceLink, error) {
+	rec, err := svc.store.GetRecording(ctx, recordingID)
+	if err != nil {
+		return nil, fmt.Errorf("recordings: get recording: %w", err)
+	}
+	if rec.ProjectID != projectID {
+		return nil, fmt.Errorf("recordings: not found")
+	}
+	return svc.store.TracesForRecording(ctx, recordingID)
 }
 
 // PurgeOldRecordings deletes recordings older than retentionDays from both R2 and SQLite.


### PR DESCRIPTION
## Context

We have a three-part observability stack — **SpanBarn** (OTLP traces/metrics/logs), **BugBarn** (errors), and **FunnelBarn** (analytics + rrweb session recordings). The missing link was correlation: there was no way to go from an error trace in SpanBarn/BugBarn to the FunnelBarn session that produced it and replay what the user did.

The unifying join key is the W3C **trace_id**. SpanBarn stores traces by it, BugBarn errors carry it — this PR makes FunnelBarn associate trace_ids with the session recording timeline so the link closes.

This is **PR 1 of the effort: the backend link primitive.** It unblocks the SDK trace capture and the Playwright replay CLI (follow-up PRs).

## What's included

- **`recording_traces` table** (migration `00025`): timestamped `(trace_id, span_id, url)` rows tied to `recording_id` + `session_id`, scoped by `project_id`. Indexed for reverse lookup (`trace_id → recording`), forward lookup (`recording → ordered timeline`), and session rollup.
- **Chunk ingest** accepts an optional `traces` array; `IngestChunk` persists links after the recording row exists. A trace-link failure logs but never drops the chunk itself.
- **`GET /api/v1/traces/{trace_id}`** (API key auth) — resolves a trace to its session/recording plus **seek offset** (`occurred_at - recording.started_at`). This is the cross-stack deep-link target for SpanBarn/BugBarn and the replay CLI.
- **`GET /api/v1/projects/{id}/recordings/{rid}/traces`** (session auth) — ordered trace timeline for scrubber overlays in the replay UI.

## Design notes

- Trace lookup is **project-scoped** — a leaked/guessed trace_id only resolves within the owning key's project (test covers this).
- When a trace appears across multiple chunks, the **earliest** observation is returned as the seek target.
- Inserts are **idempotent** on `(recording_id, trace_id, occurred_at)` so retried chunk uploads don't duplicate.
- FunnelBarn's `recording_id` is already a 32-hex value = a valid W3C trace_id, which the SDK PR will use for deterministic generation when the app has no active trace context.

## Tests

- Repository: insert/lookup, project scoping, earliest-wins seek offset, idempotent re-ingest, timeline ordering.
- API: end-to-end (recording chunk POST carrying a trace → `GET /traces/{id}` resolves it with correct offset), plus unauthorized + not-found.
- Full suite green (19 packages), `go vet` + `staticcheck` + `gofmt` clean.