### PR TITLE
chore: upgrade Go toolchain to 1.26

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -184,14 +184,11 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Install nfpm
-        # Pin nfpm: v2.47.0+ bumped its go directive to go 1.26.4, which fails
-        # `go install` under GOTOOLCHAIN=local on the go 1.25 runner. v2.46.0 is the
-        # newest release still on the go 1.25 line. Bump when the runner's Go is >= 1.26.
-        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.46.0
+        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
 
       - name: Build binary
         env:
@@ -237,7 +234,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Build macOS binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: go fmt
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Go tests with race detector

--- a/deploy/docker/service.Dockerfile
+++ b/deploy/docker/service.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS build
+FROM golang:1.26-alpine AS build
 
 RUN apk add --no-cache gcc musl-dev
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wiebe-xyz/funnelbarn
 
-go 1.25.7
+go 1.26.0
 
 require (
 	github.com/XSAM/otelsql v0.42.0
@@ -64,7 +64,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/log v0.20.0 // indirect
-	go.opentelemetry.io/otel/metric v1.44.0 // indirect
+	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect


### PR DESCRIPTION
## Why

CI on `main` is red: `staticcheck@latest` now needs `go >= 1.26.0` and the
runners are on 1.25 with `GOTOOLCHAIN=local`, so the `go-quality` job fails
before it runs a single check. The same wall previously broke
`Binary Release` via `nfpm@latest` (v2.47.0 moved to `go 1.26.4`), which
#191 papered over by pinning nfpm to v2.46.0.

Holding the tooling back doesn't scale — move the toolchain forward.

## Changes

- `go.mod`: `go 1.25.7` → `go 1.26.0`
- `.github/workflows/ci.yml`, `.github/workflows/binary-release.yml`:
  `setup-go` `1.25` → `1.26`
- `deploy/docker/service.Dockerfile`: `golang:1.25-alpine` → `golang:1.26-alpine`
- Drop the nfpm `v2.46.0` pin from #191, back to `@latest`

## Note on the self-hosted runners

The issue listed provisioning Go 1.26 on `mac-mini-funnelbarn-mac-*` as a
prerequisite. It isn't one: every job that runs Go (`go-quality`, `go-test`,
`build-debs`, `build-darwin-tarballs`) is on `ubuntu-latest`, so
`actions/setup-go` provisions the toolchain. The self-hosted runners only do
Docker builds and `kubectl` deploys, and the Docker build gets its Go from
the `golang:1.26-alpine` build stage.

Closes #192