### PR TITLE
Instrument the OIDC/IAMBarn auth flow with spans and metrics

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/wiebe-xyz/funnelbarn/internal/auth"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
+	"github.com/wiebe-xyz/funnelbarn/internal/tracing"
 )
 
 // dummyBcryptHash is a valid bcrypt hash compared against on the user-not-found
@@ -93,6 +94,10 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 // can end the IdP session too. Shared by handleLogout (JSON API) and
 // handleOIDCLoggedOut (the IAMBarn RP-initiated logout landing endpoint).
 func (s *Server) clearSession(w http.ResponseWriter, r *http.Request) (logoutURL string) {
+	ctx, span := tracing.StartSpan(r.Context(), "oidc.logout")
+	defer span.End()
+	r = r.WithContext(ctx)
+
 	if cookie, err := r.Cookie("funnelbarn_session"); err == nil && s.webSessions != nil {
 		idHash := auth.HashSessionToken(cookie.Value)
 		if ws, err := s.webSessions.GetWebSession(r.Context(), idHash); err == nil {
@@ -102,6 +107,7 @@ func (s *Server) clearSession(w http.ResponseWriter, r *http.Request) (logoutURL
 				// even when the IdP is unreachable.
 				if ws.RefreshToken != "" {
 					if err := s.oidc.RevokeRefreshToken(r.Context(), ws.RefreshToken); err != nil {
+						tracing.RecordError(span, err)
 						slog.WarnContext(r.Context(), "logout: revoke refresh token", "error", err)
 					}
 				}
@@ -109,6 +115,7 @@ func (s *Server) clearSession(w http.ResponseWriter, r *http.Request) (logoutURL
 					if u, err := s.oidc.EndSessionURL(ws.IDToken); err == nil {
 						logoutURL = u
 					} else {
+						tracing.RecordError(span, err)
 						slog.WarnContext(r.Context(), "logout: build end-session url", "error", err)
 					}
 				}
@@ -116,6 +123,7 @@ func (s *Server) clearSession(w http.ResponseWriter, r *http.Request) (logoutURL
 			// Deleting the row IS the revocation — the opaque handle is
 			// worthless the moment the row is gone.
 			if err := s.webSessions.DeleteWebSession(r.Context(), idHash); err != nil {
+				tracing.RecordError(span, err)
 				slog.ErrorContext(r.Context(), "logout: delete session", "err", err, "handled", false)
 			}
 		}

--- a/internal/api/backchannel_logout.go
+++ b/internal/api/backchannel_logout.go
@@ -1,8 +1,13 @@
 package api
 
 import (
+	"errors"
 	"log/slog"
 	"net/http"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/wiebe-xyz/funnelbarn/internal/tracing"
 )
 
 // handleBackchannelLogout implements the RP side of OIDC Back-Channel Logout
@@ -22,24 +27,32 @@ func (s *Server) handleBackchannelLogout(w http.ResponseWriter, r *http.Request)
 		jsonError(w, "oidc not configured", http.StatusNotFound)
 		return
 	}
+	ctx, span := tracing.StartSpan(r.Context(), "oidc.backchannel_logout")
+	defer span.End()
+	r = r.WithContext(ctx)
+
 	// Per spec the response must not be cached.
 	w.Header().Set("Cache-Control", "no-store")
 
 	if err := r.ParseForm(); err != nil {
+		tracing.RecordError(span, err)
 		jsonError(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
 	raw := r.PostFormValue("logout_token")
 	if raw == "" {
+		tracing.RecordError(span, errors.New("backchannel-logout: logout_token missing"))
 		jsonError(w, "logout_token required", http.StatusBadRequest)
 		return
 	}
 	claims, err := s.oidc.VerifyLogoutToken(r.Context(), raw)
 	if err != nil {
+		tracing.RecordError(span, err)
 		slog.WarnContext(r.Context(), "backchannel-logout: token rejected", "error", err)
 		jsonError(w, "invalid logout token", http.StatusBadRequest)
 		return
 	}
+	span.SetAttributes(attribute.String("oidc.sid", claims.SessionID), attribute.String("oidc.sub", claims.Subject))
 
 	// Prefer the precise sid (one IdP session); fall back to sub (all of the
 	// user's sessions). Deleting zero rows is still a success per spec — the
@@ -51,11 +64,13 @@ func (s *Server) handleBackchannelLogout(w http.ResponseWriter, r *http.Request)
 		deleted, err = s.webSessions.DeleteWebSessionsByIdpSub(r.Context(), claims.Subject)
 	}
 	if err != nil {
+		tracing.RecordError(span, err)
 		slog.ErrorContext(r.Context(), "backchannel-logout: delete sessions",
 			"err", err, "handled", false, "sid", claims.SessionID, "sub", claims.Subject)
 		jsonError(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
+	span.SetAttributes(attribute.Int64("oidc.sessions_deleted", deleted))
 	slog.InfoContext(r.Context(), "backchannel-logout: sessions revoked",
 		"sid", claims.SessionID, "sub", claims.Subject, "deleted", deleted)
 	w.WriteHeader(http.StatusOK)

--- a/internal/api/oidc_confidential.go
+++ b/internal/api/oidc_confidential.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -12,8 +13,11 @@ import (
 
 	"golang.org/x/oauth2"
 
+	"go.opentelemetry.io/otel/attribute"
+
 	"github.com/wiebe-xyz/funnelbarn/internal/auth"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
+	"github.com/wiebe-xyz/funnelbarn/internal/tracing"
 )
 
 // IAMBarnUserRepo is the storage interface needed by the OIDC callback handler
@@ -38,11 +42,16 @@ func (s *Server) handleOIDCConfidentialLogin(w http.ResponseWriter, r *http.Requ
 		jsonError(w, "oidc not configured", http.StatusNotFound)
 		return
 	}
+	ctx, span := tracing.StartSpan(r.Context(), "oidc.login_start")
+	defer span.End()
+	r = r.WithContext(ctx)
+
 	state := oidcConfRandomToken()
 	nonce := oidcConfRandomToken()
 	verifier := oauth2.GenerateVerifier()
 	authURL, err := s.oidc.AuthorizeURL(state, nonce, verifier)
 	if err != nil {
+		tracing.RecordError(span, err)
 		slog.WarnContext(r.Context(), "oidc: build authorize url", "error", err)
 		jsonError(w, "oidc unavailable", http.StatusServiceUnavailable)
 		return
@@ -61,36 +70,47 @@ func (s *Server) handleOIDCConfidentialCallback(w http.ResponseWriter, r *http.R
 		jsonError(w, "oidc not configured", http.StatusNotFound)
 		return
 	}
+	ctx, span := tracing.StartSpan(r.Context(), "oidc.login_callback")
+	defer span.End()
+	r = r.WithContext(ctx)
+
 	stateCookie, err := r.Cookie(oidcConfStateCookie)
 	if err != nil || stateCookie.Value == "" {
+		tracing.RecordError(span, errors.New("oidc: state cookie missing"))
 		slog.WarnContext(r.Context(), "oidc: state cookie missing")
 		jsonError(w, "oidc state mismatch", http.StatusBadRequest)
 		return
 	}
 	state, verifier, ok := parseStateCookie(stateCookie.Value)
 	if !ok || state != r.URL.Query().Get("state") {
+		tracing.RecordError(span, errors.New("oidc: state mismatch"))
 		slog.WarnContext(r.Context(), "oidc: state mismatch")
 		jsonError(w, "oidc state mismatch", http.StatusBadRequest)
 		return
 	}
 	nonceCookie, err := r.Cookie(oidcConfNonceCookie)
 	if err != nil || nonceCookie.Value == "" {
+		tracing.RecordError(span, errors.New("oidc: nonce cookie missing"))
 		jsonError(w, "oidc nonce missing", http.StatusBadRequest)
 		return
 	}
 	code := r.URL.Query().Get("code")
 	if code == "" {
+		tracing.RecordError(span, errors.New("oidc: code missing"))
 		jsonError(w, "oidc code missing", http.StatusBadRequest)
 		return
 	}
 	result, err := s.oidc.ExchangeFull(r.Context(), code, nonceCookie.Value, verifier)
 	if err != nil {
+		tracing.RecordError(span, err)
 		slog.WarnContext(r.Context(), "oidc: exchange failed", "error", err)
 		jsonError(w, "oidc exchange failed", http.StatusUnauthorized)
 		return
 	}
 	claims := result.Claims
+	span.SetAttributes(attribute.String("oidc.sub", claims.Subject))
 	if !s.oidc.Allowed(claims) {
+		tracing.RecordError(span, errors.New("oidc: access denied"))
 		slog.WarnContext(r.Context(), "oidc: access denied",
 			"sub", claims.Subject, "groups", claims.Groups, "roles", claims.Roles)
 		jsonError(w, "access denied: user is not a member of the required group", http.StatusForbidden)
@@ -98,6 +118,8 @@ func (s *Server) handleOIDCConfidentialCallback(w http.ResponseWriter, r *http.R
 	}
 	if s.sessionManager == nil || s.webSessions == nil {
 		// Misconfiguration: OIDC enabled but no session plumbing wired.
+		err := errors.New("oidc: session store not configured")
+		tracing.RecordError(span, err)
 		slog.ErrorContext(r.Context(), "oidc: session store not configured",
 			"handled", false, "sub", claims.Subject)
 		jsonError(w, "session unavailable", http.StatusServiceUnavailable)
@@ -129,6 +151,7 @@ func (s *Server) handleOIDCConfidentialCallback(w http.ResponseWriter, r *http.R
 		ClaimsJSON:      marshalClaims(claims),
 	})
 	if err != nil {
+		tracing.RecordError(span, err)
 		slog.ErrorContext(r.Context(), "oidc: failed to create session",
 			"err", err, "handled", false, "sub", claims.Subject, "username", username)
 		jsonError(w, "session unavailable", http.StatusServiceUnavailable)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -14,6 +14,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/sync/singleflight"
 
+	"go.opentelemetry.io/otel/attribute"
+
 	"github.com/wiebe-xyz/funnelbarn/internal/auth"
 	"github.com/wiebe-xyz/funnelbarn/internal/domain"
 	"github.com/wiebe-xyz/funnelbarn/internal/environment"
@@ -677,6 +679,9 @@ func accessTokenExpired(ws repository.WebSession, now time.Time) bool {
 //   - transient failure (IdP down): serve stale within the grace window
 //     measured from the FIRST failure; past the window → row deleted, error
 func (s *Server) refreshSession(ctx context.Context, idHash string) (repository.WebSession, error) {
+	ctx, span := tracing.StartSpan(ctx, "oidc.refresh_session")
+	defer span.End()
+
 	// The refresh must complete even if the triggering request is canceled
 	// mid-rotation — losing the rotated refresh token kills the session.
 	// Waiting singleflight sharers also must not inherit a canceled context.
@@ -686,9 +691,11 @@ func (s *Server) refreshSession(ctx context.Context, idHash string) (repository.
 		if err != nil {
 			return nil, err
 		}
+		span.SetAttributes(attribute.String("oidc.sub", ws.IdpSub))
 		now := time.Now()
 		if !accessTokenExpired(ws, now) {
 			// Another flight already refreshed while we waited.
+			span.SetAttributes(attribute.String("oidc.refresh_outcome", "already_refreshed"))
 			return ws, nil
 		}
 
@@ -696,6 +703,7 @@ func (s *Server) refreshSession(ctx context.Context, idHash string) (repository.
 		if errors.Is(err, auth.ErrRefreshInvalid) {
 			// Revoked / rotated-elsewhere / user suspended: kill the session
 			// immediately. invalid_grant never gets grace.
+			span.SetAttributes(attribute.String("oidc.refresh_outcome", "invalid_grant"))
 			slog.InfoContext(bgCtx, "session refresh: invalid_grant, session revoked",
 				"username", ws.Username, "sub", ws.IdpSub)
 			_ = s.webSessions.DeleteWebSession(bgCtx, idHash)
@@ -713,11 +721,14 @@ func (s *Server) refreshSession(ctx context.Context, idHash string) (repository.
 				ws.RefreshFailingSince = failingSince
 			}
 			if now.Unix()-failingSince > int64(s.oidcRefreshGrace.Seconds()) {
+				span.SetAttributes(attribute.String("oidc.refresh_outcome", "grace_exceeded"))
+				tracing.RecordError(span, err)
 				slog.WarnContext(bgCtx, "session refresh: grace exceeded, session cut off",
 					"username", ws.Username, "failing_for", now.Unix()-failingSince)
 				_ = s.webSessions.DeleteWebSession(bgCtx, idHash)
 				return nil, err
 			}
+			span.SetAttributes(attribute.String("oidc.refresh_outcome", "stale_within_grace"))
 			slog.WarnContext(bgCtx, "session refresh failed, serving stale within grace",
 				"err", err, "username", ws.Username)
 			return ws, nil
@@ -735,10 +746,13 @@ func (s *Server) refreshSession(ctx context.Context, idHash string) (repository.
 			// The old refresh token is already burned; failing to store the new
 			// one makes the session unrenewable. Fail the request rather than
 			// pretend the session is healthy.
+			span.SetAttributes(attribute.String("oidc.refresh_outcome", "persist_error"))
+			tracing.RecordError(span, err)
 			slog.ErrorContext(bgCtx, "session refresh: persist rotated tokens",
 				"err", err, "handled", false)
 			return nil, err
 		}
+		span.SetAttributes(attribute.String("oidc.refresh_outcome", "rotated"))
 		ws.IDToken = refreshed.IDToken
 		ws.AccessToken = refreshed.AccessToken
 		ws.RefreshToken = refreshed.RefreshToken

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -18,6 +18,11 @@ import (
 
 	oidcv3 "github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/wiebe-xyz/funnelbarn/internal/metrics"
+	"github.com/wiebe-xyz/funnelbarn/internal/tracing"
 )
 
 // OIDCConfig is the static configuration for the OIDC login flow.
@@ -111,25 +116,47 @@ func (c *OIDCClient) ExchangeFull(ctx context.Context, code, nonce, verifier str
 	if verifier != "" {
 		opts = append(opts, oauth2.VerifierOption(verifier))
 	}
+	ctx, span := tracing.StartSpan(ctx, "oidc.exchange")
+	defer span.End()
+	start := time.Now()
+
 	tok, err := c.oauth.Exchange(ctx, code, opts...)
+	metrics.OIDCRequestDuration.WithLabelValues("exchange").Observe(time.Since(start).Seconds())
 	if err != nil {
-		return ExchangeResult{}, fmt.Errorf("oidc: token exchange: %w", err)
+		metrics.OIDCRequests.WithLabelValues("exchange", "error").Inc()
+		err = fmt.Errorf("oidc: token exchange: %w", err)
+		tracing.RecordError(span, err)
+		return ExchangeResult{}, err
 	}
 	rawID, ok := tok.Extra("id_token").(string)
 	if !ok || rawID == "" {
-		return ExchangeResult{}, errors.New("oidc: token response missing id_token")
+		metrics.OIDCRequests.WithLabelValues("exchange", "error").Inc()
+		err := errors.New("oidc: token response missing id_token")
+		tracing.RecordError(span, err)
+		return ExchangeResult{}, err
 	}
 	idToken, err := c.verifier.Verify(ctx, rawID)
 	if err != nil {
-		return ExchangeResult{}, fmt.Errorf("oidc: verify id_token: %w", err)
+		metrics.OIDCRequests.WithLabelValues("exchange", "error").Inc()
+		err = fmt.Errorf("oidc: verify id_token: %w", err)
+		tracing.RecordError(span, err)
+		return ExchangeResult{}, err
 	}
 	if idToken.Nonce != nonce {
-		return ExchangeResult{}, errors.New("oidc: nonce mismatch")
+		metrics.OIDCRequests.WithLabelValues("exchange", "error").Inc()
+		err := errors.New("oidc: nonce mismatch")
+		tracing.RecordError(span, err)
+		return ExchangeResult{}, err
 	}
 	var claims OIDCClaims
 	if err := idToken.Claims(&claims); err != nil {
-		return ExchangeResult{}, fmt.Errorf("oidc: decode claims: %w", err)
+		metrics.OIDCRequests.WithLabelValues("exchange", "error").Inc()
+		err = fmt.Errorf("oidc: decode claims: %w", err)
+		tracing.RecordError(span, err)
+		return ExchangeResult{}, err
 	}
+	metrics.OIDCRequests.WithLabelValues("exchange", "success").Inc()
+	span.SetAttributes(attribute.String("oidc.sub", claims.Subject))
 	return ExchangeResult{
 		Claims:       claims,
 		IDToken:      rawID,
@@ -175,14 +202,25 @@ func (c *OIDCClient) Refresh(ctx context.Context, refreshToken string) (Refreshe
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 
+	ctx, span := tracing.StartSpan(ctx, "oidc.refresh")
+	defer span.End()
+	start := time.Now()
+
 	tok, err := c.oauth.TokenSource(ctx, &oauth2.Token{RefreshToken: refreshToken}).Token()
+	metrics.OIDCRequestDuration.WithLabelValues("refresh").Observe(time.Since(start).Seconds())
 	if err != nil {
 		var retrieveErr *oauth2.RetrieveError
 		if errors.As(err, &retrieveErr) && retrieveErr.ErrorCode == "invalid_grant" {
+			metrics.OIDCRequests.WithLabelValues("refresh", "invalid_grant").Inc()
+			tracing.RecordError(span, ErrRefreshInvalid)
 			return RefreshedTokens{}, ErrRefreshInvalid
 		}
-		return RefreshedTokens{}, fmt.Errorf("oidc: refresh token: %w", err)
+		metrics.OIDCRequests.WithLabelValues("refresh", "error").Inc()
+		err = fmt.Errorf("oidc: refresh token: %w", err)
+		tracing.RecordError(span, err)
+		return RefreshedTokens{}, err
 	}
+	metrics.OIDCRequests.WithLabelValues("refresh", "success").Inc()
 	// golang.org/x/oauth2 falls back to the refresh_token we sent if the
 	// response omits one (its accommodation for non-rotating providers), so
 	// tok.RefreshToken is never empty here on a successful response —
@@ -221,6 +259,10 @@ func (c *OIDCClient) RevokeRefreshToken(ctx context.Context, refreshToken string
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 
+	ctx, span := tracing.StartSpan(ctx, "oidc.revoke")
+	defer span.End()
+	start := time.Now()
+
 	form := url.Values{}
 	form.Set("token", refreshToken)
 	form.Set("token_type_hint", "refresh_token")
@@ -228,18 +270,28 @@ func (c *OIDCClient) RevokeRefreshToken(ctx context.Context, refreshToken string
 	form.Set("client_secret", c.cfg.ClientSecret)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.revocationEndpoint, strings.NewReader(form.Encode()))
 	if err != nil {
+		metrics.OIDCRequests.WithLabelValues("revoke", "error").Inc()
+		tracing.RecordError(span, err)
 		return err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	resp, err := http.DefaultClient.Do(req)
+	metrics.OIDCRequestDuration.WithLabelValues("revoke").Observe(time.Since(start).Seconds())
 	if err != nil {
-		return fmt.Errorf("oidc: revoke refresh token: %w", err)
+		metrics.OIDCRequests.WithLabelValues("revoke", "error").Inc()
+		err = fmt.Errorf("oidc: revoke refresh token: %w", err)
+		tracing.RecordError(span, err)
+		return err
 	}
 	defer resp.Body.Close()
 	_, _ = io.Copy(io.Discard, resp.Body)
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("oidc: revoke refresh token: status %d", resp.StatusCode)
+		metrics.OIDCRequests.WithLabelValues("revoke", "error").Inc()
+		err := fmt.Errorf("oidc: revoke refresh token: status %d", resp.StatusCode)
+		tracing.RecordError(span, err)
+		return err
 	}
+	metrics.OIDCRequests.WithLabelValues("revoke", "success").Inc()
 	return nil
 }
 
@@ -289,9 +341,17 @@ func (c *OIDCClient) VerifyLogoutToken(ctx context.Context, raw string) (LogoutC
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 
+	ctx, span := tracing.StartSpan(ctx, "oidc.verify_logout_token")
+	defer span.End()
+	start := time.Now()
+
 	tok, err := c.verifier.Verify(ctx, raw)
+	metrics.OIDCRequestDuration.WithLabelValues("verify_logout_token").Observe(time.Since(start).Seconds())
 	if err != nil {
-		return LogoutClaims{}, fmt.Errorf("oidc: verify logout token: %w", err)
+		metrics.OIDCRequests.WithLabelValues("verify_logout_token", "error").Inc()
+		err = fmt.Errorf("oidc: verify logout token: %w", err)
+		tracing.RecordError(span, err)
+		return LogoutClaims{}, err
 	}
 	var claims struct {
 		Sub    string                     `json:"sub"`
@@ -301,24 +361,41 @@ func (c *OIDCClient) VerifyLogoutToken(ctx context.Context, raw string) (LogoutC
 		Events map[string]json.RawMessage `json:"events"`
 	}
 	if err := tok.Claims(&claims); err != nil {
-		return LogoutClaims{}, fmt.Errorf("oidc: decode logout token claims: %w", err)
+		metrics.OIDCRequests.WithLabelValues("verify_logout_token", "error").Inc()
+		err = fmt.Errorf("oidc: decode logout token claims: %w", err)
+		tracing.RecordError(span, err)
+		return LogoutClaims{}, err
 	}
 	if claims.Nonce != nil {
 		// The spec REQUIRES rejecting logout tokens with a nonce — it is what
 		// distinguishes them from ID tokens, blocking cross-protocol replay.
-		return LogoutClaims{}, errors.New("oidc: logout token must not contain nonce")
+		metrics.OIDCRequests.WithLabelValues("verify_logout_token", "error").Inc()
+		err := errors.New("oidc: logout token must not contain nonce")
+		tracing.RecordError(span, err)
+		return LogoutClaims{}, err
 	}
 	if _, ok := claims.Events[backchannelLogoutEvent]; !ok {
-		return LogoutClaims{}, errors.New("oidc: logout token missing backchannel-logout event")
+		metrics.OIDCRequests.WithLabelValues("verify_logout_token", "error").Inc()
+		err := errors.New("oidc: logout token missing backchannel-logout event")
+		tracing.RecordError(span, err)
+		return LogoutClaims{}, err
 	}
 	iat := time.Unix(claims.Iat, 0)
 	now := time.Now()
 	if claims.Iat == 0 || now.Sub(iat) > logoutTokenMaxAge || iat.Sub(now) > logoutTokenMaxAge {
-		return LogoutClaims{}, errors.New("oidc: logout token iat outside acceptance window")
+		metrics.OIDCRequests.WithLabelValues("verify_logout_token", "error").Inc()
+		err := errors.New("oidc: logout token iat outside acceptance window")
+		tracing.RecordError(span, err)
+		return LogoutClaims{}, err
 	}
 	if claims.Sub == "" && claims.Sid == "" {
-		return LogoutClaims{}, errors.New("oidc: logout token has neither sub nor sid")
+		metrics.OIDCRequests.WithLabelValues("verify_logout_token", "error").Inc()
+		err := errors.New("oidc: logout token has neither sub nor sid")
+		tracing.RecordError(span, err)
+		return LogoutClaims{}, err
 	}
+	metrics.OIDCRequests.WithLabelValues("verify_logout_token", "success").Inc()
+	span.SetAttributes(attribute.String("oidc.sid", claims.Sid))
 	return LogoutClaims{Subject: claims.Sub, SessionID: claims.Sid}, nil
 }
 
@@ -349,11 +426,21 @@ func (c *OIDCClient) ensureReady(ctx context.Context) error {
 	}
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
+
+	ctx, span := tracing.StartSpan(ctx, "oidc.discover", attribute.String("oidc.issuer", c.cfg.Issuer))
+	defer span.End()
+	start := time.Now()
+
 	issuer := strings.TrimRight(c.cfg.Issuer, "/")
 	prov, err := oidcv3.NewProvider(ctx, issuer)
+	metrics.OIDCRequestDuration.WithLabelValues("discover").Observe(time.Since(start).Seconds())
 	if err != nil {
-		return fmt.Errorf("oidc: discover issuer %q: %w", c.cfg.Issuer, err)
+		metrics.OIDCRequests.WithLabelValues("discover", "error").Inc()
+		err = fmt.Errorf("oidc: discover issuer %q: %w", c.cfg.Issuer, err)
+		tracing.RecordError(span, err)
+		return err
 	}
+	metrics.OIDCRequests.WithLabelValues("discover", "success").Inc()
 	c.provider = prov
 	// Revocation + end-session endpoints are optional discovery fields; fall
 	// back to iambarn's conventional paths when the document omits them.


### PR DESCRIPTION
Follow-up to #203: upstream's OIDC relying-party rewrite (#200/#201) replaced the IAMBarn client after the original observability pass had already instrumented it, so that instrumentation was dropped during the production-merge rebase rather than rushed through a conflict resolution in security-sensitive code.

Wires the already-defined but previously-unused `OIDCRequests`/`OIDCRequestDuration` Prometheus metrics into the actual OIDC client (discover, exchange, refresh, revoke, verify_logout_token), and adds spans across login start/callback, logout, backchannel-logout, and the singleflighted session-refresh grace-window logic, recording errors at every failure branch.