### PR TITLE
fix(deploy): copy sdks/go before go mod download in service.Dockerfile

### DIFF
--- a/deploy/docker/service.Dockerfile
+++ b/deploy/docker/service.Dockerfile
@@ -6,11 +6,11 @@ WORKDIR /src
 
 COPY go.mod go.sum ./
 COPY sdks/go-bugbarn ./sdks/go-bugbarn
+COPY sdks/go ./sdks/go
 RUN go mod download
 
 COPY cmd ./cmd
 COPY internal ./internal
-COPY sdks/go ./sdks/go
 
 RUN CGO_ENABLED=1 go build -o /out/funnelbarn ./cmd/funnelbarn
 


### PR DESCRIPTION
The local replace directive (sdks/go => ./sdks/go) added in #203 needs that directory present when go mod download resolves it, but the Dockerfile only copied it after the download step, breaking every image build since that commit landed on main. Verified locally with docker buildx build.