### PR TITLE
test(e2e): decode the authorize URL before asserting the OIDC redirect

### DIFF
--- a/e2e/iambarn.spec.ts
+++ b/e2e/iambarn.spec.ts
@@ -70,8 +70,13 @@ test.describe('OIDC login page', () => {
     await page.goto('/login')
     await page.waitForURL(/iam\./, { waitUntil: 'commit', timeout: 10000 })
     const url = page.url()
-    expect(url).toContain('/oauth2/authorize')
-    expect(url).toContain('code_challenge')
+    // An unauthenticated visitor is bounced to IAMBarn's /auth/login with the
+    // authorization request URL-encoded in redirect_uri, so decode before
+    // asserting the PKCE authorize request is present (works whether IAMBarn
+    // lands us directly on /oauth2/authorize or on the login page first).
+    const decoded = decodeURIComponent(url)
+    expect(decoded).toContain('/oauth2/authorize')
+    expect(decoded).toContain('code_challenge')
   })
 })
 


### PR DESCRIPTION
The funnelbarn app deploys and works; only the post-deploy e2e assertion failed. IAMBarn bounces an unauthenticated visitor to `/auth/login?redirect_uri=%2Foauth2%2Fauthorize…`, so the raw URL contains the authorize path URL-encoded and `toContain('/oauth2/authorize')` failed on the encoding. Decode the URL first so the PKCE-authorize assertion holds whether IAMBarn lands the user on the authorize endpoint directly or on its login page.