### PR TITLE
feat(sdk): capture trace context and link it to session recordings

### DIFF
--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -30,6 +30,32 @@ export interface FunnelBarnOptions {
   recordInclude?: string[];
   /** URL path patterns to always ignore (checked before server rules) */
   recordExclude?: string[];
+  /**
+   * Capture W3C trace context (traceparent) from outgoing fetch/XHR requests
+   * during a recording and link it to the session. This is the cross-stack join
+   * key: a trace_id seen in SpanBarn/BugBarn resolves back to this recording.
+   * Read-only — never modifies requests. Default: true (only active while recording).
+   */
+  traceCapture?: boolean;
+  /**
+   * When an outgoing request carries no traceparent, generate one and inject it
+   * so an un-instrumented backend's trace still reaches SpanBarn correlatable to
+   * this recording. The injected trace_id is the recording_id (deterministic, so
+   * it resolves with no lookup). Same-origin requests only, unless an origin is
+   * listed in tracePropagateOrigins. Default: false (opt-in — injecting a header
+   * cross-origin requires the server to allow it via CORS).
+   */
+  tracePropagate?: boolean;
+  /** Extra origins (besides same-origin) eligible for traceparent injection. */
+  tracePropagateOrigins?: string[];
+}
+
+/** A W3C trace observed in the browser during a recording. */
+export interface TraceLink {
+  trace_id: string;
+  span_id?: string;
+  url?: string;
+  occurred_at: string;
 }
 
 export interface EventProperties {
@@ -123,6 +149,14 @@ export class FunnelBarnClient {
   private recordingSnapshotFlushed = false;
   private recordingOptions: FunnelBarnOptions;
   private serverRecordingRules: RecordingRule[] = [];
+
+  // trace capture (fetch/XHR instrumentation, active only while recording)
+  private traceBuffer: TraceLink[] = [];
+  private traceCaptureInstalled = false;
+  private origFetch?: typeof fetch;
+  private origXhrOpen?: typeof XMLHttpRequest.prototype.open;
+  private origXhrSetHeader?: typeof XMLHttpRequest.prototype.setRequestHeader;
+  private origXhrSend?: typeof XMLHttpRequest.prototype.send;
 
   constructor(options: FunnelBarnOptions) {
     this.apiKey = options.apiKey;
@@ -550,6 +584,8 @@ export class FunnelBarnClient {
     const interval = chunkMs ?? 10_000;
     this.recordingTimer = setInterval(() => { this.flushRecordingChunk().catch(() => {}); }, interval);
     window.addEventListener('beforeunload', this.handleRecordingUnload);
+    // Begin observing outgoing requests' trace context so it links to this recording.
+    this.installTraceCapture();
   }
 
   private handleRecordingUnload = (): void => {
@@ -619,8 +655,10 @@ export class FunnelBarnClient {
     if (typeof window !== "undefined") {
       window.removeEventListener('beforeunload', this.handleRecordingUnload);
     }
+    this.uninstallTraceCapture();
     this.clearRecordingState();
     this.rrwebBuffer = [];
+    this.traceBuffer = [];
     this.recordingChunkIndex = 0;
     this.recordingSnapshotFlushed = false;
   }
@@ -688,6 +726,148 @@ export class FunnelBarnClient {
     return true; // default: capture
   }
 
+  // installTraceCapture wraps fetch + XHR to observe the W3C traceparent on
+  // outgoing requests while a recording is active. Harvesting is read-only;
+  // injection (tracePropagate) only mutates same-origin / allow-listed requests.
+  private installTraceCapture(): void {
+    if (this.traceCaptureInstalled) return;
+    if (typeof window === 'undefined') return;
+    if (this.recordingOptions.traceCapture === false) return;
+    this.traceCaptureInstalled = true;
+
+    // fetch
+    if (typeof window.fetch === 'function' && !(window.fetch as { __fb?: boolean }).__fb) {
+      const orig = window.fetch.bind(window);
+      this.origFetch = orig;
+      const wrapped = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        try {
+          const url = this.resolveURL(input);
+          let hdrs: Headers;
+          if (init?.headers) hdrs = new Headers(init.headers as HeadersInit);
+          else if (typeof Request !== 'undefined' && input instanceof Request) hdrs = new Headers(input.headers);
+          else hdrs = new Headers();
+
+          const existing = hdrs.get('traceparent');
+          if (existing) {
+            const p = parseTraceparent(existing);
+            if (p) this.recordTrace(p.traceId, p.spanId, url);
+          } else if (this.shouldPropagate(url)) {
+            const traceId = this.recordingId || randomHex(16);
+            const spanId = randomHex(8);
+            hdrs.set('traceparent', buildTraceparent(traceId, spanId));
+            this.recordTrace(traceId, spanId, url);
+            if (typeof Request !== 'undefined' && input instanceof Request) {
+              input = new Request(input, { headers: hdrs });
+            } else {
+              init = { ...(init || {}), headers: hdrs };
+            }
+          }
+        } catch {
+          // Never let trace capture break the app's own request.
+        }
+        return orig(input, init);
+      };
+      (wrapped as { __fb?: boolean }).__fb = true;
+      window.fetch = wrapped;
+    }
+
+    // XMLHttpRequest
+    if (typeof XMLHttpRequest !== 'undefined' && !(XMLHttpRequest.prototype.send as { __fb?: boolean }).__fb) {
+      const proto = XMLHttpRequest.prototype;
+      this.origXhrOpen = proto.open;
+      this.origXhrSetHeader = proto.setRequestHeader;
+      this.origXhrSend = proto.send;
+      const self = this;
+      proto.open = function (this: XMLHttpRequest, method: string, url: string | URL, ...rest: unknown[]) {
+        (this as { __fbUrl?: string; __fbTp?: string }).__fbUrl = self.resolveURL(url);
+        (this as { __fbTp?: string }).__fbTp = undefined;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (self.origXhrOpen as any).call(this, method, url, ...rest);
+      };
+      proto.setRequestHeader = function (this: XMLHttpRequest, name: string, value: string) {
+        if (String(name).toLowerCase() === 'traceparent') {
+          (this as { __fbTp?: string }).__fbTp = value;
+        }
+        return (self.origXhrSetHeader as typeof proto.setRequestHeader).call(this, name, value);
+      };
+      const sendWrapped = function (this: XMLHttpRequest, body?: Document | XMLHttpRequestBodyInit | null) {
+        try {
+          const url = (this as { __fbUrl?: string }).__fbUrl ?? '';
+          const tp = (this as { __fbTp?: string }).__fbTp;
+          if (tp) {
+            const p = parseTraceparent(tp);
+            if (p) self.recordTrace(p.traceId, p.spanId, url);
+          } else if (self.shouldPropagate(url)) {
+            const traceId = self.recordingId || randomHex(16);
+            const spanId = randomHex(8);
+            (self.origXhrSetHeader as typeof proto.setRequestHeader).call(this, 'traceparent', buildTraceparent(traceId, spanId));
+            self.recordTrace(traceId, spanId, url);
+          }
+        } catch {
+          // ignore — never break the app's request
+        }
+        return (self.origXhrSend as typeof proto.send).call(this, body ?? null);
+      };
+      (sendWrapped as { __fb?: boolean }).__fb = true;
+      proto.send = sendWrapped;
+    }
+  }
+
+  private uninstallTraceCapture(): void {
+    if (!this.traceCaptureInstalled) return;
+    this.traceCaptureInstalled = false;
+    if (this.origFetch && typeof window !== 'undefined') {
+      window.fetch = this.origFetch;
+      this.origFetch = undefined;
+    }
+    if (typeof XMLHttpRequest !== 'undefined' && this.origXhrSend) {
+      const proto = XMLHttpRequest.prototype;
+      if (this.origXhrOpen) proto.open = this.origXhrOpen;
+      if (this.origXhrSetHeader) proto.setRequestHeader = this.origXhrSetHeader;
+      proto.send = this.origXhrSend;
+      this.origXhrOpen = this.origXhrSetHeader = this.origXhrSend = undefined;
+    }
+  }
+
+  // recordTrace buffers a trace link, but only while a recording is active and
+  // capped so a chatty page can't grow the buffer without bound.
+  private recordTrace(traceId: string, spanId: string, url: string): void {
+    if (!this.rrwebStop) return;
+    if (this.traceBuffer.length >= 500) return;
+    this.traceBuffer.push({
+      trace_id: traceId,
+      span_id: spanId || undefined,
+      url: url || undefined,
+      occurred_at: new Date().toISOString(),
+    });
+  }
+
+  // shouldPropagate reports whether a traceparent may be injected on this URL.
+  private shouldPropagate(url: string): boolean {
+    if (!this.rrwebStop) return false;
+    if (!this.recordingOptions.tracePropagate) return false;
+    if (typeof window === 'undefined') return false;
+    try {
+      const u = new URL(url, window.location.href);
+      if (u.origin === window.location.origin) return true;
+      return (this.recordingOptions.tracePropagateOrigins ?? []).includes(u.origin);
+    } catch {
+      return false;
+    }
+  }
+
+  private resolveURL(input: unknown): string {
+    try {
+      if (typeof input === 'string') return input;
+      if (typeof URL !== 'undefined' && input instanceof URL) return input.href;
+      if (typeof Request !== 'undefined' && input instanceof Request) return input.url;
+      if (input && typeof (input as { url?: unknown }).url === 'string') return (input as { url: string }).url;
+    } catch {
+      // fall through
+    }
+    return '';
+  }
+
   private async flushRecordingChunk(useKeepalive = false): Promise<void> {
     if (!this.shouldRecordCurrentPage()) {
       this.rrwebBuffer = [];
@@ -695,6 +875,7 @@ export class FunnelBarnClient {
     }
     const events = this.rrwebBuffer.splice(0);
     if (!events.length) return;
+    const traces = this.traceBuffer.splice(0);
     const chunkIndex = this.recordingChunkIndex++;
     try {
       await fetch(`${this.endpoint}/api/v1/recordings/chunk`, {
@@ -711,6 +892,7 @@ export class FunnelBarnClient {
           started_at: this.recordingStartedAt,
           duration_ms: Date.now() - this.recordingStartMs,
           page_url: typeof window !== 'undefined' ? window.location.href : undefined,
+          traces: traces.length ? traces : undefined,
         }),
         // keepalive has a 64 KB body limit per the Fetch spec — rrweb full
         // snapshots are 1-5 MB so we only use it for the final unload flush
@@ -721,6 +903,7 @@ export class FunnelBarnClient {
       // On failure, push events back to the front so the next flush retries
       // them — most importantly this preserves the full snapshot (chunk 0).
       this.rrwebBuffer.unshift(...events);
+      if (traces.length) this.traceBuffer.unshift(...traces);
       this.recordingChunkIndex--;
     }
   }
@@ -759,6 +942,41 @@ export class FunnelBarnClient {
       return {};
     }
   }
+}
+
+// --------------------------------------------------------------------------
+// W3C trace context helpers
+// --------------------------------------------------------------------------
+
+/**
+ * parseTraceparent validates a W3C `traceparent` header and extracts the
+ * trace + span ids. Returns null for malformed or all-zero (invalid) ids.
+ * Format: `00-<32 hex trace-id>-<16 hex span-id>-<2 hex flags>`.
+ */
+export function parseTraceparent(value: string): { traceId: string; spanId: string } | null {
+  if (!value) return null;
+  const m = /^00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9a-f]{2}$/i.exec(value.trim());
+  if (!m) return null;
+  const traceId = m[1].toLowerCase();
+  const spanId = m[2].toLowerCase();
+  if (traceId === '0'.repeat(32) || spanId === '0'.repeat(16)) return null;
+  return { traceId, spanId };
+}
+
+/** buildTraceparent assembles a sampled (flags=01) W3C traceparent header. */
+export function buildTraceparent(traceId: string, spanId: string): string {
+  return `00-${traceId}-${spanId}-01`;
+}
+
+/** randomHex returns `bytes` cryptographically-random bytes as a lowercase hex string. */
+function randomHex(bytes: number): string {
+  const arr = new Uint8Array(bytes);
+  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+    crypto.getRandomValues(arr);
+  } else {
+    for (let i = 0; i < arr.length; i++) arr[i] = Math.floor(Math.random() * 256);
+  }
+  return Array.from(arr).map((b) => b.toString(16).padStart(2, '0')).join('');
 }
 
 // --------------------------------------------------------------------------

--- a/sdks/js/test/sdk.test.mjs
+++ b/sdks/js/test/sdk.test.mjs
@@ -1,6 +1,16 @@
 import { describe, it, before, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { FunnelBarnClient } from '../dist/esm/index.js';
+import { FunnelBarnClient, parseTraceparent, buildTraceparent } from '../dist/esm/index.js';
+
+// defineWritable temporarily overrides a global (e.g. window) and returns a restore fn.
+function defineWritable(obj, key, value) {
+  const orig = Object.getOwnPropertyDescriptor(obj, key);
+  Object.defineProperty(obj, key, { value, writable: true, configurable: true });
+  return () => {
+    if (orig) Object.defineProperty(obj, key, orig);
+    else delete obj[key];
+  };
+}
 
 // Stub localStorage for Node (not available outside a browser).
 const _store = {};
@@ -256,6 +266,149 @@ describe('FunnelBarnClient', () => {
       restoreScreen();
       restoreNavigator();
       restoreIntl();
+    }
+  });
+});
+
+describe('trace context helpers', () => {
+  it('parseTraceparent accepts a valid header', () => {
+    const got = parseTraceparent(`00-${'1'.repeat(32)}-${'2'.repeat(16)}-01`);
+    assert.deepEqual(got, { traceId: '1'.repeat(32), spanId: '2'.repeat(16) });
+  });
+
+  it('parseTraceparent rejects malformed and all-zero ids', () => {
+    assert.equal(parseTraceparent(''), null);
+    assert.equal(parseTraceparent('garbage'), null);
+    assert.equal(parseTraceparent(`01-${'1'.repeat(32)}-${'2'.repeat(16)}-01`), null); // wrong version
+    assert.equal(parseTraceparent(`00-${'0'.repeat(32)}-${'2'.repeat(16)}-01`), null); // zero trace
+    assert.equal(parseTraceparent(`00-${'1'.repeat(32)}-${'0'.repeat(16)}-01`), null); // zero span
+  });
+
+  it('buildTraceparent assembles a sampled header', () => {
+    assert.equal(buildTraceparent('a'.repeat(32), 'b'.repeat(16)), `00-${'a'.repeat(32)}-${'b'.repeat(16)}-01`);
+  });
+});
+
+describe('recording trace capture', () => {
+  it('recording chunk body includes buffered traces', async () => {
+    const client = new FunnelBarnClient({ apiKey: 'k', endpoint: 'http://localhost:8080' });
+    client.recordingId = 'rec1';
+    client.recordingStartedAt = new Date().toISOString();
+    client.recordingStartMs = Date.now();
+    client.rrwebBuffer.push({ type: 3, data: {} });
+    client.traceBuffer.push({ trace_id: 'a'.repeat(32), span_id: 'b'.repeat(16), occurred_at: new Date().toISOString() });
+
+    await client.flushRecordingChunk();
+
+    const chunkReq = requests.find((r) => String(r.url).includes('/recordings/chunk'));
+    assert.ok(chunkReq, 'a recording chunk request was sent');
+    const body = JSON.parse(chunkReq.options.body);
+    assert.equal(body.traces.length, 1);
+    assert.equal(body.traces[0].trace_id, 'a'.repeat(32));
+  });
+
+  it('chunk body omits traces when none buffered', async () => {
+    const client = new FunnelBarnClient({ apiKey: 'k', endpoint: 'http://localhost:8080' });
+    client.recordingId = 'rec2';
+    client.recordingStartedAt = new Date().toISOString();
+    client.recordingStartMs = Date.now();
+    client.rrwebBuffer.push({ type: 3, data: {} });
+
+    await client.flushRecordingChunk();
+
+    const chunkReq = requests.find((r) => String(r.url).includes('/recordings/chunk'));
+    const body = JSON.parse(chunkReq.options.body);
+    assert.equal(body.traces, undefined);
+  });
+
+  it('harvests an existing traceparent from an outgoing fetch', async () => {
+    const restoreWindow = defineWritable(global, 'window', {
+      location: { href: 'https://app.example/p', origin: 'https://app.example' },
+      addEventListener() {},
+      removeEventListener() {},
+      fetch: async () => ({ ok: true, status: 200 }),
+    });
+    try {
+      const client = new FunnelBarnClient({ apiKey: 'k', endpoint: 'https://app.example' });
+      client.rrwebStop = () => {}; // mark recording active
+      client.recordingId = 'r'.repeat(32);
+      client.installTraceCapture();
+
+      const tp = `00-${'1'.repeat(32)}-${'2'.repeat(16)}-01`;
+      await global.window.fetch('https://app.example/api/data', { headers: { traceparent: tp } });
+
+      assert.equal(client.traceBuffer.length, 1);
+      assert.equal(client.traceBuffer[0].trace_id, '1'.repeat(32));
+      assert.equal(client.traceBuffer[0].span_id, '2'.repeat(16));
+      assert.equal(client.traceBuffer[0].url, 'https://app.example/api/data');
+    } finally {
+      restoreWindow();
+    }
+  });
+
+  it('injects a deterministic traceparent (trace_id = recording_id) when tracePropagate is on', async () => {
+    const appCalls = [];
+    const restoreWindow = defineWritable(global, 'window', {
+      location: { href: 'https://app.example/p', origin: 'https://app.example' },
+      addEventListener() {},
+      removeEventListener() {},
+      fetch: async (input, init) => { appCalls.push({ input, init }); return { ok: true, status: 200 }; },
+    });
+    try {
+      const client = new FunnelBarnClient({ apiKey: 'k', endpoint: 'https://app.example', tracePropagate: true });
+      client.rrwebStop = () => {};
+      client.recordingId = 'c'.repeat(32);
+      client.installTraceCapture();
+
+      await global.window.fetch('https://app.example/api/pay'); // same-origin, no traceparent
+
+      assert.equal(client.traceBuffer.length, 1);
+      assert.equal(client.traceBuffer[0].trace_id, 'c'.repeat(32), 'injected trace_id is the recording_id');
+      const injected = appCalls[0].init.headers.get('traceparent');
+      assert.ok(injected.includes('c'.repeat(32)), 'traceparent header injected into the outgoing request');
+    } finally {
+      restoreWindow();
+    }
+  });
+
+  it('does not inject cross-origin unless allow-listed', async () => {
+    const appCalls = [];
+    const restoreWindow = defineWritable(global, 'window', {
+      location: { href: 'https://app.example/p', origin: 'https://app.example' },
+      addEventListener() {},
+      removeEventListener() {},
+      fetch: async (input, init) => { appCalls.push({ input, init }); return { ok: true, status: 200 }; },
+    });
+    try {
+      const client = new FunnelBarnClient({ apiKey: 'k', endpoint: 'https://app.example', tracePropagate: true });
+      client.rrwebStop = () => {};
+      client.recordingId = 'd'.repeat(32);
+      client.installTraceCapture();
+
+      await global.window.fetch('https://other.example/api'); // cross-origin, not allow-listed
+
+      assert.equal(client.traceBuffer.length, 0, 'no trace recorded for a non-propagated cross-origin request');
+    } finally {
+      restoreWindow();
+    }
+  });
+
+  it('does not harvest when recording is inactive', async () => {
+    const restoreWindow = defineWritable(global, 'window', {
+      location: { href: 'https://app.example/p', origin: 'https://app.example' },
+      addEventListener() {},
+      removeEventListener() {},
+      fetch: async () => ({ ok: true, status: 200 }),
+    });
+    try {
+      const client = new FunnelBarnClient({ apiKey: 'k', endpoint: 'https://app.example' });
+      // rrwebStop intentionally not set -> recording inactive
+      client.installTraceCapture();
+      const tp = `00-${'1'.repeat(32)}-${'2'.repeat(16)}-01`;
+      await global.window.fetch('https://app.example/api/data', { headers: { traceparent: tp } });
+      assert.equal(client.traceBuffer.length, 0);
+    } finally {
+      restoreWindow();
     }
   });
 });


