### PR TITLE
feat(replay): add funnelbarn-replay CLI (trace_id -> session replay)

### DIFF
--- a/tools/replay/README.md
+++ b/tools/replay/README.md
@@ -1,0 +1,89 @@
+# funnelbarn-replay
+
+Resolve a W3C `trace_id` — the one you see on an error span in **SpanBarn** or an
+issue in **BugBarn** — to the **FunnelBarn** session recording that captured it,
+and replay that recording locally in a Playwright-driven browser, **seeking
+straight to the moment the trace fired**.
+
+This is the consumer end of the trace-correlation link:
+
+```
+SpanBarn / BugBarn (trace_id)
+        │
+        ▼
+FunnelBarn  GET /api/v1/traces/{trace_id}     ← resolve to session + recording + seek offset
+        │   GET /api/v1/recordings/{rid}/chunks/{i}   ← fetch rrweb chunks
+        ▼
+rrweb-player in Playwright Chromium, auto-seeked to offset_ms
+```
+
+## Install
+
+```bash
+cd tools/replay
+npm install
+npx playwright install chromium   # one-time browser download (needed for live replay)
+npm run build
+```
+
+`npm install` alone (with `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`) is enough for
+`--dry-run`, which never launches a browser.
+
+## Usage
+
+```bash
+export FUNNELBARN_ENDPOINT=https://funnelbarn.wiebe.xyz
+export FUNNELBARN_API_KEY=fb_xxx          # a key scoped to the recording's project
+
+# Watch the session, auto-seeked to the trace moment:
+node dist/cli.js --trace 4bf92f3577b34da6a3ce929d0e0e4736
+
+# Headless, just grab the frame at the trace moment:
+node dist/cli.js --trace <id> --headless --screenshot ./moment.png
+
+# Resolve + assemble only (no browser), for scripting/agents:
+node dist/cli.js --trace <id> --dry-run
+
+# Save a standalone, offline replay page you can open anywhere:
+node dist/cli.js --trace <id> --out ./replay.html
+```
+
+| Flag | Meaning |
+|------|---------|
+| `--trace <id>` | trace_id from SpanBarn/BugBarn (required) |
+| `--endpoint <url>` | FunnelBarn base URL (env `FUNNELBARN_ENDPOINT`) |
+| `--api-key <key>` | FunnelBarn API key (env `FUNNELBARN_API_KEY`) |
+| `--headed` / `--headless` | visible window (default) vs. offscreen |
+| `--screenshot <path>` | PNG at the seek point |
+| `--out <path>` | write the self-contained replay HTML |
+| `--keep-open <ms>` | headed window lifetime, `0` = until closed |
+| `--dry-run` | resolve + fetch + assemble, print JSON, no browser |
+
+## How the link is formed
+
+The FunnelBarn browser SDK observes the `traceparent` on outgoing requests while
+recording and ships `(trace_id, span_id, url, occurred_at)` with each rrweb
+chunk. FunnelBarn stores those in `recording_traces`, so a trace_id resolves back
+to the recording and the **seek offset** (`occurred_at − recording.started_at`).
+
+When the app isn't instrumented, the SDK can inject a **deterministic**
+traceparent whose `trace_id` *is* the `recording_id` (opt-in `tracePropagate`),
+so the SpanBarn trace correlates with no lookup at all.
+
+## Reproducing application state (roadmap)
+
+Replaying the recording reconstructs exactly what the **user saw** (the DOM), which
+is usually enough to understand a bug. Getting the **backend** into the same state
+— spinning the whole stack locally against a restored database snapshot so you can
+re-drive the exact requests — is a larger, infra-specific step. The intended
+workflow, to be automated next:
+
+1. `funnelbarn-replay --trace <id> --dry-run` → identify the session, time window,
+   and (via the harvested trace links) the exact backend traces involved.
+2. Restore the relevant DB snapshot into a local stack (deploy scripts under
+   `deploy/`).
+3. Point the app at the local stack (`--base-url`, reserved) and step through the
+   replay alongside the restored data.
+
+Today the tool delivers steps that need no infra: resolve → fetch → replay →
+seek. The `--base-url` hook is reserved for the stack-bound step.

