### PR TITLE
feat(deploy): surface the deployed version/tag at runtime

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -111,6 +111,8 @@ jobs:
             kubectl apply -k /tmp/funnelbarn-deploy/deploy/k8s/testing
             kubectl -n ${NAMESPACE} set image deployment/funnelbarn \
               funnelbarn=${SERVICE_IMAGE}:${{ github.sha }}
+            kubectl -n ${NAMESPACE} set env deployment/funnelbarn \
+              FUNNELBARN_VERSION=${{ github.sha }}
             kubectl -n ${NAMESPACE} set image deployment/funnelbarn-web \
               funnelbarn-web=${WEB_IMAGE}:${{ github.sha }}
             kubectl -n ${NAMESPACE} rollout status deployment/funnelbarn --timeout=360s
@@ -193,6 +195,8 @@ jobs:
             kubectl apply -k /tmp/funnelbarn-deploy-staging/deploy/k8s/staging
             kubectl -n ${NAMESPACE} set image deployment/funnelbarn \
               funnelbarn=${SERVICE_IMAGE}:${{ github.sha }}
+            kubectl -n ${NAMESPACE} set env deployment/funnelbarn \
+              FUNNELBARN_VERSION=${{ github.sha }}
             kubectl -n ${NAMESPACE} set image deployment/funnelbarn-web \
               funnelbarn-web=${WEB_IMAGE}:${{ github.sha }}
             kubectl -n ${NAMESPACE} rollout status deployment/funnelbarn --timeout=360s

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -125,6 +125,8 @@ jobs:
             kubectl apply -k /tmp/funnelbarn-deploy/deploy/k8s/production
             kubectl -n ${NAMESPACE} set image deployment/funnelbarn \
               funnelbarn=${SERVICE_IMAGE}:${SHA}
+            kubectl -n ${NAMESPACE} set env deployment/funnelbarn \
+              FUNNELBARN_VERSION=${{ github.event.inputs.production_version }}
             kubectl -n ${NAMESPACE} set image deployment/funnelbarn-web \
               funnelbarn-web=${WEB_IMAGE}:${SHA}
             kubectl -n ${NAMESPACE} rollout status deployment/funnelbarn --timeout=180s

