### PR TITLE
Win f.<domain> ingest over co-located app subdomain routes (#206 follow-up)

### DIFF
--- a/deploy/RUNBOOK.md
+++ b/deploy/RUNBOOK.md
@@ -168,6 +168,24 @@ the `f.` label and sends the visitor to the app the host fronts (e.g. `https://f
 endpoint. The redirect lives in the Go app (`internal/api/server.go`) and fires for `GET`/`HEAD` on
 any non-ingest path; the dashboard SPA is never exposed on customer domains.
 
+**Co-located app collision (why the ingest routes run at `priority: 200`).** When the consuming app
+is deployed on this *same* cluster and greedily claims all of its own subdomains, its IngressRoute
+will otherwise swallow `f.<its-domain>` before FunnelBarn sees it. Real case: `profotograaf`'s app
+(`profotograaf-production/profotograaf-profotograaf-subdomain`) matches `HostRegexp(^…\.profotograaf\.nl$)`
+— i.e. *all* of `*.profotograaf.nl`, including `f.profotograaf.nl` — with priority up to 115 on `/api`.
+FunnelBarn's ingest routes therefore run at **priority 200** so the reserved `f.` label wins ingest
+regardless of any co-located app. The `f.` label is reserved for FunnelBarn; the root redirect stays
+at `priority: 1`, so `f.<domain>/` still lands on a co-located app's own root (which is the point of
+the redirect anyway). **The same collision breaks `sb.`/`bb.`/`iam.` on such a domain** — each barn
+tool must assert its own prefix priority (or the app must exclude the reserved labels from its matcher).
+
+**Debugging tip:** if `f.<domain>` 404s, `curl -sI` it and check whether the response is from your
+cluster or the customer's edge. A `server: cloudflare` 404 with the host resolving into the *customer's*
+Cloudflare zone means their DNS isn't pointed at the shared cluster yet (onboarding step 1). If it
+resolves to the shared cluster and *still* 404s, hit the origin directly
+(`curl -k --resolve f.<domain>:443:<cluster-ip> https://f.<domain>/api/v1/health`) — a 404 there is a
+Traefik routing collision with a co-located app (see the priority note above).
+
 **Onboarding a customer (one-time, DNS side only):**
 
 1. Point `f.<brand>` at the shared cluster — a CNAME to the same target the customer's other barn

--- a/deploy/k8s/production/ingressroute-f-wildcard.yaml
+++ b/deploy/k8s/production/ingressroute-f-wildcard.yaml
@@ -18,11 +18,20 @@
 # the `f.` label — see internal/api/server.go). So a customer can hand out `f.<brand>` as a friendly
 # link and a browser hitting it lands on their app, while the SDK still ingests to the same host.
 # The dashboard SPA is NOT exposed on customer domains — non-ingest paths only ever reach the Go
-# service, never funnelbarn-web. `priority: 1` keeps any concrete per-host Ingress that deliberately
-# overrides the default (e.g. f.bananasketch.nl, which exposes its own SPA on funnelbarn-web with a
-# Cloudflare-issued cert) winning for its own host and TLS; the three routes below match disjoint path
-# sets, so they never tie at equal priority. Any other f.<domain> is served entirely by this route —
-# onboarding a new project is DNS-only (CNAME + port 80 for ACME), no manifest change.
+# service, never funnelbarn-web. Any other f.<domain> is served entirely by this route — onboarding a
+# new project is DNS-only (CNAME + port 80 for ACME), no manifest change.
+#
+# PRIORITIES — the `f.` label is RESERVED for FunnelBarn ingest, so the ingest paths must win even when
+# a consuming app is co-located on this same cluster and greedily claims all of its own subdomains.
+# That is exactly what profotograaf does: its `profotograaf-profotograaf-subdomain` IngressRoute matches
+# `HostRegexp(^…\.profotograaf\.nl$)` (i.e. ALL of *.profotograaf.nl, including f.profotograaf.nl) with
+# priority up to 115 on `/api`. A pinned `priority: 1` here loses that race, so f.profotograaf.nl/api
+# silently 404s into the profotograaf app (the #206 incident). So the ingest routes below run at a high
+# priority (200) to decisively win `f.*` ingest over any co-located app; they route to the SAME services
+# a concrete f.<host> Ingress would (funnelbarn / funnelbarn-web), so this never changes a destination —
+# it only wins the tie. The bare-host redirect (root) stays at `priority: 1` so a concrete per-host
+# Ingress that deliberately exposes its own SPA (f.bananasketch.nl → funnelbarn-web) still wins its root,
+# and a co-located app keeps serving its own root — the browser lands on the app either way.
 #
 # Onboarding a customer: point f.<brand> at the shared cluster (CNAME, same target as bt.*/sb.*) with
 # port 80 reachable so the HTTP-01 ACME challenge can validate. See deploy/RUNBOOK.md §"Custom ingest domain".
@@ -34,21 +43,24 @@ spec:
   entryPoints:
     - websecure
   routes:
+    # Reserved-prefix ingest routes: priority 200 so `f.*` ingest wins over any co-located app that
+    # greedily claims its own subdomains (see the PRIORITIES note above). Same destinations a concrete
+    # f.<host> Ingress would use, so winning the tie never changes where a request goes.
     - match: HostRegexp(`^f\..+$`) && (Path(`/sdk.js`) || Path(`/sdk/funnelbarn.js`))
       kind: Rule
-      priority: 1
+      priority: 200
       services:
         - name: funnelbarn-web
           port: 3000
     - match: HostRegexp(`^f\..+$`) && PathPrefix(`/api`)
       kind: Rule
-      priority: 1
+      priority: 200
       services:
         - name: funnelbarn
           port: 8080
     # Bare-host redirect: every non-ingest, non-SDK path (root `/` and anything else) goes to the Go
-    # service, which 301s it to https://<domain> (drops the `f.` label). Disjoint from the two routes
-    # above, so priority: 1 is safe. Keeps the dashboard SPA off customer domains (Go service only).
+    # service, which 301s it to https://<domain> (drops the `f.` label). Kept at priority: 1 so a
+    # concrete per-host Ingress (f.bananasketch.nl → its own SPA) or a co-located app keeps its own root.
     - match: HostRegexp(`^f\..+$`) && !PathPrefix(`/api`) && !Path(`/sdk.js`) && !Path(`/sdk/funnelbarn.js`)
       kind: Rule
       priority: 1


### PR DESCRIPTION
## Summary

Follow-up to #207. After DNS for `f.profotograaf.nl` was pointed at the shared cluster, ingest **still 404'd** — but not due to DNS or the FunnelBarn deploy. It's a **cross-namespace Traefik routing collision**: profotograaf's own app is co-located on the same cluster and its `profotograaf-profotograaf-subdomain` IngressRoute greedily matches `HostRegexp(^…\.profotograaf\.nl$)` (all of `*.profotograaf.nl`, including `f.profotograaf.nl`) at **priority up to 115** on `/api`. FunnelBarn's `f.*` wildcard was pinned at **priority 1**, so `f.profotograaf.nl/api/v1/events` was grabbed by the profotograaf app → 404, and FunnelBarn got no analytics (the #206 incident). The same collision also breaks `sb.`/`bb.`/`iam.` on that domain.

## Change

The `f.` label is **reserved** for FunnelBarn ingest, so raise the ingest routes to win decisively:

| Route | Before | After |
|---|---|---|
| `f.*` `/api/*` → funnelbarn | priority 1 | **priority 200** |
| `f.*` `/sdk.js`, `/sdk/funnelbarn.js` → funnelbarn-web | priority 1 | **priority 200** |
| `f.*` root (bare-host 301) → funnelbarn | priority 1 | priority 1 (unchanged) |

The ingest routes point at the **same** services a concrete `f.<host>` Ingress would, so winning the tie never changes a destination — `f.bananasketch.nl` (concrete SPA Ingress) and the canonical host are unaffected. The root redirect stays low so a co-located app keeps serving its own root (the browser lands on the app either way — the intent of the redirect).

## Verification plan (post-deploy)

```sh
# co-located app domain — was 404, should ingest now:
curl -sk -o /dev/null -w "%{http_code}\n" --resolve f.profotograaf.nl:443:<cluster-ip> \
  https://f.profotograaf.nl/api/v1/health          # expect 200

# no regression on hosts that already worked:
curl -sk --resolve f.bananasketch.nl:443:<cluster-ip> https://f.bananasketch.nl/     # expect 200 (SPA)
curl -sk --resolve funnelbarn.wiebe.xyz:443:<cluster-ip> https://funnelbarn.wiebe.xyz/  # expect 200
```

## Notes

- **`sb.`/`bb.`/`iam.` on profotograaf are broken by the same route** — each barn tool must assert its own prefix priority (or the app must exclude the reserved labels). Out of scope here; flagged in the RUNBOOK.
- RUNBOOK documents the collision and a curl-based debugging recipe.

Refs #206