--- a/tools/replay/package-lock.json
+++ b/tools/replay/package-lock.json
@@ -1,0 +1,251 @@
+{
+  "name": "@funnelbarn/replay",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@funnelbarn/replay",
+      "version": "0.1.0",
+      "dependencies": {
+        "playwright": "^1.49.0",
+        "rrweb-player": "^1.0.0-alpha.4"
+      },
+      "bin": {
+        "funnelbarn-replay": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rrweb/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-x8cNaKFxdvS0/5IfKOj1xG8Htnw1fUwqoPqgP61bOaWqZL6t9UtRPpO9ZlMB2z+FiTxg9zlFFL+Da4ZpFuhoiA==",
+      "license": "MIT"
+    },
+    "node_modules/@rrweb/utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rrweb/utils/-/utils-2.0.1.tgz",
+      "integrity": "sha512-t+b+4rB23/e4EpoGMdPUr6cKtDsFuOb3LxA9IHE8e3A/Xo0nMUfH0bkwqdpUNa/VGDOdiGeG3bhHjuO9zWX54g==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/svelte": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-1.0.13.tgz",
+      "integrity": "sha512-5lYJP45Xllo4yE/RUBccBT32eBlRDbqN8r1/MIvQbKxW3aFqaYPCNgm8D5V20X4ShHcwvYWNlKg3liDh1MlBoA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/css-font-loading-module": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@xstate/fsm": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
+      "integrity": "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==",
+      "license": "MIT"
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rrdom": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rrdom/-/rrdom-2.0.1.tgz",
+      "integrity": "sha512-z8GdQWFmVfa8GpcGkAqfBXseb89z0ciTPSBkID0qr0i6KHCye1MdQ4VoXFf0Ejp3ELe/c7AObu4zsbSbMT+hiw==",
+      "license": "MIT",
+      "dependencies": {
+        "rrweb-snapshot": "^2.0.1"
+      }
+    },
+    "node_modules/rrweb": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.0.1.tgz",
+      "integrity": "sha512-MQYzOtI7aZft9ffDMT6rmRSAj6hO4W6T7iA4eB9Mtcuiv3M7DbnnxDMrcPW0sQXepgYN46YhfSKe75d/mlUHrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rrweb/types": "^2.0.1",
+        "@rrweb/utils": "^2.0.1",
+        "@types/css-font-loading-module": "0.0.7",
+        "@xstate/fsm": "^1.4.0",
+        "base64-arraybuffer": "^1.0.1",
+        "mitt": "^3.0.0",
+        "rrdom": "^2.0.1",
+        "rrweb-snapshot": "^2.0.1"
+      }
+    },
+    "node_modules/rrweb-player": {
+      "version": "1.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/rrweb-player/-/rrweb-player-1.0.0-alpha.4.tgz",
+      "integrity": "sha512-Wlmn9GZ5Fdqa37vd3TzsYdLl/JWEvXNUrLCrYpnOwEgmY409HwVIvvA5aIo7k582LoKgdRCsB87N+f0oWAR0Kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsconfig/svelte": "^1.0.0",
+        "rrweb": "^2.0.0-alpha.4"
+      }
+    },
+    "node_modules/rrweb-snapshot": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.0.1.tgz",
+      "integrity": "sha512-H8TA29ct2tpYtr5oaB0N+ksRY9bhEErfAYcKbce4+w8lqEUQChpKZd41HpBJLkp04b5QUfWUg4v6r9Okf8r7vA==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^8.4.38"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/tools/replay/package.json
+++ b/tools/replay/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@funnelbarn/replay",
+  "version": "0.1.0",
+  "description": "Resolve a trace_id (from SpanBarn/BugBarn) to a FunnelBarn session recording and replay it locally in a Playwright-driven browser, seeking to the moment the trace fired.",
+  "type": "module",
+  "bin": {
+    "funnelbarn-replay": "dist/cli.js"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
+    "test": "npm run build && node --test test/*.test.mjs",
+    "replay": "node dist/cli.js"
+  },
+  "dependencies": {
+    "playwright": "^1.49.0",
+    "rrweb-player": "^1.0.0-alpha.4"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/tools/replay/src/assemble.ts
+++ b/tools/replay/src/assemble.ts
@@ -1,0 +1,111 @@
+/**
+ * Assemble rrweb chunks into a single ordered, validated event stream and build
+ * a self-contained replay HTML page.
+ */
+
+export interface RRWebEvent {
+  type: number;
+  timestamp: number;
+  data?: unknown;
+}
+
+export interface AssembleResult {
+  events: RRWebEvent[];
+  hasSnapshot: boolean;
+  startTimestamp: number;
+  endTimestamp: number;
+  durationMs: number;
+}
+
+/**
+ * Order events by timestamp and report whether the stream is replayable (rrweb
+ * needs a full-snapshot event, type 2). Chunks can arrive out of order, so we
+ * always sort; a stable sort keeps same-timestamp events in arrival order.
+ */
+export function assembleEvents(raw: unknown[]): AssembleResult {
+  const events = (raw as RRWebEvent[])
+    .filter((e) => e && typeof e.type === "number" && typeof e.timestamp === "number")
+    .slice()
+    .sort((a, b) => a.timestamp - b.timestamp);
+
+  const hasSnapshot = events.some((e) => e.type === 2);
+  const startTimestamp = events.length ? events[0].timestamp : 0;
+  const endTimestamp = events.length ? events[events.length - 1].timestamp : 0;
+
+  return {
+    events,
+    hasSnapshot,
+    startTimestamp,
+    endTimestamp,
+    durationMs: endTimestamp - startTimestamp,
+  };
+}
+
+export interface BuildHTMLOptions {
+  events: RRWebEvent[];
+  /** Milliseconds from recording start to auto-seek to (the trace moment). */
+  seekMs: number;
+  /** rrweb-player UMD JS source to inline (keeps the page offline). */
+  playerJs: string;
+  /** rrweb-player CSS to inline. */
+  playerCss: string;
+  /** Optional banner text (trace id, url) shown above the player. */
+  banner?: string;
+}
+
+/**
+ * Build a fully self-contained HTML page that renders the recording with
+ * rrweb-player and auto-seeks to the trace moment. Everything is inlined so the
+ * page works offline inside a headless browser.
+ */
+export function buildReplayHTML(opts: BuildHTMLOptions): string {
+  const eventsJson = JSON.stringify(opts.events);
+  const seek = Math.max(0, Math.floor(opts.seekMs));
+  const banner = opts.banner ? escapeHtml(opts.banner) : "";
+  return `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>FunnelBarn replay</title>
+<style>${opts.playerCss}</style>
+<style>
+  body { margin: 0; background: #1a1a1a; color: #eee; font-family: ui-monospace, monospace; }
+  #banner { padding: 8px 12px; background: #111; font-size: 13px; border-bottom: 1px solid #333; }
+  #marker { color: #ffb454; }
+  #player { display: flex; justify-content: center; padding: 16px; }
+</style>
+</head>
+<body>
+<div id="banner">${banner} <span id="marker">▶ seeking to +${seek}ms</span></div>
+<div id="player"></div>
+<script>${opts.playerJs}</script>
+<script>
+  (function () {
+    var events = ${eventsJson};
+    var seekMs = ${seek};
+    if (!events.length) {
+      document.getElementById('marker').textContent = 'no events to replay';
+      return;
+    }
+    // rrweb-player UMD exposes the constructor as window.rrwebPlayer.
+    var PlayerCtor = window.rrwebPlayer || (window.rrweb && window.rrweb.Player);
+    var player = new PlayerCtor({
+      target: document.getElementById('player'),
+      props: { events: events, autoPlay: true, showController: true, width: 1024, height: 640 },
+    });
+    // Jump straight to the trace moment so the developer lands where it happened.
+    try { player.goto(seekMs); } catch (e) { /* older player API */ }
+    window.__fbReplayReady = true;
+  })();
+</script>
+</body>
+</html>`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/tools/replay/src/cli.ts
+++ b/tools/replay/src/cli.ts
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * funnelbarn-replay — resolve a trace_id to a session recording and replay it.
+ *
+ *   funnelbarn-replay --trace <trace_id> [--endpoint URL] [--api-key KEY] [options]
+ *
+ * Endpoint/key default to FUNNELBARN_ENDPOINT / FUNNELBARN_API_KEY.
+ */
+
+import { parseArgs } from "node:util";
+import { writeFileSync } from "node:fs";
+import { ReplayClient } from "./client.js";
+import { assembleEvents, buildReplayHTML } from "./assemble.js";
+
+const USAGE = `funnelbarn-replay — replay the session recording behind a trace
+
+Usage:
+  funnelbarn-replay --trace <trace_id> [options]
+
+Options:
+  --trace <id>         W3C trace_id (from SpanBarn/BugBarn). Required.
+  --endpoint <url>     FunnelBarn base URL (env: FUNNELBARN_ENDPOINT).
+  --api-key <key>      FunnelBarn API key (env: FUNNELBARN_API_KEY).
+  --headed             Open a visible browser window to watch/scrub (default).
+  --headless           Render without a window (use with --screenshot).
+  --screenshot <path>  Save a PNG at the trace moment.
+  --out <path>         Write the self-contained replay HTML to a file.
+  --keep-open <ms>     Headed window lifetime; 0 = until closed (default 0).
+  --dry-run            Resolve + fetch + assemble only; no browser.
+  -h, --help           Show this help.
+`;
+
+interface ParsedArgs {
+  trace: string;
+  endpoint: string;
+  apiKey: string;
+  headed: boolean;
+  screenshot?: string;
+  out?: string;
+  keepOpen: number;
+  dryRun: boolean;
+}
+
+export function parseCliArgs(argv: string[], env: Record<string, string | undefined>): ParsedArgs {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      trace: { type: "string" },
+      endpoint: { type: "string" },
+      "api-key": { type: "string" },
+      headed: { type: "boolean" },
+      headless: { type: "boolean" },
+      screenshot: { type: "string" },
+      out: { type: "string" },
+      "keep-open": { type: "string" },
+      "dry-run": { type: "boolean" },
+      help: { type: "boolean", short: "h" },
+    },
+    allowPositionals: false,
+  });
+
+  if (values.help) {
+    process.stdout.write(USAGE);
+    process.exit(0);
+  }
+
+  const trace = values.trace ?? "";
+  const endpoint = values.endpoint ?? env.FUNNELBARN_ENDPOINT ?? "";
+  const apiKey = values["api-key"] ?? env.FUNNELBARN_API_KEY ?? "";
+
+  const missing: string[] = [];
+  if (!trace) missing.push("--trace");
+  if (!endpoint) missing.push("--endpoint (or FUNNELBARN_ENDPOINT)");
+  if (!apiKey) missing.push("--api-key (or FUNNELBARN_API_KEY)");
+  if (missing.length) {
+    throw new Error(`missing required: ${missing.join(", ")}\n\n${USAGE}`);
+  }
+
+  return {
+    trace,
+    endpoint,
+    apiKey,
+    headed: values.headless ? false : true,
+    screenshot: values.screenshot,
+    out: values.out,
+    keepOpen: values["keep-open"] ? Number(values["keep-open"]) : 0,
+    dryRun: Boolean(values["dry-run"]),
+  };
+}
+
+export async function run(args: ParsedArgs): Promise<void> {
+  const client = new ReplayClient({ endpoint: args.endpoint, apiKey: args.apiKey });
+
+  console.error(`resolving trace ${args.trace} …`);
+  const lookup = await client.lookupTrace(args.trace);
+  console.error(
+    `→ recording ${lookup.recording_id} (session ${lookup.session_id}), ` +
+      `seek +${lookup.offset_ms}ms of ${lookup.duration_ms}ms, ` +
+      `chunks ${lookup.first_chunk_index}..${lookup.last_chunk_index}` +
+      (lookup.page_url ? `, page ${lookup.page_url}` : "")
+  );
+
+  const raw = await client.fetchAllEvents(lookup, (w) => console.error(`  ${w}`));
+  const assembled = assembleEvents(raw);
+  console.error(
+    `assembled ${assembled.events.length} events, ` +
+      `${assembled.durationMs}ms, snapshot=${assembled.hasSnapshot}`
+  );
+  if (!assembled.hasSnapshot) {
+    console.error("warning: no full snapshot in this recording — playback may be blank.");
+  }
+
+  let html = "";
+  const needHtml = args.out || !args.dryRun;
+  if (needHtml) {
+    const { loadPlayerAssets } = await import("./replay.js");
+    const assets = loadPlayerAssets();
+    html = buildReplayHTML({
+      events: assembled.events,
+      seekMs: lookup.offset_ms,
+      playerJs: assets.js,
+      playerCss: assets.css,
+      banner: `trace ${args.trace} · session ${lookup.session_id}` + (lookup.url ? ` · ${lookup.url}` : ""),
+    });
+  }
+
+  if (args.out) {
+    writeFileSync(args.out, html, "utf8");
+    console.error(`replay HTML written to ${args.out}`);
+  }
+
+  if (args.dryRun) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          recording_id: lookup.recording_id,
+          session_id: lookup.session_id,
+          offset_ms: lookup.offset_ms,
+          duration_ms: lookup.duration_ms,
+          chunk_count: lookup.chunk_count,
+          event_count: assembled.events.length,
+          has_snapshot: assembled.hasSnapshot,
+        },
+        null,
+        2
+      ) + "\n"
+    );
+    return;
+  }
+
+  const { renderReplay } = await import("./replay.js");
+  await renderReplay({
+    html,
+    headed: args.headed,
+    screenshotPath: args.screenshot,
+    keepOpenMs: args.keepOpen,
+  });
+}
+
+// Entry point when run as a binary (not when imported by tests).
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  try {
+    const args = parseCliArgs(process.argv.slice(2), process.env);
+    await run(args);
+  } catch (err) {
+    console.error(`error: ${(err as Error).message}`);
+    process.exit(1);
+  }
+}

