### PR TITLE
fix(ingest): stop silently dropping events that name no project

### DIFF
--- a/cmd/funnelbarn/cli.go
+++ b/cmd/funnelbarn/cli.go
@@ -74,6 +74,89 @@ func runWorkerOnce(cfg config.Config) error {
 	return nil
 }
 
+// runReplayDeadLetter re-processes the dead-letter spool. Records that failed
+// only because they could not be attributed to a project (the dominant cause —
+// an instance-wide API key sent with no x-funnelbarn-project header) are
+// replayable once the operator names the project they belong to, which is what
+// --project does. Without it, only records that carry their own slug replay.
+//
+// The dead-letter file is truncated only when every record was applied, so a
+// partial run can be retried without losing the remainder.
+func runReplayDeadLetter(cfg config.Config, args []string) error {
+	fs := flag.NewFlagSet("replay-dead-letter", flag.ContinueOnError)
+	project := fs.String("project", "", "project slug to attribute records that carry none")
+	dryRun := fs.Bool("dry-run", false, "report what would be replayed without writing")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	store, err := repository.Open(cfg.DBPath)
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	records, err := spool.ReadRecords(spool.DeadLetterPath(cfg.SpoolDir))
+	if err != nil {
+		return err
+	}
+
+	ctx, span := tracing.StartSpan(context.Background(), "worker.replay_dead_letter",
+		attribute.Int("records", len(records)),
+	)
+	defer span.End()
+
+	var replayed, skipped int
+	for _, record := range records {
+		slug := record.ProjectSlug
+		if slug == "" {
+			slug = *project
+		}
+		if slug == "" {
+			skipped++
+			slog.Warn("replay: record has no project slug and no --project given", "ingest_id", record.IngestID)
+			continue
+		}
+
+		event, err := worker.SafeProcess(record)
+		if err != nil {
+			skipped++
+			slog.Error("replay: process record", "ingest_id", record.IngestID, "err", err)
+			continue
+		}
+
+		proj, projErr := store.EnsureProject(ctx, slug)
+		if projErr != nil {
+			skipped++
+			slog.Error("replay: resolve project", "ingest_id", record.IngestID, "slug", slug, "err", projErr)
+			continue
+		}
+		event.ProjectID = proj.ID
+
+		if *dryRun {
+			replayed++
+			continue
+		}
+		if err := worker.PersistEvent(ctx, store, event, nil); err != nil {
+			skipped++
+			slog.Error("replay: persist event", "ingest_id", record.IngestID, "err", err)
+			continue
+		}
+		replayed++
+	}
+
+	span.SetAttributes(attribute.Int("replayed", replayed), attribute.Int("skipped", skipped))
+
+	if !*dryRun && skipped == 0 && len(records) > 0 {
+		if err := spool.TruncateDeadLetter(cfg.SpoolDir); err != nil {
+			return fmt.Errorf("truncate dead-letter spool: %w", err)
+		}
+	}
+
+	fmt.Printf("{\"records\":%d,\"replayed\":%d,\"skipped\":%d,\"dry_run\":%t}\n", len(records), replayed, skipped, *dryRun)
+	return nil
+}
+
 // runUserCmd handles: funnelbarn user create --username=X --password=Y
 func runUserCmd(cfg config.Config, args []string) error {
 	if len(args) == 0 {

--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -489,6 +489,36 @@ const (
 	workerRotateThreshold = 64 << 20 // 64 MiB
 )
 
+// deadLetterRecord parks an unprocessable record and advances the cursor past
+// it, so one bad record can never wedge the spool. reason labels the metric:
+// "dead_letter" for a record that exhausted its retries, "unresolved_project"
+// for one that could never have been persisted at all. Returns the new offset.
+func deadLetterRecord(spoolDir string, record spool.Record, endOffset int64, reason string) int64 {
+	if err := spool.AppendDeadLetter(spoolDir, record); err != nil {
+		slog.Error("worker dead-letter write", "ingest_id", record.IngestID, "err", err)
+	}
+	metrics.EventErrors.WithLabelValues(reason).Inc()
+	if err := spool.WriteCursor(spoolDir, endOffset); err != nil {
+		slog.Error("worker write cursor", "err", err)
+	}
+	return endOffset
+}
+
+// resolveEventProject looks up the project a spool record belongs to. A record
+// with no slug, or one whose slug can never resolve, comes back wrapped in
+// repository.ErrProjectUnresolvable: events.project_id is NOT NULL REFERENCES
+// projects(id), so persisting it could only ever fail the foreign key.
+func resolveEventProject(ctx context.Context, store *repository.Store, slug string) (string, error) {
+	if slug == "" {
+		return "", fmt.Errorf("%w: spool record carries no project slug", repository.ErrProjectUnresolvable)
+	}
+	proj, err := store.EnsureProject(ctx, slug)
+	if err != nil {
+		return "", err
+	}
+	return proj.ID, nil
+}
+
 func runBackgroundWorker(ctx context.Context, cfg config.Config, store *repository.Store, eventSpool *spool.Spool, geoLookup *geoip.Lookup, recordings service.Recordings) {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
@@ -633,15 +663,8 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 							"ingest_id", record.IngestID,
 							"attempts", retryCounts[record.IngestID],
 						)
-						if dlErr := spool.AppendDeadLetter(cfg.SpoolDir, record); dlErr != nil {
-							slog.Error("worker dead-letter write", "ingest_id", record.IngestID, "err", dlErr)
-						}
-						metrics.EventErrors.WithLabelValues("dead_letter").Inc()
 						delete(retryCounts, record.IngestID)
-						offset = entry.EndOffset
-						if err := spool.WriteCursor(cfg.SpoolDir, offset); err != nil {
-							slog.Error("worker write cursor", "err", err)
-						}
+						offset = deadLetterRecord(cfg.SpoolDir, record, entry.EndOffset, "dead_letter")
 					} else {
 						metrics.EventErrors.WithLabelValues("retry").Inc()
 					}
@@ -657,40 +680,26 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 					attribute.String("ingest.id", record.IngestID),
 					attribute.String("project.slug", record.ProjectSlug),
 				)
