### PR TITLE
feat(observability): adopt incoming W3C trace context on requests

### DIFF
--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
@@ -52,6 +53,15 @@ func signalURL(tracesEndpoint, signal string) string {
 }
 
 func Init(ctx context.Context, cfg Config) (func(context.Context) error, error) {
+	// Always honour incoming W3C trace context so FunnelBarn's own spans/logs
+	// join the caller's trace in SpanBarn — the same trace_id that BugBarn errors
+	// and the recorded session carry. Set unconditionally (even when export is
+	// off) so extraction/injection behave consistently.
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
 	if cfg.Endpoint == "" || cfg.APIKey == "" {
 		tracer = otel.Tracer(cfg.ServiceName)
 		return func(context.Context) error { return nil }, nil
@@ -93,8 +103,12 @@ func Middleware(next http.Handler) http.Handler {
 			return
 		}
 
+		// Adopt any incoming W3C traceparent so this server span becomes a child
+		// of the caller's trace rather than a new root.
+		ctx := otel.GetTextMapPropagator().Extract(r.Context(), propagation.HeaderCarrier(r.Header))
+
 		// Provisional name until the mux resolves the route pattern.
-		ctx, span := tracer.Start(r.Context(), r.Method,
+		ctx, span := tracer.Start(ctx, r.Method,
 			trace.WithSpanKind(trace.SpanKindServer),
 			trace.WithAttributes(
 				semconv.HTTPMethod(r.Method),

--- a/internal/tracing/tracing_test.go
+++ b/internal/tracing/tracing_test.go
@@ -7,7 +7,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestInit_NoEndpointReturnsNoopShutdown(t *testing.T) {
@@ -119,4 +123,58 @@ func TestRecordError_IgnoresNilError(t *testing.T) {
 	_, span := StartSpan(context.Background(), "x")
 	defer span.End()
 	RecordError(span, nil) // no-op, should not crash
+}
+
+// TestMiddleware_AdoptsIncomingTraceparent verifies a request carrying a W3C
+// traceparent produces a server span on the SAME trace — the property that lets
+// FunnelBarn's spans/logs correlate to the caller's trace in SpanBarn.
+func TestMiddleware_AdoptsIncomingTraceparent(t *testing.T) {
+	tp := sdktrace.NewTracerProvider()
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	prev := tracer
+	tracer = tp.Tracer("test")
+	defer func() { tracer = prev }()
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{}, propagation.Baggage{},
+	))
+
+	const wantTrace = "0af7651916cd43dd8448eb211c80319c"
+	var gotTrace string
+	var sampled bool
+	h := Middleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		sc := trace.SpanContextFromContext(r.Context())
+		gotTrace = sc.TraceID().String()
+		sampled = sc.IsSampled()
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/events", nil)
+	req.Header.Set("traceparent", "00-"+wantTrace+"-b7ad6b7169203331-01")
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	if gotTrace != wantTrace {
+		t.Errorf("server span trace_id = %q, want %q (incoming traceparent not adopted)", gotTrace, wantTrace)
+	}
+	if !sampled {
+		t.Error("sampled flag from incoming traceparent not honoured")
+	}
+}
+
+// TestMiddleware_NoTraceparentStartsRoot verifies a request without trace context
+// still gets a valid new-root span.
+func TestMiddleware_NoTraceparentStartsRoot(t *testing.T) {
+	tp := sdktrace.NewTracerProvider()
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	prev := tracer
+	tracer = tp.Tracer("test")
+	defer func() { tracer = prev }()
+
+	var valid bool
+	h := Middleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		valid = trace.SpanContextFromContext(r.Context()).TraceID().IsValid()
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/health", nil)
+	h.ServeHTTP(httptest.NewRecorder(), req)
+	if !valid {
+		t.Error("expected a valid new-root trace id when no traceparent is present")
+	}
 }


### PR DESCRIPTION
## Context

Final piece of the trace-correlation effort (backend #182, SDK #183, CLI #184). FunnelBarn already **exports** its own OTLP traces/logs/metrics to SpanBarn, but its HTTP middleware started a fresh root span for every request, ignoring any incoming `traceparent`. So FunnelBarn's own telemetry never joined the caller's trace.

## Change

- Set a global **W3C TraceContext + Baggage** propagator in `tracing.Init` (unconditionally, even when export is off, for consistent behaviour).
- Extract incoming trace context in `tracing.Middleware` so the server span becomes a **child** of the caller's trace instead of a new root.

This completes the correlation story end-to-end: the `trace_id` that a **BugBarn** error and a recorded **FunnelBarn** session carry is now also the trace that FunnelBarn's ingest spans/logs report under in **SpanBarn** — one id ties all three systems together.

A request with no `traceparent` still starts a valid new-root span (unchanged behaviour).

## Tests
Two new middleware tests: adopt-incoming-traceparent (asserts same trace_id + sampled flag propagate to the handler's span context) and no-traceparent-starts-root. Full suite green (19 packages), vet + staticcheck + gofmt clean.

Independent of #182/#183/#184 — can merge in any order.