--- a/tools/replay/src/client.ts
+++ b/tools/replay/src/client.ts
@@ -1,0 +1,109 @@
+/**
+ * FunnelBarn replay API client.
+ *
+ * Talks to the FunnelBarn HTTP API with an API key to (1) resolve a W3C
+ * trace_id to the session recording that captured it and (2) fetch that
+ * recording's rrweb chunks for local replay.
+ */
+
+export interface TraceLookup {
+  trace_id: string;
+  project_id: string;
+  session_id: string;
+  recording_id: string;
+  occurred_at: string;
+  offset_ms: number;
+  url?: string;
+  recording_started_at: string;
+  first_chunk_index: number;
+  last_chunk_index: number;
+  chunk_count: number;
+  duration_ms: number;
+  environment?: string;
+  page_url?: string;
+}
+
+/** A minimal fetch signature so the client is testable without a browser/global. */
+export type FetchLike = (
+  url: string,
+  init?: { method?: string; headers?: Record<string, string> }
+) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown>; text: () => Promise<string> }>;
+
+export interface ClientOptions {
+  endpoint: string;
+  apiKey: string;
+  fetchImpl?: FetchLike;
+}
+
+export class ReplayClient {
+  private readonly endpoint: string;
+  private readonly apiKey: string;
+  private readonly fetchImpl: FetchLike;
+
+  constructor(opts: ClientOptions) {
+    this.endpoint = opts.endpoint.replace(/\/$/, "");
+    this.apiKey = opts.apiKey;
+    const f = opts.fetchImpl ?? (globalThis.fetch as unknown as FetchLike | undefined);
+    if (!f) {
+      throw new Error("no fetch implementation available (Node 18+ or pass fetchImpl)");
+    }
+    this.fetchImpl = f;
+  }
+
+  private headers(): Record<string, string> {
+    return { "x-funnelbarn-api-key": this.apiKey };
+  }
+
+  /** Resolve a trace_id to its recording. Throws with a clear message on 404/!ok. */
+  async lookupTrace(traceId: string): Promise<TraceLookup> {
+    const url = `${this.endpoint}/api/v1/traces/${encodeURIComponent(traceId)}`;
+    const resp = await this.fetchImpl(url, { headers: this.headers() });
+    if (resp.status === 404) {
+      throw new Error(`trace ${traceId} not found (no recording captured it, or wrong project key)`);
+    }
+    if (!resp.ok) {
+      throw new Error(`trace lookup failed: HTTP ${resp.status} ${await safeText(resp)}`);
+    }
+    return (await resp.json()) as TraceLookup;
+  }
+
+  /** Fetch a single recording chunk's rrweb event array. */
+  async fetchChunk(recordingId: string, index: number): Promise<unknown[]> {
+    const url = `${this.endpoint}/api/v1/recordings/${encodeURIComponent(recordingId)}/chunks/${index}`;
+    const resp = await this.fetchImpl(url, { headers: this.headers() });
+    if (!resp.ok) {
+      throw new Error(`chunk ${index} fetch failed: HTTP ${resp.status} ${await safeText(resp)}`);
+    }
+    const data = (await resp.json()) as unknown;
+    if (!Array.isArray(data)) {
+      throw new Error(`chunk ${index} is not an event array`);
+    }
+    return data;
+  }
+
+  /**
+   * Fetch every chunk in [first, last] and concatenate into one ordered rrweb
+   * event stream. Missing chunks are skipped with a warning rather than aborting
+   * — a single lost chunk still leaves a partially replayable recording.
+   */
+  async fetchAllEvents(lookup: TraceLookup, onWarn?: (msg: string) => void): Promise<unknown[]> {
+    const events: unknown[] = [];
+    for (let i = lookup.first_chunk_index; i <= lookup.last_chunk_index; i++) {
+      try {
+        const chunk = await this.fetchChunk(lookup.recording_id, i);
+        events.push(...chunk);
+      } catch (err) {
+        onWarn?.(`skipping chunk ${i}: ${(err as Error).message}`);
+      }
+    }
+    return events;
+  }
+}
+
+async function safeText(resp: { text: () => Promise<string> }): Promise<string> {
+  try {
+    return (await resp.text()).slice(0, 200);
+  } catch {
+    return "";
+  }
+}

