### PR TITLE
fix(ci): pin nfpm to v2.46.0 so the .deb build works on the go 1.25 runner

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -188,7 +188,10 @@ jobs:
           cache: true
 
       - name: Install nfpm
-        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+        # Pin nfpm: v2.47.0+ bumped its go directive to go 1.26.4, which fails
+        # `go install` under GOTOOLCHAIN=local on the go 1.25 runner. v2.46.0 is the
+        # newest release still on the go 1.25 line. Bump when the runner's Go is >= 1.26.
+        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.46.0
 
       - name: Build binary
         env:


### PR DESCRIPTION
## Problem

`Binary Release` fails on every push to `main` at the **Build .deb Packages** jobs:

```
go: github.com/goreleaser/nfpm/v2/cmd/nfpm@latest: github.com/goreleaser/nfpm/v2@v2.47.0
requires go >= 1.26.4 (running go 1.25.11; GOTOOLCHAIN=local)
```

nfpm `v2.47.0` bumped its go directive to `go 1.26.4`. The workflow does `go install ...nfpm@latest`, and under `GOTOOLCHAIN=local` on the self-hosted runner (Go 1.25.11) that install fails. This has been breaking the `.deb`/APT distribution channel; the k8s deploy path is unaffected.

## Fix

Pin nfpm to `v2.46.0` — the newest release still on the `go 1.25` line (the runner's Go 1.25.11 satisfies it). Verified via the module proxy `go.mod` directives:

| nfpm | go directive |
|---|---|
| v2.47.0 | `go 1.26.4` ❌ |
| **v2.46.0** | `go 1.25` ✅ |
| v2.43.2 | `go 1.25` ✅ |

A comment notes to bump the pin once the runner's Go reaches 1.26.

## Verification

The `Binary Release` run on this branch should get past the `Install nfpm` step and complete the `Build .deb Packages` jobs (previously red). No functional change to packaging — nfpm 2.46 vs 2.47 only differ by the toolchain requirement here.