### PR TITLE
fix(overview): project names in visitors-per-site tooltip

### DIFF
--- a/web/src/pages/Overview.tsx
+++ b/web/src/pages/Overview.tsx
@@ -123,9 +123,9 @@ export default function Overview() {
                 <XAxis dataKey="day" stroke={C.muted} fontSize={11} />
                 <YAxis stroke={C.muted} fontSize={11} allowDecimals={false} />
                 <Tooltip contentStyle={{ background: C.surface, border: `1px solid ${C.border}`, borderRadius: 8, color: C.text }} />
-                <Legend formatter={(v) => nameFor(String(v))} />
+                <Legend />
                 {chartProjectIds.map((pid, i) => (
-                  <Line key={pid} type="monotone" dataKey={pid} name={pid} stroke={LINE_COLORS[i % LINE_COLORS.length]} dot={false} strokeWidth={2} />
+                  <Line key={pid} type="monotone" dataKey={pid} name={nameFor(pid)} stroke={LINE_COLORS[i % LINE_COLORS.length]} dot={false} strokeWidth={2} />
                 ))}
               </LineChart>
             </ResponsiveContainer>


### PR DESCRIPTION
The visitors-per-site chart tooltip showed raw project ids (UUIDs) because each line's series name defaulted to its `dataKey` (the project id). Set each line's `name` to the resolved project name so tooltip and legend both label by name.

Frontend-only. tsc/eslint clean, 147 vitest tests pass.