--- a/tools/replay/src/index.ts
+++ b/tools/replay/src/index.ts
@@ -1,0 +1,5 @@
+export { ReplayClient } from "./client.js";
+export type { TraceLookup, ClientOptions, FetchLike } from "./client.js";
+export { assembleEvents, buildReplayHTML } from "./assemble.js";
+export type { RRWebEvent, AssembleResult, BuildHTMLOptions } from "./assemble.js";
+export { parseCliArgs, run } from "./cli.js";

--- a/tools/replay/src/replay.ts
+++ b/tools/replay/src/replay.ts
@@ -1,0 +1,108 @@
+/**
+ * Playwright-driven rendering of an assembled replay page.
+ *
+ * Playwright and the rrweb-player assets are loaded lazily so the data layer
+ * (client + assemble) stays usable — and testable — without a browser install.
+ */
+
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+
+export interface PlayerAssets {
+  js: string;
+  css: string;
+}
+
+/**
+ * Load the rrweb-player UMD JS + CSS from the installed package so the replay
+ * page is fully offline. Throws a clear, actionable error if the dependency is
+ * missing.
+ */
+export function loadPlayerAssets(): PlayerAssets {
+  const require = createRequire(import.meta.url);
+  let pkgJsonPath: string;
+  try {
+    pkgJsonPath = require.resolve("rrweb-player/package.json");
+  } catch {
+    throw new Error(
+      "rrweb-player is not installed. Run `npm install` in tools/replay before replaying."
+    );
+  }
+  const root = dirname(pkgJsonPath);
+  // rrweb-player ships a UMD bundle + stylesheet under dist/.
+  const jsCandidates = ["dist/index.js", "dist/rrweb-player.umd.cjs", "dist/index.umd.js"];
+  const cssCandidates = ["dist/style.css", "dist/index.css"];
+  const js = readFirst(root, jsCandidates, "rrweb-player JS bundle");
+  const css = readFirst(root, cssCandidates, "rrweb-player CSS", true);
+  return { js, css };
+}
+
+function readFirst(root: string, candidates: string[], label: string, optional = false): string {
+  for (const c of candidates) {
+    try {
+      return readFileSync(join(root, c), "utf8");
+    } catch {
+      // try next
+    }
+  }
+  if (optional) return "";
+  throw new Error(`could not locate ${label} in rrweb-player (looked for: ${candidates.join(", ")})`);
+}
+
+export interface RenderOptions {
+  html: string;
+  /** Run a visible browser window so a developer can watch/scrub. */
+  headed?: boolean;
+  /** If set, capture a PNG at the seek point to this path. */
+  screenshotPath?: string;
+  /** How long to keep a headed window open before exiting (ms). 0 = until closed. */
+  keepOpenMs?: number;
+}
+
+/**
+ * Render the replay HTML in a Playwright Chromium. Returns once the screenshot
+ * (if requested) is taken and the keep-open window has elapsed.
+ */
+export async function renderReplay(opts: RenderOptions): Promise<void> {
+  let chromium;
+  try {
+    ({ chromium } = await import("playwright"));
+  } catch {
+    throw new Error(
+      "playwright is not installed. Run `npm install && npx playwright install chromium` in tools/replay."
+    );
+  }
+
+  const browser = await chromium.launch({ headless: !opts.headed });
+  try {
+    const page = await browser.newPage({ viewport: { width: 1100, height: 720 } });
+    page.on("console", (msg) => {
+      if (msg.type() === "error") console.error(`[replay page] ${msg.text()}`);
+    });
+    await page.setContent(opts.html, { waitUntil: "load" });
+    // Wait for the player to mount and seek.
+    await page.waitForFunction("window.__fbReplayReady === true", { timeout: 15000 }).catch(() => {
+      console.error("warning: replay player did not signal ready within 15s");
+    });
+    // Give the player a beat to paint the seeked frame before snapshotting.
+    await page.waitForTimeout(1000);
+
+    if (opts.screenshotPath) {
+      await page.screenshot({ path: opts.screenshotPath, fullPage: false });
+      console.error(`screenshot written to ${opts.screenshotPath}`);
+    }
+
+    if (opts.headed) {
+      const keep = opts.keepOpenMs ?? 0;
+      if (keep > 0) {
+        await page.waitForTimeout(keep);
+      } else {
+        // Stay open until the user closes the window.
+        await page.waitForEvent("close", { timeout: 0 }).catch(() => {});
+      }
+    }
+  } finally {
+    await browser.close();
+  }
+}