--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -122,6 +122,14 @@ func isHealthProbeLog(r slog.Record) bool {
 func run() error {
 	cfg := config.Load()
 
+	// Runtime version: the deploy injects the actual release tag via
+	// FUNNELBARN_VERSION (images are SHA-tagged and reused across environments),
+	// which overrides the build-time default baked into the binary.
+	version := Version
+	if cfg.Version != "" {
+		version = cfg.Version
+	}
+
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
 		case "version", "--version", "-v":
@@ -195,7 +203,7 @@ func run() error {
 		Endpoint:    cfg.SpanBarnEndpoint,
 		APIKey:      cfg.SpanBarnAPIKey,
 		ServiceName: "funnelbarn",
-		Version:     Version,
+		Version:     version,
 		Environment: cfg.SelfEnvironment,
 	}
 
@@ -304,7 +312,7 @@ func run() error {
 		SetupRatePerMinute:  cfg.SetupRatePerMinute,
 		SetupRateBurst:      cfg.SetupRateBurst,
 		DB:                  store,
-		Version:             Version,
+		Version:             version,
 		TrustedProxies:      cfg.TrustedProxies,
 		BugbarnEndpoint:     cfg.SelfEndpoint,
 		BugbarnIngestKey:    cfg.SelfAPIKey,
@@ -336,7 +344,7 @@ func run() error {
 		Handler: httpHandler,
 	}
 
-	slog.Info("funnelbarn starting", "addr", cfg.Addr, "version", Version)
+	slog.Info("funnelbarn starting", "addr", cfg.Addr, "version", version)
 
 	errCh := make(chan error, 1)
 	go func() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,9 +30,14 @@ type Config struct {
 	SelfAPIKey          string
 	SelfProject         string
 	SelfEnvironment     string
-	DogfoodAPIKey       string
-	DogfoodProject      string
-	EventRetentionDays  int // 0 = disabled; default 90
+	// Version, when set (FUNNELBARN_VERSION), overrides the build-time version
+	// baked into the binary. Images are SHA-tagged and reused across
+	// environments, so the deploy injects the actual release tag here to make
+	// the running version visible (e.g. in /api/v1/health).
+	Version            string
+	DogfoodAPIKey      string
+	DogfoodProject     string
+	EventRetentionDays int // 0 = disabled; default 90
 
 	// AutoRegisterMaxFlags caps auto-created flags per project (0 disables
 	// auto-registration). AutoRegisterTTLDays is how long an auto-created,
@@ -96,6 +101,7 @@ func Load() Config {
 		SelfAPIKey:          os.Getenv("FUNNELBARN_SELF_API_KEY"),
 		SelfProject:         getenv("FUNNELBARN_SELF_PROJECT", "funnelbarn"),
 		SelfEnvironment:     getenv("FUNNELBARN_ENVIRONMENT", "production"),
+		Version:             os.Getenv("FUNNELBARN_VERSION"),
 		DogfoodAPIKey:       os.Getenv("FUNNELBARN_DOGFOOD_API_KEY"),
 		DogfoodProject:      getenv("FUNNELBARN_DOGFOOD_PROJECT", "funnelbarn"),
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -198,3 +198,17 @@ func TestLoad_FlagAutoRegisterOverrides(t *testing.T) {
 		t.Errorf("AutoRegisterTTLDays: want 7, got %d", cfg.AutoRegisterTTLDays)
 	}
 }
+
+func TestLoad_VersionFromEnv(t *testing.T) {
+	t.Setenv("FUNNELBARN_VERSION", "v1.2.3")
+	if got := Load().Version; got != "v1.2.3" {
+		t.Errorf("Version from env: got %q, want v1.2.3", got)
+	}
+}
+
+func TestLoad_VersionEmptyByDefault(t *testing.T) {
+	t.Setenv("FUNNELBARN_VERSION", "")
+	if got := Load().Version; got != "" {
+		t.Errorf("Version default: got %q, want empty (main falls back to build var)", got)
+	}
+}


### PR DESCRIPTION
## Context

After deploying v0.5.87, `funnelbarn.wiebe.xyz/api/v1/health` reported `"version":"dev"` — you couldn't tell which release was actually running. Root cause: images are built on the main push and **SHA-tagged**, then the same image is reused across testing/staging/production. The binary's build-time `Version` is never set to a release tag (the tag doesn't exist yet at build time), so it stays `"dev"`.

Since the image is shared across environments, the version is really *deploy-time release metadata* — so inject it at deploy time rather than baking it in.

## Change

- **`FUNNELBARN_VERSION` env**: when set, overrides the build-time default and flows into `/api/v1/health`, the OTLP resource (`service.version` in SpanBarn), and the startup log. Falls back to the build-time var (still what `funnelbarn --version` prints).
- **Production deploy** sets it to the release **tag** (e.g. `v0.5.87`).
- **Testing/staging deploys** set it to the **commit SHA**, so every environment reports a meaningful identifier instead of `dev`.

## Why env (not ldflags rebuild)

Baking via ldflags can't show the tag in prod: the prod-deployed image was built on the main push, before the tag existed, and prod deliberately **reuses** that verified SHA image rather than rebuilding. Deploy-time env injection is the fit for shared, immutable images.

## Tests
Config tests for the env read and empty-default fallback. Full suite green (19 packages); vet + staticcheck + gofmt clean. The deploy workflow changes are `kubectl set env` lines mirroring the existing `set image` pattern.

## After merge
The next push to main redeploys testing/staging (they'll report the SHA). To make **production** show `v0.5.87`, re-run Deploy Production for that tag once this is merged — or it'll apply automatically on the next tagged release.