### PR TITLE
fix(recording): clear error for global API key + session recording docs

### DIFF
--- a/internal/api/recordings.go
+++ b/internal/api/recordings.go
@@ -11,6 +11,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
+	"github.com/wiebe-xyz/funnelbarn/internal/domain"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 	"github.com/wiebe-xyz/funnelbarn/internal/service"
 	"github.com/wiebe-xyz/funnelbarn/internal/tracing"
@@ -47,6 +48,20 @@ func (s *Server) handleIngestRecordingChunk(w http.ResponseWriter, r *http.Reque
 	)
 	defer span.End()
 
+	// The global env-var key (FUNNELBARN_API_KEY) resolves with an empty
+	// project ID. Recording chunks must be attributed to a specific project, so
+	// this key cannot be used here. A common misconfiguration is setting
+	// BUGBARN_FUNNELBARN_API_KEY (or equivalent cross-barn env vars) to the
+	// global key instead of a per-project key from the project settings page.
+	if projectID == "" {
+		slog.WarnContext(ctx, "recording chunk: global API key cannot be used for recording; project-scoped key required",
+			"user_agent", r.Header.Get("User-Agent"),
+			"request_id", RequestIDFromContext(ctx),
+		)
+		jsonError(w, "recording requires a project-scoped API key — use the key from the project settings page, not the global FUNNELBARN_API_KEY", http.StatusUnauthorized)
+		return
+	}
+
 	if s.projectHealth != nil {
 		pid := projectID
 		go func() {
@@ -58,7 +73,18 @@ func (s *Server) handleIngestRecordingChunk(w http.ResponseWriter, r *http.Reque
 
 	proj, err := s.projects.GetProject(ctx, projectID)
 	if err != nil {
-		tracing.RecordError(span, err)
+		// A key that resolves to a project that no longer exists is a client
+		// misconfiguration (404), not a server fault — log it so the case is
+		// distinguishable, but keep it off the span's error count.
+		if domain.IsNotFound(err) {
+			slog.WarnContext(ctx, "recording chunk: project not found for API key",
+				"project_id", projectID,
+				"user_agent", r.Header.Get("User-Agent"),
+				"request_id", RequestIDFromContext(ctx),
+			)
+		} else {
+			tracing.RecordError(span, err)
+		}
 		mapServiceError(w, err, "handleIngestRecordingChunk")
 		return
 	}

--- a/internal/api/recordings_globalkey_test.go
+++ b/internal/api/recordings_globalkey_test.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// The global env-var key resolves with an empty project ID, which used to
+// reach GetProject("") and come back as a bare 404 — indistinguishable from a
+// deleted project. Recording chunks must name a project, so this is a 401 with
+// an actionable message instead.
+func TestIngestRecordingChunk_GlobalKeyRejected(t *testing.T) {
+	srv, _ := newRecordingServer(t, "global-instance-key")
+
+	w := postChunk(t, srv, "global-instance-key", map[string]any{
+		"recording_id": "rec-1",
+		"session_id":   "sess-1",
+		"chunk_index":  0,
+		"events":       []map[string]any{{"type": 2}},
+		"started_at":   time.Now().UTC(),
+		"duration_ms":  0,
+	})
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for global key, got %d: %s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.Error == "unauthorized" || body.Error == "not found" {
+		t.Errorf("expected an actionable message naming the project-scoped key, got %q", body.Error)
+	}
+}

--- a/internal/api/recordings_trace_test.go
+++ b/internal/api/recordings_trace_test.go
@@ -56,11 +56,15 @@ func (s *memStorage) Delete(_ context.Context, key string) error {
 
 // newRecordingServer builds a server with session recording enabled and a
 // DB-backed API key authorizer (so a key can be bound to a real project).
-func newRecordingServer(t *testing.T) (*Server, *repository.Store) {
+func newRecordingServer(t *testing.T, staticKey ...string) (*Server, *repository.Store) {
 	t.Helper()
 	store := openMemoryStore(t)
 	sp := newTestSpool(t)
-	authz := auth.New("").WithDBLookup(store.ValidAPIKeySHA256, store.TouchAPIKey)
+	global := ""
+	if len(staticKey) > 0 {
+		global = staticKey[0]
+	}
+	authz := auth.New(global).WithDBLookup(store.ValidAPIKeySHA256, store.TouchAPIKey)
 	ingestHandler := ingest.NewHandler(authz, sp, 0)
 	sm := auth.NewSessionManager("test-secret", time.Hour)
 	userAuth, _ := auth.NewUserAuthenticator("", "", "")

--- a/site/src/content/docs/sdk-js.md
+++ b/site/src/content/docs/sdk-js.md
@@ -46,11 +46,15 @@ analytics.page();
 
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `apiKey` | `string` | required | Your ingest API key |
+| `apiKey` | `string` | required | Your ingest API key (see [API keys](#api-keys)) |
 | `endpoint` | `string` | required | Full URL of your FunnelBarn instance |
-| `projectName` | `string` | — | Project identifier sent as `x-funnelbarn-project` header |
+| `projectName` | `string` | — | Project identifier sent as `x-funnelbarn-project` header (events only; not used for recording) |
 | `flushInterval` | `number` | `5000` | How often (ms) the event queue is flushed |
 | `sessionTimeout` | `number` | `1800000` | Session idle timeout in ms (default 30 min) |
+| `recording` | `boolean` | `false` | Enable session recording immediately on init (server config can also enable it) |
+| `recordingChunkMs` | `number` | `10000` | How often (ms) a recording chunk is flushed to the server |
+| `recordInclude` | `string[]` | — | URL path glob patterns to always record (e.g. `['/checkout/**']`) |
+| `recordExclude` | `string[]` | — | URL path glob patterns to never record (e.g. `['/admin/**']`) |
 
 ## Tracking page views
 
@@ -121,6 +125,63 @@ function Analytics() {
   return null;
 }
 ```
+
+## Session Recording
+
+FunnelBarn can record user sessions with rrweb and replay them in the dashboard.
+
+### API keys
+
+> **Important:** session recording requires a **project-scoped API key** — the
+> key shown on your project's settings page. The global `FUNNELBARN_API_KEY`
+> (the env-var key used for self-hosting) is not bound to any project and will
+> be rejected with a `401` when the SDK tries to send recording chunks.
+>
+> If you are integrating two barns (e.g. bugbarn sending recordings to
+> funnelbarn), set the cross-barn env var (`BUGBARN_FUNNELBARN_API_KEY` etc.)
+> to the **project-scoped key** from the funnelbarn project settings page, not
+> the global `FUNNELBARN_API_KEY`.
+
+### Enabling recording
+
+Recording is off by default. Turn it on in one of two ways:
+
+**Option A — enable in the dashboard** (recommended): Go to your project's Settings → Session Recording and toggle recording on. The SDK fetches this setting on init via `GET /api/v1/recording-config` and starts recording automatically.
+
+**Option B — enable in the SDK init:**
+
+```javascript
+const analytics = new FunnelBarnClient({
+  apiKey: 'your-project-scoped-api-key',
+  endpoint: 'https://funnelbarn.example.com',
+  recording: true,
+});
+```
+
+### Script-tag usage with recording
+
+```html
+<script src="https://funnelbarn.example.com/sdk.js"
+        data-api-key="your-project-scoped-api-key" defer></script>
+```
+
+Recording is controlled server-side when using the script tag. Enable it from the project settings in the dashboard.
+
+### Filtering which pages are recorded
+
+```javascript
+const analytics = new FunnelBarnClient({
+  apiKey: 'your-project-scoped-api-key',
+  endpoint: 'https://funnelbarn.example.com',
+  recording: true,
+  recordInclude: ['/checkout/**', '/signup'],
+  recordExclude: ['/admin/**', '/account/password'],
+});
+```
+
+`recordInclude` and `recordExclude` are checked first. Server-side rules (set from the dashboard) are applied next. If no rule matches, the page is recorded by default.
+
+To mask sensitive input fields, add the `fb-block` CSS class to any element and its contents will be hidden in the recording.
 
 ## TypeScript
 


### PR DESCRIPTION
## Problem

`POST /api/v1/recordings/chunk` returned `404 {"error":"not found"}` when
called with the global `FUNNELBARN_API_KEY` (the env-var key). That 404 comes
from `GetProject("")` failing — the global key resolves with an empty project
ID, which looks identical to a missing project.

Root cause: when bugbarn (or any cross-barn setup) sets
`BUGBARN_FUNNELBARN_API_KEY` to the global instance key instead of a
per-project key, every recording chunk silently 404s. The operator has no
signal pointing at the misconfiguration.

## Changes

**`internal/api/recordings.go`**
- Detect `projectID == ""` (global key) immediately after auth and return
  `401` with a message that names the problem and how to fix it, plus a
  structured warn log so it's findable in the log stream
- Add a warn log before `mapServiceError` for the "project deleted but key
  still exists" path — makes that case distinguishable from the empty-ID case

**`site/src/content/docs/sdk-js.md`**
- Add a Session Recording section covering: how to enable recording, the
  project-scoped key requirement (with a callout for cross-barn setups), page
  filtering with `recordInclude`/`recordExclude`, and the `fb-block` masking
  class
- Expand the options table with all recording-related options

## How to reproduce the bug (before this fix)

```bash
# Global key → 404 (was confusing, now 401 with clear message)
curl -si -X POST https://funnelbarn.wiebe.xyz/api/v1/recordings/chunk \
  -H "x-funnelbarn-api-key: $GLOBAL_KEY" \
  -H "Content-Type: application/json" \
  -d '{"recording_id":"x","session_id":"y","chunk_index":0,"events":[{}],"started_at":"2026-06-23T00:00:00Z","duration_ms":0}'
```

## Operational follow-up required

The bugbarn production secret `BUGBARN_FUNNELBARN_API_KEY` needs to be
rotated to a project-scoped key from the funnelbarn dashboard (Settings →
API Keys for the bugbarn project). That is a config change outside this PR.