--- a/tools/replay/test/replay.test.mjs
+++ b/tools/replay/test/replay.test.mjs
@@ -1,0 +1,155 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  ReplayClient,
+  assembleEvents,
+  buildReplayHTML,
+  parseCliArgs,
+} from '../dist/index.js';
+
+function jsonResp(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+const LOOKUP = {
+  trace_id: 't1',
+  project_id: 'p1',
+  session_id: 's1',
+  recording_id: 'r1',
+  occurred_at: '2026-01-01T00:00:04Z',
+  offset_ms: 4000,
+  recording_started_at: '2026-01-01T00:00:00Z',
+  first_chunk_index: 0,
+  last_chunk_index: 2,
+  chunk_count: 3,
+  duration_ms: 9000,
+  page_url: 'https://shop.example/checkout',
+};
+
+describe('ReplayClient', () => {
+  it('lookupTrace resolves a trace to its recording', async () => {
+    const client = new ReplayClient({
+      endpoint: 'https://fb.example/',
+      apiKey: 'k',
+      fetchImpl: async (url, init) => {
+        assert.equal(url, 'https://fb.example/api/v1/traces/t1');
+        assert.equal(init.headers['x-funnelbarn-api-key'], 'k');
+        return jsonResp(200, LOOKUP);
+      },
+    });
+    const got = await client.lookupTrace('t1');
+    assert.equal(got.recording_id, 'r1');
+    assert.equal(got.offset_ms, 4000);
+  });
+
+  it('lookupTrace throws a clear error on 404', async () => {
+    const client = new ReplayClient({
+      endpoint: 'https://fb.example',
+      apiKey: 'k',
+      fetchImpl: async () => jsonResp(404, { error: 'not found' }),
+    });
+    await assert.rejects(() => client.lookupTrace('missing'), /not found/);
+  });
+
+  it('fetchChunk rejects a non-array body', async () => {
+    const client = new ReplayClient({
+      endpoint: 'https://fb.example',
+      apiKey: 'k',
+      fetchImpl: async () => jsonResp(200, { not: 'an array' }),
+    });
+    await assert.rejects(() => client.fetchChunk('r1', 0), /not an event array/);
+  });
+
+  it('fetchAllEvents concatenates chunks and skips missing ones', async () => {
+    const warnings = [];
+    const client = new ReplayClient({
+      endpoint: 'https://fb.example',
+      apiKey: 'k',
+      fetchImpl: async (url) => {
+        if (url.endsWith('/chunks/0')) return jsonResp(200, [{ type: 2, timestamp: 1 }]);
+        if (url.endsWith('/chunks/1')) return jsonResp(500, {}); // missing/broken
+        if (url.endsWith('/chunks/2')) return jsonResp(200, [{ type: 3, timestamp: 2 }]);
+        return jsonResp(404, {});
+      },
+    });
+    const events = await client.fetchAllEvents(LOOKUP, (w) => warnings.push(w));
+    assert.equal(events.length, 2);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /chunk 1/);
+  });
+});
+
+describe('assembleEvents', () => {
+  it('orders by timestamp, detects snapshot, computes duration', () => {
+    const res = assembleEvents([
+      { type: 3, timestamp: 300 },
+      { type: 2, timestamp: 100 },
+      { type: 3, timestamp: 200 },
+      { bogus: true }, // filtered out
+    ]);
+    assert.equal(res.events.length, 3);
+    assert.equal(res.events[0].timestamp, 100);
+    assert.equal(res.events[2].timestamp, 300);
+    assert.equal(res.hasSnapshot, true);
+    assert.equal(res.durationMs, 200);
+  });
+
+  it('reports no snapshot when type 2 is absent', () => {
+    const res = assembleEvents([{ type: 3, timestamp: 1 }]);
+    assert.equal(res.hasSnapshot, false);
+  });
+});
+
+describe('buildReplayHTML', () => {
+  it('inlines events, seek, and an escaped banner', () => {
+    const html = buildReplayHTML({
+      events: [{ type: 2, timestamp: 100 }],
+      seekMs: 4000,
+      playerJs: 'window.rrwebPlayer = function(){};',
+      playerCss: '.x{}',
+      banner: 'trace <b>t1</b>',
+    });
+    assert.match(html, /var seekMs = 4000;/);
+    assert.match(html, /"type":2/);
+    assert.match(html, /trace &lt;b&gt;t1&lt;\/b&gt;/); // banner HTML-escaped
+    assert.match(html, /window\.rrwebPlayer/);
+  });
+});
+
+describe('parseCliArgs', () => {
+  it('throws when required args are missing', () => {
+    assert.throws(() => parseCliArgs([], {}), /missing required/);
+  });
+
+  it('falls back to environment variables', () => {
+    const args = parseCliArgs(['--trace', 'abc'], {
+      FUNNELBARN_ENDPOINT: 'https://fb.example',
+      FUNNELBARN_API_KEY: 'envkey',
+    });
+    assert.equal(args.trace, 'abc');
+    assert.equal(args.endpoint, 'https://fb.example');
+    assert.equal(args.apiKey, 'envkey');
+    assert.equal(args.headed, true);
+  });
+
+  it('--headless disables the visible window', () => {
+    const args = parseCliArgs(
+      ['--trace', 'abc', '--endpoint', 'https://x', '--api-key', 'k', '--headless'],
+      {}
+    );
+    assert.equal(args.headed, false);
+  });
+
+  it('--dry-run is parsed', () => {
+    const args = parseCliArgs(
+      ['--trace', 'abc', '--endpoint', 'https://x', '--api-key', 'k', '--dry-run'],
+      {}
+    );
+    assert.equal(args.dryRun, true);
+  });
+});

