### PR TITLE
feat(edge): accept generic f.<domain> custom ingest domains (#189)

### DIFF
--- a/deploy/RUNBOOK.md
+++ b/deploy/RUNBOOK.md
@@ -147,6 +147,45 @@ kubectl -n $NAMESPACE rollout status deployment/funnelbarn-web --timeout=180s
 
 ---
 
+## 2b. Custom ingest domain (`f.<brand>` CNAME)
+
+Consuming apps can front FunnelBarn under their own branded subdomain (e.g. BrandTrace uses
+`f.brandtrace.net`) instead of exposing `funnelbarn.wiebe.xyz` in `<script>` tags and API calls. This
+is handled generically at the edge — **no per-customer manifest change and no application config**.
+
+**How it works.** `deploy/k8s/production/ingressroute-f-wildcard.yaml` is a Traefik `IngressRoute`
+that matches any host of the form `f.<domain>` (`HostRegexp(`^f\..+$`)`) and routes `/sdk.js` (+ the
+legacy `/sdk/funnelbarn.js`) to the web/nginx service and `/api/*` to the Go service. Traefik v3
+issues a Let's Encrypt certificate per incoming SNI on-demand (`certResolver: letsencrypt`). This is
+the same pattern the sibling barn tools use (`bt.*` for BrandTrace, `sb.*` for SpanBarn). Projects are
+still resolved by API key + the `x-funnelbarn-project` header, so the custom host needs no app-side
+mapping.
+
+**Onboarding a customer (one-time, DNS side only):**
+
+1. Point `f.<brand>` at the shared cluster — a CNAME to the same target the customer's other barn
+   subdomains (`bt.<brand>`, `sb.<brand>`) already use. Port 80 must reach Traefik for that host so
+   the HTTP-01 ACME challenge can validate and the per-SNI cert can issue.
+2. Install the snippet against the custom host: `<script src="https://f.<brand>/sdk.js"
+   data-api-key="…" data-project-name="…" defer></script>`. The SDK derives its endpoint from the
+   script's own origin, so events go to `https://f.<brand>/api/v1/events` automatically.
+3. Verify (see checks in Section 2c below).
+
+Only `/sdk.js` and `/api/*` are exposed on customer domains — the dashboard SPA is not.
+
+### 2c. Verify a custom ingest domain
+
+```sh
+curl -sI https://f.<brand>/sdk.js            # expect HTTP 200 (served by nginx)
+curl -sI https://f.<brand>/api/v1/health     # expect HTTP 200 (Go service)
+```
+
+Then load a page embedding the snippet and confirm in the browser console that `window.funnelbarn`
+initializes and a `track()` POST to `https://f.<brand>/api/v1/events` returns 2xx. Event volume for
+the project should appear on the dashboard within a minute.
+
+---
+
 ## 3. Rollback
 
 ### Automatic rollback

--- a/deploy/k8s/production/ingressroute-f-wildcard.yaml
+++ b/deploy/k8s/production/ingressroute-f-wildcard.yaml
@@ -1,0 +1,42 @@
+# Generic custom ingest domain support.
+#
+# Accepts any `f.<customer-domain>` (e.g. f.brandtrace.net) so consuming apps can front FunnelBarn
+# under their own branded subdomain instead of funnelbarn.wiebe.xyz. A plain k8s Ingress cannot
+# express this — its host wildcard must be `*.<fixed-suffix>` (one zone), whereas customer domains
+# span different apexes — so this uses a Traefik IngressRoute with HostRegexp.
+#
+# This mirrors the established sibling pattern on the same cluster: BrandTrace's `bt.*`
+# (brandtrace-brandtrace-bt-cname) and SpanBarn's `sb.*` (spanbarn-forward-domains). Traefik v3
+# issues a Let's Encrypt certificate per incoming SNI on-demand via `certResolver: letsencrypt`, so
+# no per-domain cert or manifest edit is needed when a new customer onboards.
+#
+# Scope is intentionally tight — only the paths the browser SDK fetches from its origin:
+#   - /sdk.js (+ legacy /sdk/funnelbarn.js) served by nginx (funnelbarn-web)
+#   - /api/*  (events, evaluate, recording-config, recordings/chunk, health) served by the Go service
+# The dashboard SPA is NOT exposed on customer domains. `priority: 1` keeps FunnelBarn's own concrete
+# per-host Ingresses (f.bananasketch.nl, ingress-f.yaml) winning for their own hosts and TLS.
+#
+# Onboarding a customer: point f.<brand> at the shared cluster (CNAME, same target as bt.*/sb.*) with
+# port 80 reachable so the HTTP-01 ACME challenge can validate. See deploy/RUNBOOK.md §"Custom ingest domain".
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: funnelbarn-f-wildcard
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: HostRegexp(`^f\..+$`) && (Path(`/sdk.js`) || Path(`/sdk/funnelbarn.js`))
+      kind: Rule
+      priority: 1
+      services:
+        - name: funnelbarn-web
+          port: 3000
+    - match: HostRegexp(`^f\..+$`) && PathPrefix(`/api`)
+      kind: Rule
+      priority: 1
+      services:
+        - name: funnelbarn
+          port: 8080
+  tls:
+    certResolver: letsencrypt

--- a/deploy/k8s/production/kustomization.yaml
+++ b/deploy/k8s/production/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - web-service.yaml
   - ingress.yaml
   - ingress-f.yaml
+  - ingressroute-f-wildcard.yaml
 images:
   - name: funnelbarn/service
     newName: ghcr.io/webwiebe/funnelbarn/service


### PR DESCRIPTION
Closes #189.

## Problem

Consuming apps want to front FunnelBarn under their own branded subdomain (e.g. BrandTrace's `f.brandtrace.net`) instead of exposing `funnelbarn.wiebe.xyz` in `<script>` tags and API calls. FunnelBarn never served that host, so `<script src="https://f.brandtrace.net/sdk.js">` 404s → `window.funnelbarn` never initializes → every `track()` is a silent no-op. Prod event volume collapsed ~99.5% at the rebrand.

## Why this is an edge-only change

- Projects are resolved by **API key + the `x-funnelbarn-project` header**, never by hostname.
- The browser SDK derives its endpoint from its own `<script src>` origin, so loading from `f.brandtrace.net` makes it POST to `f.brandtrace.net/api/v1/events` automatically.
- Production CORS is fully open (`FUNNELBARN_ALLOWED_ORIGINS` unset), so cross-origin ingest from any customer page already works.

No application, SDK, or CORS code changes.

## Approach

Add a Traefik `IngressRoute` (`deploy/k8s/production/ingressroute-f-wildcard.yaml`) matching any `f.<domain>` host via `HostRegexp(` + "`^f\\..+$`" + `)`, routing `/sdk.js` (+ legacy `/sdk/funnelbarn.js`) → nginx web service and `/api/*` → Go service, with per-SNI on-demand Let's Encrypt certs (`certResolver: letsencrypt`).

A plain k8s `Ingress` can't express this — its host wildcard must be `*.<fixed-suffix>` (single zone), whereas customer domains span different apexes. This is the **exact pattern the sibling barn tools already run on this cluster** (`bt.*` for BrandTrace, `sb.*` for SpanBarn), so a new customer `f.<brand>` onboards with a DNS record alone — no per-domain manifest edit.

- Scope is tight: only `/sdk.js` + `/api/*` are exposed on customer domains (dashboard SPA is not).
- `priority: 1` keeps the existing concrete `f.bananasketch.nl` / `ingress-f.yaml` hosts winning for their own hosts and TLS.
- `f.brandtrace.net` is currently unclaimed by any cluster router (verified), so it's served the moment this deploys.

## Validation

- Cluster runs **Traefik v3.6.7** with the `ingressroutes.traefik.io` CRD installed → API group + `HostRegexp` syntax confirmed.
- `kubectl apply --dry-run=server --server-side` accepts the manifest (`ingressroute.traefik.io/funnelbarn-f-wildcard serverside-applied`).

## Post-deploy verification (prod)

```sh
curl -sI https://f.brandtrace.net/sdk.js         # expect 200 (was 404)
curl -sI https://f.brandtrace.net/api/v1/health  # expect 200
```

Then confirm the SDK initializes on a page embedding the snippet and BrandTrace prod event volume recovers on the dashboard.

RUNBOOK gets a new "Custom ingest domain" onboarding + verification section.