### PR TITLE
cors: audit-guard comments + e2e config test against re-tightening ingest CORS

### DIFF
--- a/e2e/api.spec.ts
+++ b/e2e/api.spec.ts
@@ -104,3 +104,60 @@ test.describe('API: ingest', () => {
     expect([401, 403]).toContain(resp.status())
   })
 })
+
+/**
+ * CORS configuration guard — validates the deployed edge, not just the handler.
+ *
+ * This is the regression net for the custom-CNAME ingest break (CORS-1 in #195,
+ * fixed in #198): a browser SDK preflights POST /api/v1/events carrying headers
+ * we don't control (notably `traceparent` from distributed tracing), and the
+ * non-credentialed ingest path MUST echo them back or the browser blocks the
+ * real request. It only reproduces in a browser — curl skips preflight — so we
+ * pin the actual OPTIONS response the browser would enforce on. Running against
+ * the live deployment (E2E_BASE_URL) also catches an edge/proxy that strips or
+ * rewrites the CORS headers, which a Go unit test cannot.
+ */
+test.describe('API: CORS config', () => {
+  const CUSTOMER_ORIGIN = 'https://cors-e2e-customer.example'
+
+  test('ingest preflight reflects the origin and echoes requested headers incl. traceparent', async ({
+    request,
+  }) => {
+    const resp = await request.fetch('/api/v1/events', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: CUSTOMER_ORIGIN,
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Headers': 'content-type,traceparent,x-funnelbarn-api-key',
+      },
+    })
+    expect(resp.status()).toBe(204)
+
+    const h = resp.headers()
+    // Origin reflected (browser SDKs live on arbitrary customer sites).
+    expect(h['access-control-allow-origin']).toBe(CUSTOMER_ORIGIN)
+    // The header that regressed — must be echoed back, or the POST is blocked.
+    expect((h['access-control-allow-headers'] ?? '').toLowerCase()).toContain('traceparent')
+    // Non-credentialed: these auth with an API-key header, never cookies.
+    expect(h['access-control-allow-credentials']).toBeUndefined()
+  })
+
+  test('credentialed dashboard endpoint does not open CORS to an arbitrary origin', async ({
+    request,
+  }) => {
+    const resp = await request.fetch('/api/v1/projects', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://cors-e2e-evil.example',
+        'Access-Control-Request-Method': 'GET',
+        'Access-Control-Request-Headers': 'x-evil-injected',
+      },
+    })
+    const h = resp.headers()
+    // An off-allowlist origin must get NO Allow-Origin (credentialed API is not
+    // reflected cross-origin) and certainly no reflected injected header. This
+    // is the strict posture CORS-1 established and #198 preserved.
+    expect(h['access-control-allow-origin']).toBeUndefined()
+    expect((h['access-control-allow-headers'] ?? '').toLowerCase()).not.toContain('x-evil-injected')
+  })
+})

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -432,6 +432,14 @@ func (s *Server) metricsHandler() http.Handler {
 // publicIngestCORSPaths are the endpoints a browser SDK on an arbitrary
 // customer origin legitimately calls cross-origin. They authenticate with an
 // API-key header (never cookies), so they get open, NON-credentialed CORS.
+//
+// AUDIT GUARD: do NOT "harden" these by pinning Access-Control-Allow-Headers to
+// the fixed corsAllowHeaders list — they must keep reflecting the preflight's
+// requested headers (see setCORSHeaders). SDKs/tracing add headers we don't
+// control (e.g. `traceparent`); a fixed list drops the missing one and the
+// browser blocks the whole request. This regressed once (CORS-1 in #195, fixed
+// in #198) and only shows up in a real browser, never in curl or unit tests.
+// The fixed allowlist is safe ONLY on the credentialed dashboard API.
 var publicIngestCORSPaths = map[string]bool{
 	"/api/v1/events":           true,
 	"/api/v1/recordings/chunk": true,
@@ -440,8 +448,10 @@ var publicIngestCORSPaths = map[string]bool{
 	"/api/v1/client-config":    true,
 }
 
-// corsAllowHeaders is the fixed set of request headers permitted cross-origin.
-// We never reflect Access-Control-Request-Headers verbatim.
+// corsAllowHeaders is the fixed set of request headers permitted cross-origin
+// on the CREDENTIALED dashboard API only. We never reflect
+// Access-Control-Request-Headers verbatim there. NOTE: this list is deliberately
+// NOT used for the public ingest paths — see publicIngestCORSPaths.
 var corsAllowHeaders = "Content-Type, Authorization, " + auth.HeaderAPIKey +
 	", x-funnelbarn-project, x-funnelbarn-environment, X-FunnelBarn-CSRF, X-Requested-With"
 


### PR DESCRIPTION
Follow-up to #198 — makes the CORS regression hard to reintroduce in a future audit. Two guards:

## 1. Audit-guard comments (no behavior change)
Comments at the two spots a CORS audit would touch when "hardening":
- `publicIngestCORSPaths` — must keep **reflecting** the preflight's requested headers (SDK/tracing add `traceparent` etc.); a fixed list regressed once (CORS-1 #195 → fixed #198) and only surfaces in a real browser.
- `corsAllowHeaders` — clarifies the fixed allowlist is for the **credentialed dashboard API only**.

## 2. E2E config test (`e2e/api.spec.ts`)
Runs against the live deployment (`E2E_BASE_URL`), so it catches an edge/proxy that strips or rewrites CORS headers — something a Go unit test can't:
- ingest preflight reflects the origin, **echoes `traceparent`**, no `Allow-Credentials`;
- credentialed dashboard endpoint does **not** open CORS to an arbitrary origin (no reflected `Allow-Origin`, no reflected injected header).

Pins the exact OPTIONS response the browser enforces on — the check curl can't do (it skips preflight), which is how #198 slipped through. Verified green against `funnelbarn.test.wiebe.xyz`.

Complements the Go handler unit tests from #198 (`TestCORS_IngestReflectsRequestedHeaders`, `TestCORS_DashboardDoesNotReflectRequestedHeaders`) and a persistent maintainer memory capturing the footgun.