--- a/tools/replay/tsconfig.json
+++ b/tools/replay/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Context

PR 3 of the trace-correlation effort (backend #182, SDK #183). With traces linked to recordings and resolvable by `trace_id`, this is the **consumer**: a CLI that turns a trace_id from **SpanBarn**/**BugBarn** into a local replay of the **FunnelBarn** session that produced it — auto-seeked to the moment the trace fired. This is the debugging payoff: from an error span to *watching what the user did*.

```
SpanBarn/BugBarn (trace_id)
  → GET /api/v1/traces/{trace_id}            resolve to session + recording + seek offset
  → GET /api/v1/recordings/{rid}/chunks/{i}  fetch rrweb chunks (API-key replay-read)
  → rrweb-player in Playwright Chromium, seeked to offset_ms
```

## What's included (`tools/replay/`)

- **client** — resolves the trace and fetches chunks with the project API key; skips a missing chunk rather than aborting (partial recording still replays).
- **assemble** — orders rrweb events by timestamp, validates the full snapshot, builds a **fully self-contained, offline** replay HTML embedding rrweb-player.
- **replay** — lazily drives Playwright Chromium, waits for the player, seeks to `offset_ms`, optional screenshot / headed scrubbing. Lazy imports keep the data layer usable and testable **without** a browser install.
- **cli** — `--trace` (env fallbacks `FUNNELBARN_ENDPOINT`/`FUNNELBARN_API_KEY`), `--dry-run` (no browser), `--out`, `--screenshot`, `--headless`/`--headed`.

## Usage

```bash
export FUNNELBARN_ENDPOINT=https://funnelbarn.wiebe.xyz
export FUNNELBARN_API_KEY=fb_xxx
node dist/cli.js --trace <trace_id>              # watch, auto-seeked
node dist/cli.js --trace <id> --headless --screenshot moment.png
node dist/cli.js --trace <id> --dry-run         # resolve+assemble, JSON out
```

## Tests
11 tests via `node --test`: client (mock-fetch lookup, 404, non-array chunk, concat + skip-missing), assemble (ordering, snapshot detection, duration), HTML build + banner escaping, CLI arg parsing (required/env/flags). Plus a live `--dry-run` smoke test against a mock server (resolves → fetches 2 chunks → assembles 3 ordered events → correct seek). `npm run build` (strict tsc) clean.

## Notes
- Not in the CI build matrix (CI covers Go, web, sdks/js); verified locally.
- Depends on the API-key replay-read endpoints in **#182** (trace lookup returns chunk range; `GET /api/v1/recordings/{rid}/chunks/{index}`) — merge #182 first.
- Reproducing **backend** state via a restored DB snapshot / local stack is documented in the README as the next increment; the `--base-url` hook is reserved for it. This PR delivers the infra-free path: resolve → fetch → replay → seek.