-				// Resolve the project up front. Without a project ID the insert
-				// can only fail the events.project_id foreign key, so a record
-				// we cannot attribute is unrecoverable: dead-letter it now
-				// rather than retrying an insert that is guaranteed to fail.
-				projectErr := error(nil)
-				if record.ProjectSlug == "" {
-					projectErr = fmt.Errorf("%w: spool record carries no project slug", repository.ErrProjectUnresolvable)
-				} else if proj, err := store.EnsureProject(opCtx, record.ProjectSlug); err == nil {
-					event.ProjectID = proj.ID
-				} else {
-					projectErr = err
-				}
-				if projectErr != nil {
-					if errors.Is(projectErr, repository.ErrProjectUnresolvable) {
-						tracing.RecordError(span, projectErr)
-						span.End()
-						opCancel()
-						slog.Error("worker dead-lettering record: project cannot be resolved",
-							"err", projectErr, "handled", false,
-							"ingest_id", record.IngestID,
-							"project_slug", record.ProjectSlug,
-							"event_name", event.Name,
-						)
-						if dlErr := spool.AppendDeadLetter(cfg.SpoolDir, record); dlErr != nil {
-							slog.Error("worker dead-letter write", "ingest_id", record.IngestID, "err", dlErr)
-						}
-						metrics.EventErrors.WithLabelValues("unresolved_project").Inc()
-						delete(retryCounts, record.IngestID)
-						offset = entry.EndOffset
-						if err := spool.WriteCursor(cfg.SpoolDir, offset); err != nil {
-							slog.Error("worker write cursor", "err", err)
-						}
-						continue
-					}
+				projectID, projectErr := resolveEventProject(opCtx, store, record.ProjectSlug)
+				switch {
+				case projectErr == nil:
+					event.ProjectID = projectID
+				case errors.Is(projectErr, repository.ErrProjectUnresolvable):
+					// Unrecoverable: retrying an insert that must fail the
+					// project_id foreign key only burns attempts.
+					tracing.RecordError(span, projectErr)
+					span.End()
+					opCancel()
+					slog.Error("worker dead-lettering record: project cannot be resolved",
+						"err", projectErr, "handled", false,
+						"ingest_id", record.IngestID,
+						"project_slug", record.ProjectSlug,
+						"event_name", event.Name,
+					)
+					delete(retryCounts, record.IngestID)
+					offset = deadLetterRecord(cfg.SpoolDir, record, entry.EndOffset, "unresolved_project")
+					continue
+				default:
 					// A transient lookup failure (DB busy, timeout) — leave
 					// ProjectID unset and let the persist path retry the record.
 					slog.Warn("worker ensure project", "slug", record.ProjectSlug, "err", projectErr, "handled", true)
@@ -730,15 +739,8 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 						slog.Error("worker dead-lettering record after persist failures",
 							"ingest_id", record.IngestID,
 						)
-						if dlErr := spool.AppendDeadLetter(cfg.SpoolDir, record); dlErr != nil {
-							slog.Error("worker dead-letter write", "ingest_id", record.IngestID, "err", dlErr)
-						}
-						metrics.EventErrors.WithLabelValues("dead_letter").Inc()
 						delete(retryCounts, record.IngestID)
-						offset = entry.EndOffset
-						if err := spool.WriteCursor(cfg.SpoolDir, offset); err != nil {
-							slog.Error("worker write cursor", "err", err)
-						}
+						offset = deadLetterRecord(cfg.SpoolDir, record, entry.EndOffset, "dead_letter")
 					} else {
 						metrics.EventErrors.WithLabelValues("retry").Inc()
 					}

--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -130,6 +130,8 @@ func run() error {
 			return nil
 		case "worker-once":
 			return runWorkerOnce(cfg)
+		case "replay-dead-letter":
+			return runReplayDeadLetter(cfg, os.Args[2:])
 		case "user":
 			return runUserCmd(cfg, os.Args[2:])
 		case "project":
@@ -655,13 +657,43 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 					attribute.String("ingest.id", record.IngestID),
 					attribute.String("project.slug", record.ProjectSlug),
 				)
-				if record.ProjectSlug != "" {
-					proj, err := store.EnsureProject(opCtx, record.ProjectSlug)
-					if err == nil {
-						event.ProjectID = proj.ID
-					} else {
-						slog.Warn("worker ensure project", "slug", record.ProjectSlug, "err", err)
+				// Resolve the project up front. Without a project ID the insert
+				// can only fail the events.project_id foreign key, so a record
+				// we cannot attribute is unrecoverable: dead-letter it now
+				// rather than retrying an insert that is guaranteed to fail.
+				projectErr := error(nil)
+				if record.ProjectSlug == "" {
+					projectErr = fmt.Errorf("%w: spool record carries no project slug", repository.ErrProjectUnresolvable)
+				} else if proj, err := store.EnsureProject(opCtx, record.ProjectSlug); err == nil {
+					event.ProjectID = proj.ID
+				} else {
+					projectErr = err
+				}
+				if projectErr != nil {
+					if errors.Is(projectErr, repository.ErrProjectUnresolvable) {
+						tracing.RecordError(span, projectErr)
+						span.End()
+						opCancel()
+						slog.Error("worker dead-lettering record: project cannot be resolved",
+							"err", projectErr, "handled", false,
+							"ingest_id", record.IngestID,
+							"project_slug", record.ProjectSlug,
+							"event_name", event.Name,
+						)
+						if dlErr := spool.AppendDeadLetter(cfg.SpoolDir, record); dlErr != nil {
+							slog.Error("worker dead-letter write", "ingest_id", record.IngestID, "err", dlErr)
+						}
+						metrics.EventErrors.WithLabelValues("unresolved_project").Inc()
+						delete(retryCounts, record.IngestID)
+						offset = entry.EndOffset
+						if err := spool.WriteCursor(cfg.SpoolDir, offset); err != nil {
+							slog.Error("worker write cursor", "err", err)
+						}
+						continue
 					}
+					// A transient lookup failure (DB busy, timeout) — leave
+					// ProjectID unset and let the persist path retry the record.
+					slog.Warn("worker ensure project", "slug", record.ProjectSlug, "err", projectErr, "handled", true)
 				}
 
 				var geoResult *geoip.GeoResult

--- a/cmd/funnelbarn/main_test.go
+++ b/cmd/funnelbarn/main_test.go
@@ -1,10 +1,16 @@
 package main
 
 import (
+	"context"
+	"encoding/base64"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/wiebe-xyz/funnelbarn/internal/config"
+	"github.com/wiebe-xyz/funnelbarn/internal/repository"
+	"github.com/wiebe-xyz/funnelbarn/internal/spool"
 )
 
 func TestBuildOIDCClient_NilWhenUnconfigured(t *testing.T) {
@@ -140,5 +146,58 @@ func TestRunAPIKeyCmd_Validation(t *testing.T) {
 	err := runAPIKeyCmd(config.Config{}, []string{"create", "--name=app", "--scope=wat"})
 	if err == nil || !strings.Contains(err.Error(), "scope") {
 		t.Errorf("expected scope validation error, got %v", err)
+	}
+}
+
+// Dead-lettered events are recoverable: replay re-attributes records that
+// carry no project slug to --project, persists them, and clears the file only
+// when every record landed.
+func TestRunReplayDeadLetter(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Config{DBPath: filepath.Join(dir, "test.db"), SpoolDir: dir}
+
+	body := base64.StdEncoding.EncodeToString([]byte(`{"name":"pageview","url":"https://example.com/x"}`))
+	// No projectSlug — exactly the shape that used to fail the project_id
+	// foreign key and get dead-lettered.
+	rec := spool.Record{IngestID: "dl-1", ReceivedAt: time.Now().UTC(), BodyBase64: body}
+	if err := spool.AppendDeadLetter(dir, rec); err != nil {
+		t.Fatalf("AppendDeadLetter: %v", err)
+	}
+
+	// Without --project there is nothing to attribute the record to, so it is
+	// skipped and the file is left intact for a later, correct replay.
+	if err := runReplayDeadLetter(cfg, []string{"--dry-run"}); err != nil {
+		t.Fatalf("dry run: %v", err)
+	}
+	left, err := spool.ReadRecords(spool.DeadLetterPath(dir))
+	if err != nil {
+		t.Fatalf("ReadRecords: %v", err)
+	}
+	if len(left) != 1 {
+		t.Fatalf("expected the record to survive a skipped replay, got %d", len(left))
+	}
+
+	if err := runReplayDeadLetter(cfg, []string{"--project=recovered"}); err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	left, err = spool.ReadRecords(spool.DeadLetterPath(dir))
+	if err != nil {
+		t.Fatalf("ReadRecords after replay: %v", err)
+	}
+	if len(left) != 0 {
+		t.Errorf("expected the dead-letter file to be cleared after a clean replay, got %d records", len(left))
+	}
+
+	store, err := repository.Open(cfg.DBPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer store.Close()
+	got, err := store.GetEventByIngestID(context.Background(), "dl-1")
+	if err != nil || got == nil {
+		t.Fatalf("expected the replayed event to be stored, got %v (err %v)", got, err)
+	}
+	if got.ProjectID == "" {
+		t.Error("replayed event should be attributed to the --project project")
 	}
 }

--- a/deploy/RUNBOOK.md
+++ b/deploy/RUNBOOK.md
@@ -302,6 +302,49 @@ Replace `funnelbarn-production` with `funnelbarn-staging` or `funnelbarn-testing
 
 ---
 
+## 4b. Recovering dead-lettered events
+
+An event the worker cannot persist after `FUNNELBARN_WORKER_MAX_RETRIES`
+attempts is appended to `deadletter.ndjson` in the spool directory rather than
+discarded. The dominant cause is an event that names no project: an
+instance-wide API key sent without an `x-funnelbarn-project` header leaves
+`project_id` empty, and `events.project_id` is `NOT NULL REFERENCES
+projects(id)`, so the insert fails the foreign key every time. (The ingest
+endpoint now rejects those with a 400 up front, so new traffic no longer
+reaches this state — this is for recovering what was already dropped.)
+
+Check what is sitting there:
+
+```sh
+kubectl -n funnelbarn-production exec deploy/funnelbarn -- \
+  sh -c 'wc -l "$FUNNELBARN_SPOOL_DIR/deadletter.ndjson"'
+```
+
+Preview a replay without writing anything:
+
+```sh
+kubectl -n funnelbarn-production exec deploy/funnelbarn -- \
+  funnelbarn replay-dead-letter --project=<slug> --dry-run
+```
+
+Then replay for real. Records that carry their own project slug are
+re-attributed to it; `--project` supplies one for the records that do not:
+
+```sh
+kubectl -n funnelbarn-production exec deploy/funnelbarn -- \
+  funnelbarn replay-dead-letter --project=<slug>
+```
+
+Both commands print `{"records":N,"replayed":N,"skipped":N,"dry_run":bool}`.
+The file is truncated only when `skipped` is `0`, so a partial run can be
+retried safely — persistence is idempotent on `ingest_id`, and already-stored
+events are skipped rather than duplicated.
+
+> Only pass `--project` when you know the events belong to that project.
+> Attributing them to the wrong one is worse than leaving them dead-lettered.
+
+---
+
 ## 5. Log Access
 
 ### Tail service logs (production)

--- a/internal/ingest/handler.go
+++ b/internal/ingest/handler.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -35,6 +36,43 @@ type Handler struct {
 	// OnEventsReceived is called once per request after successful auth.
 	// It is optional; set by the server to track integration health.
 	OnEventsReceived func(ctx context.Context, projectID string)
+
+	// unattributedMu guards the throttle for the "no resolvable project" alert.
+	unattributedMu     sync.Mutex
+	lastUnattributedAt time.Time
+}
+
+// unattributedReAlert is the minimum gap between error-level alerts for events
+// that arrive without a resolvable project. One misconfigured client can send
+// thousands a day; the condition must be visible without flooding BugBarn, so
+// the first occurrence in each window escalates and the rest stay at warn.
+const unattributedReAlert = time.Hour
+
+// logUnattributed reports an event that could not be attributed to a project.
+// The first occurrence per unattributedReAlert window is an error (so it
+// reaches BugBarn as an issue); subsequent ones are warns.
+func (h *Handler) logUnattributed(r *http.Request) {
+	now := h.now()
+	h.unattributedMu.Lock()
+	escalate := h.lastUnattributedAt.IsZero() || now.Sub(h.lastUnattributedAt) >= unattributedReAlert
+	if escalate {
+		h.lastUnattributedAt = now
+	}
+	h.unattributedMu.Unlock()
+
+	const msg = "ingest: event rejected, no project could be resolved from the API key or x-funnelbarn-project header"
+	if escalate {
+		slog.ErrorContext(r.Context(), msg,
+			"err", errors.New("unattributed ingest event"), "handled", false,
+			"user_agent", r.Header.Get("User-Agent"),
+			"origin", r.Header.Get("Origin"),
+		)
+		return
+	}
+	slog.WarnContext(r.Context(), msg, "handled", true,
+		"user_agent", r.Header.Get("User-Agent"),
+		"origin", r.Header.Get("Origin"),
+	)
 }
 
 // NewHandler creates an ingest Handler.
@@ -195,6 +233,19 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	projectSlug := projectID
 	if projectSlug == "" {
 		projectSlug = r.Header.Get("x-funnelbarn-project")
+	}
+
+	// An event we cannot attribute to a project has nowhere to land:
+	// events.project_id is NOT NULL REFERENCES projects(id), so the worker's
+	// INSERT fails the foreign-key check (SQLITE_CONSTRAINT_FOREIGNKEY, 787)
+	// and the record is dead-lettered minutes after the client was told 202.
+	// That is silent data loss — the caller has already moved on. Refuse it
+	// here instead, where the response can name the fix.
+	if projectSlug == "" {
+		metrics.EventsRejected.WithLabelValues("unattributed").Inc()
+		h.logUnattributed(r)
+		jsonErr(w, "event cannot be attributed to a project — use a project-scoped API key from the project settings page, or send the project slug in the x-funnelbarn-project header", http.StatusBadRequest)
+		return
 	}
 
 	record := spool.Record{

--- a/internal/ingest/handler_test.go
+++ b/internal/ingest/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/wiebe-xyz/funnelbarn/internal/auth"
 	"github.com/wiebe-xyz/funnelbarn/internal/spool"
@@ -101,6 +102,9 @@ func TestServeHTTP_Accepted(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(auth.HeaderAPIKey, "mykey")
+	// The static env-var key is instance-wide and resolves with no project, so
+	// the event has to name one itself.
+	req.Header.Set("x-funnelbarn-project", "my-site")
 
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
@@ -221,4 +225,84 @@ func TestStart_DrainOnCancel(t *testing.T) {
 
 	cancel()
 	<-done // should complete promptly after cancel
+}
+
+// ---------------------------------------------------------------------------
+// ServeHTTP — unattributable events
+// ---------------------------------------------------------------------------
+
+// An instance-wide key with no x-funnelbarn-project header leaves the event
+// with no project. events.project_id is NOT NULL REFERENCES projects(id), so
+// the worker could only ever fail its insert on the foreign key and
+// dead-letter the record — long after the client saw a 202. Reject it here.
+func TestServeHTTP_RejectsUnattributedEvent(t *testing.T) {
+	sp := newTestSpool(t)
+	h := NewHandler(auth.New("mykey"), sp, 0)
+
+	body := `{"name":"pageview","url":"https://example.com/page"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(auth.HeaderAPIKey, "mykey")
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for an event with no resolvable project, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "x-funnelbarn-project") {
+		t.Errorf("error message should name the fix, got %s", w.Body.String())
+	}
+}
+
+// The header is only trusted when the key is not bound to a project; a
+// project-scoped key attributes the event on its own.
+func TestServeHTTP_ProjectScopedKeyNeedsNoHeader(t *testing.T) {
+	sp := newTestSpool(t)
+	lookup := func(_ context.Context, _ string) (string, string, bool, error) {
+		return "proj-123", "ingest", true, nil
+	}
+	h := NewHandler(auth.New("static").WithDBLookup(lookup, nil), sp, 0)
+
+	body := `{"name":"pageview"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(auth.HeaderAPIKey, "project-key")
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 for a project-scoped key, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+// The alert escalates to error level once per window and stays at warn in
+// between, so one misconfigured client cannot flood the issue tracker.
+func TestLogUnattributed_ThrottlesEscalation(t *testing.T) {
+	sp := newTestSpool(t)
+	h := NewHandler(auth.New("mykey"), sp, 0)
+
+	now := time.Unix(1_700_000_000, 0)
+	h.now = func() time.Time { return now }
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader("{}"))
+
+	h.logUnattributed(req)
+	first := h.lastUnattributedAt
+	if first.IsZero() {
+		t.Fatal("first occurrence should escalate and stamp the throttle")
+	}
+
+	now = now.Add(unattributedReAlert / 2)
+	h.logUnattributed(req)
+	if !h.lastUnattributedAt.Equal(first) {
+		t.Error("must not re-escalate inside the re-alert window")
+	}
+
+	now = now.Add(unattributedReAlert)
+	h.logUnattributed(req)
+	if h.lastUnattributedAt.Equal(first) {
+		t.Error("expected a fresh escalation after the re-alert window elapsed")
+	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -29,6 +29,15 @@ var (
 		Help: "Current number of events waiting in the in-memory ingest queue.",
 	})
 
+	// EventsRejected counts events refused at the ingest edge, labeled by
+	// "reason". "unattributed" means the request carried no resolvable project
+	// (a global API key with no x-funnelbarn-project header), which the worker
+	// could only ever fail to insert against the events.project_id foreign key.
+	EventsRejected = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "funnelbarn_events_rejected_total",
+		Help: "Total events rejected at the ingest edge, labeled by reason.",
+	}, []string{"reason"})
+
 	// Worker pipeline
 	EventsProcessed = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "funnelbarn_events_processed_total",
@@ -37,8 +46,10 @@ var (
 
 	// EventErrors is labeled by "reason": "retry" for a processing failure
 	// that will be retried, "dead_letter" for one that exhausted retries and
-	// was written to the dead-letter spool. All increment call sites must
-	// supply this label (CounterVec requires it on every observation).
+	// was written to the dead-letter spool, "unresolved_project" for one whose
+	// project can never be resolved (dead-lettered immediately, since retrying
+	// cannot help). All increment call sites must supply this label
+	// (CounterVec requires it on every observation).
 	EventErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "funnelbarn_event_errors_total",
 		Help: "Total events that failed processing, labeled by reason (retry vs dead_letter).",

--- a/internal/repository/projects.go
+++ b/internal/repository/projects.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"regexp"
 	"time"
@@ -59,6 +60,12 @@ func (s *Store) ProjectBySlug(ctx context.Context, slug string) (Project, error)
 	return projectFromGen(p), nil
 }
 
+// ErrProjectUnresolvable marks a slug that can never resolve to a project, no
+// matter how often the caller retries: a UUID with no matching project, or a
+// slug we refuse to auto-create from. Callers use it to fail fast instead of
+// burning retries on a lookup that is deterministically hopeless.
+var ErrProjectUnresolvable = errors.New("project cannot be resolved from slug")
+
 // EnsureProject fetches a project by slug, creating it if absent.
 //
 // As a defence against misconfigured trackers that send a project's *ID* in
@@ -85,14 +92,14 @@ func (s *Store) EnsureProject(ctx context.Context, slug string) (Project, error)
 		// UUID-shaped slug with no matching project either way — refuse to
 		// auto-create. A UUID is never a meaningful slug; creating one
 		// produces the "project shows up as a UUID in the picker" UX bug.
-		return Project{}, fmt.Errorf("slug %q looks like a UUID but no project with that ID exists; refusing to auto-create", slug)
+		return Project{}, fmt.Errorf("%w: slug %q looks like a UUID but no project with that ID exists; refusing to auto-create", ErrProjectUnresolvable, slug)
 	}
 
 	// Only auto-create for well-formed slugs. This blocks path-traversal /
 	// garbage values (e.g. from a forged x-funnelbarn-project header on an
 	// instance-wide key) from spawning junk projects.
 	if !projectSlugPattern.MatchString(slug) {
-		return Project{}, fmt.Errorf("refusing to auto-create project for invalid slug %q", slug)
+		return Project{}, fmt.Errorf("%w: refusing to auto-create project for invalid slug %q", ErrProjectUnresolvable, slug)
 	}
 
 	return s.CreateProject(ctx, slug, slug)

--- a/internal/repository/store_test.go
+++ b/internal/repository/store_test.go
@@ -3,6 +3,7 @@ package repository_test
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -1347,4 +1348,29 @@ func TestStore_CountNewEvents(t *testing.T) {
 	n, err := s.CountNewEvents(ctx, p.ID, now.Add(-time.Hour), "")
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), n)
+}
+
+// EnsureProject marks deterministically hopeless slugs with
+// ErrProjectUnresolvable so the ingest worker can dead-letter the record
+// immediately instead of retrying an insert that must fail the project_id
+// foreign key every time.
+func TestEnsureProject_UnresolvableSlugsAreMarked(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	cases := map[string]string{
+		"UUID with no matching project": "bad8320c-8aef-408b-a0bf-df4b0adc3877",
+		"path traversal":                "../../etc/passwd",
+	}
+	for name, slug := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := store.EnsureProject(ctx, slug)
+			if err == nil {
+				t.Fatalf("expected EnsureProject(%q) to fail", slug)
+			}
+			if !errors.Is(err, repository.ErrProjectUnresolvable) {
+				t.Errorf("expected ErrProjectUnresolvable, got %v", err)
+			}
+		})
+	}
 }

--- a/internal/service/flags.go
+++ b/internal/service/flags.go
@@ -141,7 +141,15 @@ func (svc *FlagService) EvaluateFlag(ctx context.Context, projectID, flagKey str
 
 	flag, err := svc.store.FlagByKey(ctx, projectID, flagKey)
 	if err != nil {
-		tracing.RecordError(span, err)
+		// A missing flag is an expected, well-defined outcome — the caller gets
+		// its own default (FLAG_NOT_FOUND), and auto-registration is built on
+		// exactly this path. Recording it as a span error made every evaluation
+		// of an unregistered flag look like a fault in SpanBarn.
+		if errors.Is(err, sql.ErrNoRows) {
+			span.SetAttributes(attribute.String("flag.reason", "FLAG_NOT_FOUND"))
+		} else {
+			tracing.RecordError(span, err)
+		}
 		return FlagEvalResult{}, fmt.Errorf("flag not found: %w", err)
 	}
 

--- a/internal/spool/spool.go
+++ b/internal/spool/spool.go
@@ -366,12 +366,30 @@ func ReadRecordsFrom(path string, offset int64) ([]RecordAtOffset, error) {
 	return records, nil
 }
 
+// DeadLetterPath returns the dead-letter file path for dir.
+func DeadLetterPath(dir string) string {
+	if dir == "" {
+		dir = ".data/spool"
+	}
+	return filepath.Join(dir, deadLetterFileName)
+}
+
+// TruncateDeadLetter empties the dead-letter file, used after a successful
+// replay so records are not applied twice. A missing file is not an error.
+func TruncateDeadLetter(dir string) error {
+	err := os.Truncate(DeadLetterPath(dir), 0)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
 // AppendDeadLetter writes a record to the dead-letter file in dir.
 func AppendDeadLetter(dir string, record Record) error {
 	if dir == "" {
 		dir = ".data/spool"
 	}
-	path := filepath.Join(dir, deadLetterFileName)
+	path := DeadLetterPath(dir)
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err

--- a/internal/spool/spool_test.go
+++ b/internal/spool/spool_test.go
@@ -471,3 +471,40 @@ func TestActiveSize(t *testing.T) {
 		t.Fatalf("after append: want >0,nil got %d,%v", n, err)
 	}
 }
+
+func TestDeadLetterRoundTripAndTruncate(t *testing.T) {
+	dir := t.TempDir()
+
+	rec := spool.Record{IngestID: "dl-1", ProjectSlug: "site", BodyBase64: "e30="}
+	if err := spool.AppendDeadLetter(dir, rec); err != nil {
+		t.Fatalf("AppendDeadLetter: %v", err)
+	}
+
+	got, err := spool.ReadRecords(spool.DeadLetterPath(dir))
+	if err != nil {
+		t.Fatalf("ReadRecords: %v", err)
+	}
+	if len(got) != 1 || got[0].IngestID != "dl-1" {
+		t.Fatalf("expected the dead-lettered record back, got %+v", got)
+	}
+
+	// Replay truncates rather than deletes, so the file stays where operators
+	// (and any log shipper) expect it.
+	if err := spool.TruncateDeadLetter(dir); err != nil {
+		t.Fatalf("TruncateDeadLetter: %v", err)
+	}
+	got, err = spool.ReadRecords(spool.DeadLetterPath(dir))
+	if err != nil {
+		t.Fatalf("ReadRecords after truncate: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected an empty dead-letter file, got %d records", len(got))
+	}
+}
+
+// Truncating a spool that never dead-lettered anything is a no-op, not an error.
+func TestTruncateDeadLetter_MissingFile(t *testing.T) {
+	if err := spool.TruncateDeadLetter(t.TempDir()); err != nil {
+		t.Fatalf("expected no error for a missing dead-letter file, got %v", err)
+	}
+}

--- a/internal/worker/persist_test.go
+++ b/internal/worker/persist_test.go
@@ -5,6 +5,8 @@ package worker
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -91,5 +93,33 @@ func TestPersistEvent_Idempotency(t *testing.T) {
 	// Session upsert should still happen on the first call only.
 	if len(store.sessions) != 1 {
 		t.Errorf("idempotency: want 1 session upsert, got %d", len(store.sessions))
+	}
+}
+
+// An event with no project ID can only fail the events.project_id foreign key,
+// which SQLite reports as an unattributable "FOREIGN KEY constraint failed
+// (787)". PersistEvent names the cause before the insert is attempted.
+func TestPersistEvent_RejectsEventWithoutProject(t *testing.T) {
+	store := &fakeEventStore{}
+	event := repository.Event{
+		ID:         "evt-1",
+		SessionID:  "sess-1",
+		Name:       "signup",
+		IngestID:   "ingest-1",
+		OccurredAt: time.Now(),
+	}
+
+	err := PersistEvent(context.Background(), store, event, nil)
+	if err == nil {
+		t.Fatal("expected an error for an event with no project ID")
+	}
+	if !errors.Is(err, ErrNoProject) {
+		t.Errorf("expected ErrNoProject, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "ingest-1") {
+		t.Errorf("error should name the ingest ID so it is traceable, got %q", err)
+	}
+	if len(store.events) != 0 {
+		t.Errorf("expected no insert attempt, got %d events", len(store.events))
 	}
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -148,9 +149,19 @@ type EventPersister interface {
 	UpsertSessionSignals(ctx context.Context, sessionID string, signals repository.SessionSignals) error
 }
 
+// ErrNoProject means the event carries no project ID. events.project_id is
+// NOT NULL REFERENCES projects(id), so inserting one produces an opaque
+// "FOREIGN KEY constraint failed (787)" that says nothing about which parent
+// row was missing. Catch it here, where the cause is still nameable.
+var ErrNoProject = errors.New("event has no project ID")
+
 // PersistEvent stores an event and upserts the associated session.
 // geo may be nil when geo collection is disabled or the database is unconfigured.
 func PersistEvent(ctx context.Context, store EventPersister, event repository.Event, geo *geoip.GeoResult) error {
+	if event.ProjectID == "" {
+		return fmt.Errorf("%w (ingest_id %s, event %q)", ErrNoProject, event.IngestID, event.Name)
+	}
+
 	// Check idempotency: skip if already stored.
 	existing, err := store.GetEventByIngestID(ctx, event.IngestID)
 	if err != nil {


### PR DESCRIPTION
Fixes the largest error source in the fleet — ~15.4k `worker.persist_event`
errors/day, every one of them `FOREIGN KEY constraint failed (787)`.

## The failing key

Not `session_id` or `page_view_id`, as the issue guessed: `events.session_id`
has no foreign key at all, and there is no `page_views` table. The only FK on
`events` is `project_id REFERENCES projects(id)`.

`ProcessRecord` never sets `ProjectID` — the worker does, from the spool
record's project slug. The ingest edge derives that slug from the project
bound to the API key, falling back to `x-funnelbarn-project`:

```go
projectSlug := projectID
if projectSlug == "" {
    projectSlug = r.Header.Get("x-funnelbarn-project")
}
```

The static instance-wide key (`FUNNELBARN_API_KEY`) resolves with an **empty**
project ID. A client using one without the header therefore produces a record
with no slug, the worker warn-logged and inserted anyway, and the insert could
only ever fail the FK. The client had already been handed its 202. Same
outcome for a slug that cannot resolve — the UUID case behind the
`recordings.ingest_chunk :: not found: project bad8320c-…` signal in the issue.

(This is also why FKs only started firing recently: they weren't enforced
until #195.)

## Changes

**Fail where the cause is still nameable**

- **Ingest edge** — an event that can't be attributed to a project gets a
  `400` naming the fix, not a `202` it won't survive. Counted as
  `funnelbarn_events_rejected_total{reason="unattributed"}`. The alert
  escalates to error once per hour and warns in between, so a misconfigured
  client can't trade one 15k/day flood for another.
- **Worker** — an unresolvable record is dead-lettered immediately, with an
  error naming the slug, ingest ID and event name. Retrying a deterministic FK
  failure only burned attempts. New `repository.ErrProjectUnresolvable`
  separates "can never work" from a transient lookup failure, which still
  retries.
- **`PersistEvent`** — refuses an event with no `ProjectID` up front, so the
  error says which parent row is missing instead of `787`.

**Make the loss recoverable** (the issue's third ask)

```
funnelbarn replay-dead-letter [--project=<slug>] [--dry-run]
```

Re-attributes and re-persists dead-lettered records; truncates the file only
when every record landed, so a partial run is safe to retry (persistence is
idempotent on `ingest_id`). Documented in `deploy/RUNBOOK.md` §4b.

**The two smaller signals from the same window**

- `flags.evaluate :: sql: no rows in result set` — a missing flag is an
  expected outcome (the caller gets its default, and auto-registration is
  built on exactly this path). It no longer records a span error; it sets
  `flag.reason=FLAG_NOT_FOUND`.
- `recordings.ingest_chunk :: not found: project …` — a 404 for a stale
  project is a client condition, now warn-logged and off the span's error
  count. That part lands in #188.

## Tests

- ingest: unattributed event → 400; project-scoped key needs no header;
  escalation throttle fires once per window
- worker: `PersistEvent` rejects a project-less event and names the ingest ID
- repository: `EnsureProject` marks UUID-with-no-project and traversal slugs
  `ErrProjectUnresolvable`
- spool: dead-letter round trip + truncate (incl. missing file)
- cmd: replay skips and preserves records with nothing to attribute them to,
  then applies and clears them with `--project`

Coverage: `cmd/funnelbarn` 11% → 17.5%, global 67.5%.

> Depends on #213 (Go 1.26) — `go-quality` is red on `main` until that lands.

Closes #209