### PR DESCRIPTION
## Context

PR 2 of the trace-correlation effort (backend link primitive is #182). With the backend able to store and resolve `trace_id → session/recording`, the browser SDK now needs to actually capture the trace context. This closes the loop: a developer looking at an error trace in **SpanBarn**/**BugBarn** can resolve it to the **FunnelBarn** recording and replay it.

## What's included

While a recording is active, the SDK observes the W3C trace context on outgoing requests and ships it in the `recordings/chunk` body (the backend's optional `traces` field).

### Harvest mode (default, `traceCapture: true`)
Read-only wrapping of `fetch` + `XMLHttpRequest` reads the `traceparent` header the app's own OTel/RUM instrumentation already sets. It **never mutates** requests — it only records `(trace_id, span_id, url, occurred_at)`.

### Propagate mode (opt-in, `tracePropagate: true`)
When a request carries no traceparent, the SDK generates and injects one so an **un-instrumented** backend's trace still reaches SpanBarn. The injected `trace_id` **is the recording_id** — a 32-hex value that is already a valid W3C trace-id — so it's **deterministic and correlates with no lookup** (this is the "deterministic if possible" path; the stored-mapping backbone in #182 is the fallback for harvested, app-generated ids). Same-origin only unless an origin is listed in `tracePropagateOrigins`, because cross-origin header injection requires server CORS opt-in.

This mixed default (harvest when instrumented, deterministic-inject when not) matches real fleets where some apps emit traceparent and some don't.

### Safety
- Active only while recording; buffer-capped (500 links); fully torn down with originals restored when recording stops.
- Every capture path is wrapped in try/catch — trace capture can never break the host app's own requests.
- Idempotent against the backend (re-sent links collapse on the PK).

## API additions
- Options: `traceCapture`, `tracePropagate`, `tracePropagateOrigins`.
- Exports: `TraceLink`, `parseTraceparent`, `buildTraceparent`.

## Tests
9 new tests: traceparent parse/validate (incl. all-zero rejection), build, chunk body includes/omits traces, fetch harvest, deterministic same-origin injection, cross-origin not injected unless allow-listed, no capture when recording inactive. Full SDK suite (27 tests) green; `npm run build` (esm/cjs/iife, strict tsc) clean.

## Depends on
#182 (backend `traces` field + lookup) for the captured data to be persisted and resolvable. The SDK degrades gracefully if the field is ignored.