### PR TITLE
feat(flags): project-scoped API tokens for flag read and toggle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,9 +135,12 @@ jobs:
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 
-      - name: Build SDK
+      # `npm test` builds first, so this covers the SDK's own suite as well as
+      # producing the bundle the web app links against. It was previously only
+      # built, never tested, in CI.
+      - name: Build and test SDK
         working-directory: sdks/js
-        run: npm ci && npm run build
+        run: npm ci && npm test
 
       - name: Install web deps
         working-directory: web

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -217,6 +217,32 @@ func (s *Server) handleCreateProject(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, project)
 }
 
+// safeKey is an API key as returned to the dashboard: never the hash, and with
+// last_used_at so an operator can tell a token something depends on from one
+// that was issued and forgotten before revoking it.
+type safeKey struct {
+	ID         string `json:"id"`
+	ProjectID  string `json:"project_id"`
+	Name       string `json:"name"`
+	Scope      string `json:"scope"`
+	CreatedAt  string `json:"created_at"`
+	LastUsedAt string `json:"last_used_at,omitempty"`
+}
+
+func toSafeKey(k repository.APIKey) safeKey {
+	sk := safeKey{
+		ID:        k.ID,
+		ProjectID: k.ProjectID,
+		Name:      k.Name,
+		Scope:     k.Scope,
+		CreatedAt: k.CreatedAt.Format(time.RFC3339),
+	}
+	if k.LastUsedAt != nil {
+		sk.LastUsedAt = k.LastUsedAt.Format(time.RFC3339)
+	}
+	return sk
+}
+
 // handleListAPIKeys lists API keys.
 // Accepts an optional ?project_id= query param to filter by project.
 // When omitted, returns all API keys across all projects.
@@ -235,21 +261,9 @@ func (s *Server) handleListAPIKeys(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Mask key hashes in the response.
-	type safeKey struct {
-		ID        string `json:"id"`
-		Name      string `json:"name"`
-		Scope     string `json:"scope"`
-		CreatedAt string `json:"created_at"`
-	}
 	var safe []safeKey
 	for _, k := range keys {
-		safe = append(safe, safeKey{
-			ID:        k.ID,
-			Name:      k.Name,
-			Scope:     k.Scope,
-			CreatedAt: k.CreatedAt.Format(time.RFC3339),
-		})
+		safe = append(safe, toSafeKey(k))
 	}
 	if safe == nil {
 		safe = []safeKey{}
@@ -314,21 +328,10 @@ func (s *Server) handleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Return the plaintext key once — it won't be shown again.
-	type safeKey struct {
-		ID        string `json:"id"`
-		Name      string `json:"name"`
-		Scope     string `json:"scope"`
-		CreatedAt string `json:"created_at"`
-	}
 	slog.InfoContext(r.Context(), "api key created", "key_id", key.ID, "name", body.Name, "scope", body.Scope, "project_id", body.ProjectID, "request_id", RequestIDFromContext(r.Context()))
 	writeJSON(w, http.StatusCreated, map[string]any{
-		"api_key": safeKey{
-			ID:        key.ID,
-			Name:      key.Name,
-			Scope:     key.Scope,
-			CreatedAt: key.CreatedAt.Format(time.RFC3339),
-		},
-		"key": plaintext,
+		"api_key": toSafeKey(key),
+		"key":     plaintext,
 	})
 }
 

--- a/internal/api/flag_tokens.go
+++ b/internal/api/flag_tokens.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/wiebe-xyz/funnelbarn/internal/auth"
+	"github.com/wiebe-xyz/funnelbarn/internal/repository"
+)
+
+// Flag CRUD used to be reachable only with a browser session, so no service
+// could read or toggle a flag — an operator surface had to send people to the
+// FunnelBarn dashboard to flip a switch. Splitting one deliberate action across
+// two systems is how "we thought it was off" happens.
+//
+// These routes therefore accept a project-scoped API token as well as a
+// session. The token is bound to one project, hashed at rest like every other
+// API key, issued and revoked from the dashboard, and carries a last-used
+// timestamp.
+
+// requireSessionOrFlagToken serves next to either a dashboard session or a
+// project-scoped API token holding at least wantScope.
+//
+// When the request carries an API key it is authenticated as a token and
+// nothing else: falling back to the session path on a bad token would turn a
+// revoked credential into a silent success for whoever happened to be logged
+// in on the same browser.
+func (s *Server) requireSessionOrFlagToken(wantScope string, next http.HandlerFunc) http.HandlerFunc {
+	viaSession := s.requireSession(next)
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(auth.HeaderAPIKey) == "" {
+			viaSession(w, r)
+			return
+		}
+		s.serveFlagToken(w, r, wantScope, next)
+	}
+}
+
+func (s *Server) serveFlagToken(w http.ResponseWriter, r *http.Request, wantScope string, next http.HandlerFunc) {
+	projectID, scope, ok := s.ingest.APIKeyProjectScope(r)
+	if !ok {
+		slog.WarnContext(r.Context(), "flag token: unauthorized",
+			"path", r.URL.Path,
+			"request_id", RequestIDFromContext(r.Context()),
+		)
+		jsonError(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// The instance-wide env-var key resolves with an empty project ID, which
+	// would make it a master key for every project's flags. A flag token must
+	// name the project it is allowed to touch.
+	if projectID == "" {
+		slog.WarnContext(r.Context(), "flag token: instance-wide key cannot be used for flag access",
+			"path", r.URL.Path,
+			"request_id", RequestIDFromContext(r.Context()),
+		)
+		jsonError(w, "flag access requires a project-scoped API key from the project settings page, not the global FUNNELBARN_API_KEY", http.StatusUnauthorized)
+		return
+	}
+
+	// The whole point of the scoping: rapid-root's scherpstel token must not be
+	// able to touch places.
+	if routeProject := r.PathValue("id"); routeProject != "" && routeProject != projectID {
+		jsonError(w, "api key is not scoped to this project", http.StatusForbidden)
+		return
+	}
+
+	if !scopeAllows(scope, wantScope) {
+		jsonError(w, "api key scope "+scope+" cannot "+wantScope, http.StatusForbidden)
+		return
+	}
+
+	if !s.apiLimiter.allow(s.clientIP(r)) {
+		jsonError(w, "too many requests", http.StatusTooManyRequests)
+		return
+	}
+
+	// No CSRF check: this request is authenticated by a header the browser
+	// never attaches on its own, so there is nothing to forge across origins.
+	next(w, r)
+}
+
+// scopeAllows reports whether a key's scope covers the access a route needs.
+// Read is implied by write; "ingest" covers neither, and an unknown scope
+// covers nothing.
+func scopeAllows(have, want string) bool {
+	if have == repository.APIKeyScopeFull {
+		return true
+	}
+	switch want {
+	case repository.APIKeyScopeFlagsRead:
+		return have == repository.APIKeyScopeFlagsRead || have == repository.APIKeyScopeFlagsWrite
+	case repository.APIKeyScopeFlagsWrite:
+		return have == repository.APIKeyScopeFlagsWrite
+	}
+	return false
+}

--- a/internal/api/flag_tokens_test.go
+++ b/internal/api/flag_tokens_test.go
@@ -1,0 +1,417 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/wiebe-xyz/funnelbarn/internal/auth"
+	"github.com/wiebe-xyz/funnelbarn/internal/ingest"
+	"github.com/wiebe-xyz/funnelbarn/internal/repository"
+	"github.com/wiebe-xyz/funnelbarn/internal/service"
+)
+
+// newFlagTokenServer builds a server whose ingest authorizer resolves real
+// api_keys rows, plus a static instance-wide key, so both the scoped-token and
+// global-key paths can be exercised.
+func newFlagTokenServer(t *testing.T) (*Server, *repository.Store) {
+	t.Helper()
+	store := openMemoryStore(t)
+	sp := newTestSpool(t)
+	authz := auth.New("global-instance-key").WithDBLookup(store.ValidAPIKeySHA256, store.TouchAPIKey)
+	sm := auth.NewSessionManager("test-secret", time.Hour)
+	userAuth, _ := auth.NewUserAuthenticator("admin", "pw", "")
+
+	srv := NewServer(ServerConfig{
+		Ingest:              ingest.NewHandler(authz, sp, 0),
+		Projects:            service.NewProjectService(store),
+		Funnels:             service.NewFunnelService(store),
+		ABTests:             service.NewABTestService(store),
+		Flags:               service.NewFlagService(store),
+		Events:              service.NewEventService(store),
+		Overview:            service.NewOverviewService(store),
+		Sessions:            service.NewSessionService(store),
+		APIKeys:             service.NewAPIKeyService(store),
+		Widgets:             service.NewWidgetService(store),
+		UserAuth:            userAuth,
+		SessionManager:      sm,
+		WebSessions:         store,
+		SessionSecret:       "test-secret",
+		PublicURL:           "http://localhost",
+		LoginRatePerMinute:  1000,
+		LoginRateBurst:      1000,
+		APIRatePerMinute:    1000,
+		APIRateBurst:        1000,
+		IngestRatePerMinute: 1000,
+		IngestRateBurst:     1000,
+		DB:                  store,
+		Version:             "test",
+	})
+	return srv, store
+}
+
+func scopedKey(t *testing.T, store *repository.Store, projectID, plaintext, scope string) string {
+	t.Helper()
+	sum := sha256.Sum256([]byte(plaintext))
+	if _, err := store.CreateAPIKey(context.Background(), "test-"+scope, projectID, hex.EncodeToString(sum[:]), scope); err != nil {
+		t.Fatalf("CreateAPIKey(%s): %v", scope, err)
+	}
+	return plaintext
+}
+
+func seedFlag(t *testing.T, store *repository.Store, projectID, key string) repository.FeatureFlag {
+	t.Helper()
+	f, err := store.CreateFlag(context.Background(), repository.FeatureFlag{
+		ProjectID: projectID, FlagKey: key, Name: key, FlagType: "boolean",
+		Variants: `{"on":true,"off":false}`, DefaultVariant: "on",
+		Split: `{"on":100,"off":0}`, TargetingRules: "[]", Status: "active",
+	})
+	if err != nil {
+		t.Fatalf("CreateFlag: %v", err)
+	}
+	return f
+}
+
+func withKey(t *testing.T, srv *Server, method, path, key string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		if err := json.NewEncoder(&buf).Encode(body); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+	}
+	req := httptest.NewRequest(method, path, &buf)
+	req.Header.Set("Content-Type", "application/json")
+	if key != "" {
+		req.Header.Set(auth.HeaderAPIKey, key)
+	}
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	return w
+}
+
+// ---------------------------------------------------------------------------
+// Read
+// ---------------------------------------------------------------------------
+
+func TestFlagToken_ReadsWithoutSession(t *testing.T) {
+	srv, store := newFlagTokenServer(t)
+	p, _ := store.CreateProject(context.Background(), "Scherpstel", "scherpstel")
+	seedFlag(t, store, p.ID, "outbound_email")
+	key := scopedKey(t, store, p.ID, "read-key", repository.APIKeyScopeFlagsRead)
+
+	w := withKey(t, srv, http.MethodGet, "/api/v1/projects/"+p.ID+"/flags", key, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Flags []repository.FeatureFlag `json:"flags"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Flags) != 1 || resp.Flags[0].FlagKey != "outbound_email" {
+		t.Fatalf("unexpected flags: %+v", resp.Flags)
+	}
+	// The point of read access: report what the project holds, not what the
+	// caller's own client resolved.
+	if resp.Flags[0].Status != "active" {
+		t.Errorf("status should be the project's real state, got %q", resp.Flags[0].Status)
+	}
+}
+
+// A read token must not be able to change anything.
+func TestFlagToken_ReadScopeCannotWrite(t *testing.T) {
+	srv, store := newFlagTokenServer(t)
+	p, _ := store.CreateProject(context.Background(), "P", "p")
+	f := seedFlag(t, store, p.ID, "gate")
+	key := scopedKey(t, store, p.ID, "read-key", repository.APIKeyScopeFlagsRead)
+
+	w := withKey(t, srv, http.MethodPut, "/api/v1/projects/"+p.ID+"/flags/"+f.ID, key,
+		map[string]any{"status": "paused"})
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403 for a read token attempting a write, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	after, _ := store.FlagByID(context.Background(), f.ID)
+	if after.Status != "active" {
+		t.Errorf("the flag must be unchanged, got status %q", after.Status)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Write
+// ---------------------------------------------------------------------------
+
+// The operator surface's whole job: turning the gate off is one deliberate
+// action, not a trip to a second dashboard.
+func TestFlagToken_WriteTogglesFlag(t *testing.T) {
+	srv, store := newFlagTokenServer(t)
+	p, _ := store.CreateProject(context.Background(), "P", "p")
+	f := seedFlag(t, store, p.ID, "outbound_email")
+	key := scopedKey(t, store, p.ID, "write-key", repository.APIKeyScopeFlagsWrite)
+
+	w := withKey(t, srv, http.MethodPut, "/api/v1/projects/"+p.ID+"/flags/"+f.ID, key,
+		map[string]any{"status": "paused"})
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	after, _ := store.FlagByID(context.Background(), f.ID)
+	if after.Status != "paused" {
+		t.Errorf("status: want paused, got %q", after.Status)
+	}
+	// A partial update must not blank out everything the caller didn't send.
+	if after.Name != f.Name || after.Variants != f.Variants || after.DefaultVariant != f.DefaultVariant {
+		t.Errorf("partial update clobbered the flag: %+v", after)
+	}
+}
+
+// A write token can read too — read is implied by write.
+func TestFlagToken_WriteScopeCanRead(t *testing.T) {
+	srv, store := newFlagTokenServer(t)
+	p, _ := store.CreateProject(context.Background(), "P", "p")
+	seedFlag(t, store, p.ID, "gate")
+	key := scopedKey(t, store, p.ID, "write-key", repository.APIKeyScopeFlagsWrite)
+
+	if w := withKey(t, srv, http.MethodGet, "/api/v1/projects/"+p.ID+"/flags", key, nil); w.Code != http.StatusOK {
+		t.Errorf("want 200, got %d", w.Code)
+	}
+}
+
+// Auto-registration covers creation, and a token that can turn a gate off
+// should not also be able to delete the gate.
+func TestFlagToken_CannotCreateOrDelete(t *testing.T) {
+	srv, store := newFlagTokenServer(t)
+	p, _ := store.CreateProject(context.Background(), "P", "p")
+	f := seedFlag(t, store, p.ID, "gate")
+	key := scopedKey(t, store, p.ID, "write-key", repository.APIKeyScopeFlagsWrite)
+
+	w := withKey(t, srv, http.MethodPost, "/api/v1/projects/"+p.ID+"/flags", key,
+		map[string]any{"flag_key": "new", "name": "New"})
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("create: want 401 (session-only route), got %d", w.Code)
+	}
+
+	w = withKey(t, srv, http.MethodDelete, "/api/v1/projects/"+p.ID+"/flags/"+f.ID, key, nil)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("delete: want 401 (session-only route), got %d", w.Code)
+	}
+	if _, err := store.FlagByID(context.Background(), f.ID); err != nil {
+		t.Errorf("the flag must still exist: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scoping
+// ---------------------------------------------------------------------------
+
+// rapid-root's scherpstel token must not be able to touch places.
+func TestFlagToken_CannotCrossProjects(t *testing.T) {
+	srv, store := newFlagTokenServer(t)
+	ctx := context.Background()
+	mine, _ := store.CreateProject(ctx, "Scherpstel", "scherpstel")
+	theirs, _ := store.CreateProject(ctx, "Places", "places")
+	theirFlag := seedFlag(t, store, theirs.ID, "their_gate")
+	key := scopedKey(t, store, mine.ID, "write-key", repository.APIKeyScopeFlagsWrite)
+
+	w := withKey(t, srv, http.MethodGet, "/api/v1/projects/"+theirs.ID+"/flags", key, nil)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("listing another project: want 403, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	w = withKey(t, srv, http.MethodPut, "/api/v1/projects/"+theirs.ID+"/flags/"+theirFlag.ID, key,
+		map[string]any{"status": "paused"})
+	if w.Code != http.StatusForbidden {
+		t.Errorf("writing another project's flag: want 403, got %d", w.Code)
+	}
+}
+
+// The URL's project must be more than decoration: addressing another project's
+// flag through your own project's URL has to fail too.
+func TestFlagToken_CannotReachForeignFlagIDThroughOwnProject(t *testing.T) {
+	srv, store := newFlagTokenServer(t)
+	ctx := context.Background()
+	mine, _ := store.CreateProject(ctx, "Scherpstel", "scherpstel")
+	theirs, _ := store.CreateProject(ctx, "Places", "places")
+	theirFlag := seedFlag(t, store, theirs.ID, "their_gate")
+	key := scopedKey(t, store, mine.ID, "write-key", repository.APIKeyScopeFlagsWrite)
+
+	// 404, not 403: a caller scoped elsewhere shouldn't learn the ID exists.
+	w := withKey(t, srv, http.MethodGet, "/api/v1/projects/"+mine.ID+"/flags/"+theirFlag.ID, key, nil)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("want 404, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	w = withKey(t, srv, http.MethodPut, "/api/v1/projects/"+mine.ID+"/flags/"+theirFlag.ID, key,
+		map[string]any{"status": "paused"})
+	if w.Code != http.StatusNotFound {
+		t.Errorf("want 404, got %d", w.Code)
+	}
+	after, _ := store.FlagByID(ctx, theirFlag.ID)
+	if after.Status != "active" {
+		t.Errorf("the other project's flag must be unchanged, got %q", after.Status)
+	}
+}
+
+// An ingest key is for events. It must not read or toggle flags.
+func TestFlagToken_IngestScopeRejected(t *testing.T) {
+	srv, store := newFlagTokenServer(t)
+	p, _ := store.CreateProject(context.Background(), "P", "p")
+	seedFlag(t, store, p.ID, "gate")
+	key := scopedKey(t, store, p.ID, "ingest-key", repository.APIKeyScopeIngest)
+
+	if w := withKey(t, srv, http.MethodGet, "/api/v1/projects/"+p.ID+"/flags", key, nil); w.Code != http.StatusForbidden {
+		t.Errorf("want 403 for an ingest-scoped key, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+// The instance-wide env-var key resolves with no project, which would make it a
+// master key for every project's flags.
+func TestFlagToken_InstanceWideKeyRejected(t *testing.T) {
+	srv, store := newFlagTokenServer(t)
+	p, _ := store.CreateProject(context.Background(), "P", "p")
+	seedFlag(t, store, p.ID, "gate")
+
+	w := withKey(t, srv, http.MethodGet, "/api/v1/projects/"+p.ID+"/flags", "global-instance-key", nil)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401 for the instance-wide key, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte("project-scoped")) {
+		t.Errorf("the message should name the fix, got %s", w.Body.String())
+	}
+}
+
+// A revoked or mistyped key must not fall through to whatever session happens
+// to be on the same browser.
+func TestFlagToken_BadKeyDoesNotFallBackToSession(t *testing.T) {
+	srv, store := newFlagTokenServer(t)
+	p, _ := store.CreateProject(context.Background(), "P", "p")
+	seedFlag(t, store, p.ID, "gate")
+	cookie := sessionCookieFor(t, srv, "admin")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+p.ID+"/flags", nil)
+	req.Header.Set(auth.HeaderAPIKey, "revoked-key")
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("want 401, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+// A dashboard session keeps working exactly as before.
+func TestFlagToken_SessionStillWorks(t *testing.T) {
+	srv, store := newFlagTokenServer(t)
+	p, _ := store.CreateProject(context.Background(), "P", "p")
+	seedFlag(t, store, p.ID, "gate")
+	cookie := sessionCookieFor(t, srv, "admin")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+p.ID+"/flags", nil)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("want 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// scopeAllows
+// ---------------------------------------------------------------------------
+
+func TestScopeAllows(t *testing.T) {
+	cases := []struct {
+		have, want string
+		ok         bool
+	}{
+		{repository.APIKeyScopeFull, repository.APIKeyScopeFlagsRead, true},
+		{repository.APIKeyScopeFull, repository.APIKeyScopeFlagsWrite, true},
+		{repository.APIKeyScopeFlagsWrite, repository.APIKeyScopeFlagsRead, true},
+		{repository.APIKeyScopeFlagsWrite, repository.APIKeyScopeFlagsWrite, true},
+		{repository.APIKeyScopeFlagsRead, repository.APIKeyScopeFlagsRead, true},
+		{repository.APIKeyScopeFlagsRead, repository.APIKeyScopeFlagsWrite, false},
+		{repository.APIKeyScopeIngest, repository.APIKeyScopeFlagsRead, false},
+		{repository.APIKeyScopeIngest, repository.APIKeyScopeFlagsWrite, false},
+		{"something-new", repository.APIKeyScopeFlagsRead, false},
+	}
+	for _, c := range cases {
+		if got := scopeAllows(c.have, c.want); got != c.ok {
+			t.Errorf("scopeAllows(%q, %q) = %v, want %v", c.have, c.want, got, c.ok)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Issuance
+// ---------------------------------------------------------------------------
+
+func TestCreateAPIKey_AcceptsFlagScopes(t *testing.T) {
+	srv, store := newAuthedServer(t)
+	p, _ := store.CreateProject(context.Background(), "P", "p")
+	cookie, csrf := sessionAndCSRF(t, srv, "u")
+
+	for _, scope := range []string{repository.APIKeyScopeFlagsRead, repository.APIKeyScopeFlagsWrite} {
+		w := postJSONWithCSRF(t, srv, "/api/v1/apikeys", map[string]any{
+			"project_id": p.ID, "name": "flags " + scope, "scope": scope,
+		}, cookie, csrf)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("scope %s: want 201, got %d (body: %s)", scope, w.Code, w.Body.String())
+		}
+		var resp struct {
+			Key     string `json:"key"`
+			APIKey  safeKey
+			RawBody map[string]any
+		}
+		_ = json.Unmarshal(w.Body.Bytes(), &resp.RawBody)
+		apiKey, _ := resp.RawBody["api_key"].(map[string]any)
+		if apiKey["scope"] != scope {
+			t.Errorf("scope: want %s, got %v", scope, apiKey["scope"])
+		}
+	}
+
+	w := postJSONWithCSRF(t, srv, "/api/v1/apikeys", map[string]any{
+		"project_id": p.ID, "name": "bogus", "scope": "flags:admin",
+	}, cookie, csrf)
+	if w.Code != http.StatusUnprocessableEntity && w.Code != http.StatusBadRequest {
+		t.Errorf("an unknown scope must be refused, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+// last_used_at is what tells a token something depends on from one that was
+// issued and forgotten, before you revoke it.
+func TestAPIKeyList_ReportsLastUsed(t *testing.T) {
+	srv, store := newFlagTokenServer(t)
+	p, _ := store.CreateProject(context.Background(), "P", "p")
+	seedFlag(t, store, p.ID, "gate")
+	key := scopedKey(t, store, p.ID, "read-key", repository.APIKeyScopeFlagsRead)
+	cookie := sessionCookieFor(t, srv, "admin")
+
+	read := func() map[string]any {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/apikeys?project_id="+p.ID, nil)
+		req.AddCookie(cookie)
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, req)
+		var resp struct {
+			APIKeys []map[string]any `json:"api_keys"`
+		}
+		_ = json.Unmarshal(w.Body.Bytes(), &resp)
+		if len(resp.APIKeys) != 1 {
+			t.Fatalf("want 1 key, got %d", len(resp.APIKeys))
+		}
+		return resp.APIKeys[0]
+	}
+
+	if got := read()["last_used_at"]; got != nil {
+		t.Errorf("a never-used key should report no last_used_at, got %v", got)
+	}
+	withKey(t, srv, http.MethodGet, "/api/v1/projects/"+p.ID+"/flags", key, nil)
+	if got := read()["last_used_at"]; got == nil || got == "" {
+		t.Errorf("last_used_at should be set after the key authenticates, got %v", got)
+	}
+}

--- a/internal/api/flags.go
+++ b/internal/api/flags.go
@@ -112,26 +112,45 @@ func (s *Server) handleCreateFlag(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, flag)
 }
 
-func (s *Server) handleGetFlag(w http.ResponseWriter, r *http.Request) {
+// flagInProject loads the flag named by {fid} and confirms it belongs to the
+// project named by {id}. Without this, a project-scoped API token could reach
+// any flag in the instance by ID and the URL's project would be decoration —
+// the scoping these routes advertise has to be real.
+func (s *Server) flagInProject(w http.ResponseWriter, r *http.Request, op string) (repository.FeatureFlag, bool) {
+	projectID := r.PathValue("id")
 	flagID := r.PathValue("fid")
 	if flagID == "" {
 		jsonError(w, "flag id required", http.StatusBadRequest)
-		return
+		return repository.FeatureFlag{}, false
 	}
 	flag, err := s.flags.GetFlag(r.Context(), flagID)
 	if err != nil {
-		mapServiceError(w, err, "handleGetFlag")
+		mapServiceError(w, err, op)
+		return repository.FeatureFlag{}, false
+	}
+	// 404 rather than 403: a caller scoped to another project should not learn
+	// that this flag ID exists at all.
+	if projectID != "" && flag.ProjectID != projectID {
+		jsonError(w, "flag not found", http.StatusNotFound)
+		return repository.FeatureFlag{}, false
+	}
+	return flag, true
+}
+
+func (s *Server) handleGetFlag(w http.ResponseWriter, r *http.Request) {
+	flag, ok := s.flagInProject(w, r, "handleGetFlag")
+	if !ok {
 		return
 	}
 	writeJSON(w, http.StatusOK, flag)
 }
 
 func (s *Server) handleUpdateFlag(w http.ResponseWriter, r *http.Request) {
-	flagID := r.PathValue("fid")
-	if flagID == "" {
-		jsonError(w, "flag id required", http.StatusBadRequest)
+	existing, ok := s.flagInProject(w, r, "handleUpdateFlag.get")
+	if !ok {
 		return
 	}
+	flagID := existing.ID
 
 	var body struct {
 		Name            string `json:"name"`
@@ -155,21 +174,33 @@ func (s *Server) handleUpdateFlag(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Preserve flag_type and flag_kind from the existing record when the caller
-	// omits them, so a partial update can't silently turn a config flag back
-	// into an experiment (and start writing evaluation rows again).
-	if body.FlagType == "" || body.Kind == "" {
-		existing, err := s.flags.GetFlag(r.Context(), flagID)
-		if err != nil {
-			mapServiceError(w, err, "handleUpdateFlag.get")
-			return
-		}
-		if body.FlagType == "" {
-			body.FlagType = existing.FlagType
-		}
-		if body.Kind == "" {
-			body.Kind = existing.Kind
-		}
+	// Preserve fields the caller omits, so a partial update can't silently turn
+	// a config flag back into an experiment (and start writing evaluation rows
+	// again) or blank out its value. A service toggling a gate sends
+	// {"status": "paused"} and nothing else.
+	if body.FlagType == "" {
+		body.FlagType = existing.FlagType
+	}
+	if body.Kind == "" {
+		body.Kind = existing.Kind
+	}
+	if body.Name == "" {
+		body.Name = existing.Name
+	}
+	if body.Variants == "" {
+		body.Variants = existing.Variants
+	}
+	if body.DefaultVariant == "" {
+		body.DefaultVariant = existing.DefaultVariant
+	}
+	if body.Split == "" {
+		body.Split = existing.Split
+	}
+	if body.TargetingRules == "" {
+		body.TargetingRules = existing.TargetingRules
+	}
+	if body.Status == "" {
+		body.Status = existing.Status
 	}
 	kind, err := normalizeFlagKind(body.Kind)
 	if err != nil {
@@ -197,12 +228,11 @@ func (s *Server) handleUpdateFlag(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleDeleteFlag(w http.ResponseWriter, r *http.Request) {
-	flagID := r.PathValue("fid")
-	if flagID == "" {
-		jsonError(w, "flag id required", http.StatusBadRequest)
+	flag, ok := s.flagInProject(w, r, "handleDeleteFlag.get")
+	if !ok {
 		return
 	}
-	if err := s.flags.DeleteFlag(r.Context(), flagID); err != nil {
+	if err := s.flags.DeleteFlag(r.Context(), flag.ID); err != nil {
 		mapServiceError(w, err, "handleDeleteFlag")
 		return
 	}
@@ -211,21 +241,15 @@ func (s *Server) handleDeleteFlag(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleFlagAnalysis(w http.ResponseWriter, r *http.Request) {
 	projectID := r.PathValue("id")
-	flagID := r.PathValue("fid")
-	if projectID == "" || flagID == "" {
+	if projectID == "" {
 		jsonError(w, "project id and flag id required", http.StatusBadRequest)
 		return
 	}
-
-	flag, err := s.flags.GetFlag(r.Context(), flagID)
-	if err != nil {
-		mapServiceError(w, err, "handleFlagAnalysis.getFlag")
+	flag, ok := s.flagInProject(w, r, "handleFlagAnalysis.getFlag")
+	if !ok {
 		return
 	}
-	if flag.ProjectID != projectID {
-		jsonError(w, "flag not found", http.StatusNotFound)
-		return
-	}
+	flagID := flag.ID
 
 	to := time.Now().UTC()
 	from := to.AddDate(0, 0, -30)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -363,13 +363,18 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/funnels/{fid}/analysis", s.requireSession(s.handleFunnelAnalysis))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/funnels/{fid}/segments", s.requireSession(s.handleFunnelSegments))
 
-	// Feature Flags (session required)
-	s.mux.HandleFunc("GET /api/v1/projects/{id}/flags", s.requireSession(s.handleListFlags))
+	// Feature Flags. Reads and updates also accept a project-scoped API token
+	// (scope flags:read / flags:write) so a service can report and toggle a
+	// flag without a browser session — see internal/api/flag_tokens.go.
+	// Creation and deletion stay session-only: auto-registration already covers
+	// creation, and a token that can turn an outbound-email gate off should not
+	// also be able to delete the gate.
+	s.mux.HandleFunc("GET /api/v1/projects/{id}/flags", s.requireSessionOrFlagToken(repository.APIKeyScopeFlagsRead, s.handleListFlags))
 	s.mux.HandleFunc("POST /api/v1/projects/{id}/flags", s.requireSession(s.handleCreateFlag))
-	s.mux.HandleFunc("GET /api/v1/projects/{id}/flags/{fid}", s.requireSession(s.handleGetFlag))
-	s.mux.HandleFunc("PUT /api/v1/projects/{id}/flags/{fid}", s.requireSession(s.handleUpdateFlag))
+	s.mux.HandleFunc("GET /api/v1/projects/{id}/flags/{fid}", s.requireSessionOrFlagToken(repository.APIKeyScopeFlagsRead, s.handleGetFlag))
+	s.mux.HandleFunc("PUT /api/v1/projects/{id}/flags/{fid}", s.requireSessionOrFlagToken(repository.APIKeyScopeFlagsWrite, s.handleUpdateFlag))
 	s.mux.HandleFunc("DELETE /api/v1/projects/{id}/flags/{fid}", s.requireSession(s.handleDeleteFlag))
-	s.mux.HandleFunc("GET /api/v1/projects/{id}/flags/{fid}/analysis", s.requireSession(s.handleFlagAnalysis))
+	s.mux.HandleFunc("GET /api/v1/projects/{id}/flags/{fid}/analysis", s.requireSessionOrFlagToken(repository.APIKeyScopeFlagsRead, s.handleFlagAnalysis))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/flags/context-keys", s.requireSession(s.handleFlagContextKeys))
 	// Dogfooding playground — same flag-eval logic as the customer endpoint
 	// but session-authed so the dashboard can call it without an API key in the browser.

--- a/internal/api/setup.go
+++ b/internal/api/setup.go
@@ -161,14 +161,16 @@ func (s *Server) handleSetup(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(b, "<script src=\"%s\"\n", sdkURL)
 	fmt.Fprintf(b, "  data-api-key=\"%s\"\n", plaintext)
 	fmt.Fprintf(b, "  data-project-name=\"%s\"\n", slug)
+	fmt.Fprintf(b, "  data-environment=\"production\"\n")
 	fmt.Fprintf(b, "  data-recording=\"true\"\n")
 	fmt.Fprintf(b, "  defer></script>\n")
 	fmt.Fprintf(b, "```\n\n")
 	fmt.Fprintf(b, "> Remove `data-recording=\"true\"` to disable session recording. The SDK fetches server-side config regardless, so an admin can also toggle recording without a code deploy.\n\n")
 	fmt.Fprintf(b, "**Module-based projects**:\n\n")
-	fmt.Fprintf(b, "```bash\n")
-	fmt.Fprintf(b, "npm install @funnelbarn/js\n")
-	fmt.Fprintf(b, "```\n\n")
+	fmt.Fprintf(b, "> `@funnelbarn/js` is not on the public npm registry yet, so\n")
+	fmt.Fprintf(b, "> `npm install @funnelbarn/js` 404s. The script tag above is the supported\n")
+	fmt.Fprintf(b, "> path today and works in bundled apps too; vendor `sdks/js` if you need\n")
+	fmt.Fprintf(b, "> the module build. The API below is what the package exposes.\n\n")
 	fmt.Fprintf(b, "```typescript\n")
 	fmt.Fprintf(b, "import { FunnelBarnClient } from '@funnelbarn/js'\n\n")
 	fmt.Fprintf(b, "const fb = new FunnelBarnClient({\n")
@@ -422,6 +424,9 @@ func (s *Server) handleSetup(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(b, "// server advertises rather than one you invent.\n")
 	fmt.Fprintf(b, "cap := funnelbarn.EvaluateInt(ctx, \"cold_email_daily_cap\", 25, nil)\n")
 	fmt.Fprintf(b, "```\n\n")
+
+	writeFlagAPISection(b, publicURL, slug)
+
 	fmt.Fprintf(b, "### Python\n\n")
 	fmt.Fprintf(b, "```python\n")
 	fmt.Fprintf(b, "def evaluate(flag_key: str, default, context: dict):\n")
@@ -510,4 +515,42 @@ func writeFlagKindsSection(b *strings.Builder, maxAutoFlags int) {
 	fmt.Fprintf(b, "> A config flag needs **one variant at 100%%**. If you give it several and\n")
 	fmt.Fprintf(b, "> a split, the default variant still wins — a config value is the same for\n")
 	fmt.Fprintf(b, "> everyone by definition — but the extra variants are just noise in the UI.\n\n")
+}
+
+// writeFlagAPISection documents the server-to-server path for reading and
+// toggling a flag. Without it the only way to flip a switch is a browser
+// session, so an operator surface has to send people to a second dashboard —
+// and splitting one deliberate action across two systems is how "we thought it
+// was off" happens.
+func writeFlagAPISection(b *strings.Builder, publicURL, slug string) {
+	const keyHeader = "X-FunnelBarn-Api-Key"
+
+	fmt.Fprintf(b, "### Reading and toggling flags from a service\n\n")
+	fmt.Fprintf(b, "Evaluation (above) tells a client what *it* resolves. To report what the\n")
+	fmt.Fprintf(b, "project actually holds — and to change it — use a **project-scoped flag\n")
+	fmt.Fprintf(b, "token**. That distinction matters: \"the flag is off\" and \"the flag does not\n")
+	fmt.Fprintf(b, "exist and you are seeing your own default\" are very different answers.\n\n")
+	fmt.Fprintf(b, "Create one in the dashboard under **Settings → API Keys**, with scope:\n\n")
+	fmt.Fprintf(b, "| Scope | May |\n")
+	fmt.Fprintf(b, "|-------|-----|\n")
+	fmt.Fprintf(b, "| `flags:read` | list and read this project's flags |\n")
+	fmt.Fprintf(b, "| `flags:write` | the above, plus update an existing flag (enable / disable / change its value) |\n\n")
+	fmt.Fprintf(b, "Tokens are bound to one project, hashed at rest, revocable, and carry a\n")
+	fmt.Fprintf(b, "last-used timestamp. Neither scope can **create or delete** a flag:\n")
+	fmt.Fprintf(b, "auto-registration already covers creation, and a token that can turn a gate\n")
+	fmt.Fprintf(b, "off should not also be able to delete the gate.\n\n")
+	fmt.Fprintf(b, "```bash\n")
+	fmt.Fprintf(b, "# Read the project's real flag state\n")
+	fmt.Fprintf(b, "curl -s '%s/api/v1/projects/<project-id>/flags' \\\n", publicURL)
+	fmt.Fprintf(b, "  -H '%s: <flags-token>'\n\n", keyHeader)
+	fmt.Fprintf(b, "# Turn a gate off. Fields you omit keep their current values, so a toggle\n")
+	fmt.Fprintf(b, "# is exactly this and nothing else.\n")
+	fmt.Fprintf(b, "curl -s -X PUT '%s/api/v1/projects/<project-id>/flags/<flag-id>' \\\n", publicURL)
+	fmt.Fprintf(b, "  -H '%s: <flags-token>' \\\n", keyHeader)
+	fmt.Fprintf(b, "  -H 'Content-Type: application/json' \\\n")
+	fmt.Fprintf(b, "  -d '{\"status\": \"paused\"}'\n")
+	fmt.Fprintf(b, "```\n\n")
+	fmt.Fprintf(b, "The instance-wide `FUNNELBARN_API_KEY` is refused here: it resolves with no\n")
+	fmt.Fprintf(b, "project, which would make it a master key for every project's flags. Use a\n")
+	fmt.Fprintf(b, "key issued for `%s`.\n\n", slug)
 }

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -42,3 +42,20 @@ func Normalize(s string) string {
 	}
 	return Production
 }
+
+// IsKnown reports whether s is a recognised environment alias. An unrecognised
+// value still normalises to Production rather than being rejected — dropping an
+// event over a typo is worse than mis-filing it — but callers use this to say
+// so out loud instead of silently mis-filing "prodution" as production.
+func IsKnown(s string) bool {
+	if s == "" {
+		return true
+	}
+	_, ok := aliases[strings.ToLower(strings.TrimSpace(s))]
+	return ok
+}
+
+// Canonical returns the four canonical environment values, in reporting order.
+func Canonical() []string {
+	return []string{Production, Staging, Test, Development}
+}

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -40,3 +40,33 @@ func TestNormalize(t *testing.T) {
 		}
 	}
 }
+
+func TestIsKnown(t *testing.T) {
+	known := []string{"", "prod", "PROD", " staging ", "qa", "local"}
+	for _, s := range known {
+		if !IsKnown(s) {
+			t.Errorf("IsKnown(%q) = false, want true", s)
+		}
+	}
+	// These still normalise to production, but the caller can now say so.
+	for _, s := range []string{"prodution", "feat-branch", "not-a-real-env"} {
+		if IsKnown(s) {
+			t.Errorf("IsKnown(%q) = true, want false", s)
+		}
+		if got := Normalize(s); got != Production {
+			t.Errorf("Normalize(%q) = %q, want %q — a typo must still be filed, not dropped", s, got, Production)
+		}
+	}
+}
+
+func TestCanonical(t *testing.T) {
+	got := Canonical()
+	if len(got) != 4 || got[0] != Production {
+		t.Errorf("Canonical() = %v", got)
+	}
+	for _, e := range got {
+		if Normalize(e) != e {
+			t.Errorf("canonical value %q does not normalise to itself", e)
+		}
+	}
+}

--- a/internal/repository/apikeys.go
+++ b/internal/repository/apikeys.go
@@ -17,6 +17,10 @@ type APIKey struct {
 	KeyHash   string    `json:"-"`
 	Scope     string    `json:"scope"`
 	CreatedAt time.Time `json:"created_at"`
+	// LastUsedAt is when a request last authenticated with this key. Nil means
+	// never used — which is how you tell a token that was issued and forgotten
+	// from one something depends on before revoking it.
+	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
 }
 
 // ValidAPIKeySHA256 looks up an API key by its SHA256 hex digest.
@@ -104,7 +108,7 @@ func isNoRows(err error) bool {
 }
 
 func apiKeyFromGen(k sqlcgen.ApiKey) APIKey {
-	return APIKey{
+	key := APIKey{
 		ID:        k.ID,
 		ProjectID: k.ProjectID,
 		Name:      k.Name,
@@ -112,4 +116,9 @@ func apiKeyFromGen(k sqlcgen.ApiKey) APIKey {
 		Scope:     k.Scope,
 		CreatedAt: k.CreatedAt,
 	}
+	if k.LastUsedAt.Valid {
+		t := k.LastUsedAt.Time
+		key.LastUsedAt = &t
+	}
+	return key
 }

--- a/internal/repository/projects.go
+++ b/internal/repository/projects.go
@@ -23,6 +23,20 @@ const APIKeyScopeFull = "full"
 // APIKeyScopeIngest allows only event ingest.
 const APIKeyScopeIngest = "ingest"
 
+// APIKeyScopeFlagsRead allows reading a project's feature flags without a
+// dashboard session, so a service can report what the project actually holds
+// rather than what its own client resolved — "the flag is off" and "the flag
+// does not exist and you are seeing your own default" are very different
+// answers when the question is whether mail is about to go out.
+const APIKeyScopeFlagsRead = "flags:read"
+
+// APIKeyScopeFlagsWrite additionally allows updating an existing flag
+// (enable / disable / change its value). It deliberately does not allow
+// creating or deleting flags: auto-registration already covers creation, and a
+// token that can turn an outbound-email gate on should not also be able to
+// delete the gate.
+const APIKeyScopeFlagsWrite = "flags:write"
+
 // Project represents a tracked website or application.
 type Project struct {
 	ID        string    `json:"id"`

--- a/internal/service/apikeys.go
+++ b/internal/service/apikeys.go
@@ -26,10 +26,26 @@ func (svc *APIKeyService) CreateAPIKey(ctx context.Context, name, projectID, key
 	if strings.TrimSpace(projectID) == "" {
 		return repository.APIKey{}, &domain.ValidationError{Field: "project_id", Message: "required"}
 	}
-	if scope != repository.APIKeyScopeFull && scope != repository.APIKeyScopeIngest {
-		return repository.APIKey{}, &domain.ValidationError{Field: "scope", Message: "must be \"full\" or \"ingest\""}
+	if !validAPIKeyScope(scope) {
+		return repository.APIKey{}, &domain.ValidationError{
+			Field:   "scope",
+			Message: `must be one of "full", "ingest", "flags:read", "flags:write"`,
+		}
 	}
 	return svc.store.CreateAPIKey(ctx, name, projectID, keySHA256, scope)
+}
+
+// validAPIKeyScope gates what a key may be issued with. Anything not listed is
+// refused outright rather than stored and silently treated as no access.
+func validAPIKeyScope(scope string) bool {
+	switch scope {
+	case repository.APIKeyScopeFull,
+		repository.APIKeyScopeIngest,
+		repository.APIKeyScopeFlagsRead,
+		repository.APIKeyScopeFlagsWrite:
+		return true
+	}
+	return false
 }
 
 func (svc *APIKeyService) ListAPIKeys(ctx context.Context, projectID string) ([]repository.APIKey, error) {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/wiebe-xyz/funnelbarn/internal/enrich"
@@ -59,8 +60,14 @@ func ProcessRecord(record spool.Record) (repository.Event, error) {
 		occurredAt = record.ReceivedAt
 	}
 
-	// Normalize environment to a canonical value.
+	// Normalize environment to a canonical value. An unrecognised value is
+	// filed as production rather than rejected — dropping an event over a typo
+	// is worse than mis-filing it — but say so once per distinct value, or
+	// "prodution" silently pollutes production reporting forever.
 	env := environment.Normalize(payload.Environment)
+	if !environment.IsKnown(payload.Environment) {
+		warnUnknownEnvironment(payload.Environment, env)
+	}
 
 	// Derive session ID.
 	sessionID := payload.SessionID
@@ -278,4 +285,33 @@ func coalesce(vals ...string) string {
 		}
 	}
 	return ""
+}
+
+// unknownEnvironments bounds the "unrecognised environment" warning to one line
+// per distinct value per process, so a misconfigured client reports its typo
+// once instead of thousands of times a day. The cap stops a caller that sends a
+// random value per event from growing the set without limit.
+var unknownEnvironments = struct {
+	sync.Mutex
+	seen map[string]struct{}
+}{seen: make(map[string]struct{})}
+
+const maxTrackedUnknownEnvironments = 64
+
+func warnUnknownEnvironment(raw, filedAs string) {
+	unknownEnvironments.Lock()
+	_, already := unknownEnvironments.seen[raw]
+	if !already && len(unknownEnvironments.seen) < maxTrackedUnknownEnvironments {
+		unknownEnvironments.seen[raw] = struct{}{}
+	}
+	unknownEnvironments.Unlock()
+	if already {
+		return
+	}
+	slog.Warn("event carries an unrecognised environment; filing it under the default",
+		"handled", true,
+		"environment", raw,
+		"filed_as", filedAs,
+		"known", environment.Canonical(),
+	)
 }

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/wiebe-xyz/funnelbarn/internal/environment"
 	"github.com/wiebe-xyz/funnelbarn/internal/spool"
 )
 
@@ -295,5 +296,43 @@ func TestCoalesce(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("coalesce(%v) = %q, want %q", tc.vals, got, tc.want)
 		}
+	}
+}
+
+// An unrecognised environment is filed under the default rather than rejected —
+// dropping an event over a typo is worse than mis-filing it — but the process
+// says so once per distinct value instead of silently polluting reporting.
+func TestProcessRecord_UnknownEnvironmentIsFiledNotDropped(t *testing.T) {
+	body := base64.StdEncoding.EncodeToString([]byte(
+		`{"name":"page_view","environment":"prodution"}`))
+	rec := spool.Record{
+		IngestID:   "ingest-env-1",
+		ReceivedAt: time.Now().UTC(),
+		BodyBase64: body,
+	}
+
+	event, err := ProcessRecord(rec)
+	if err != nil {
+		t.Fatalf("ProcessRecord: %v", err)
+	}
+	if event.Environment != environment.Production {
+		t.Errorf("environment: want %q, got %q", environment.Production, event.Environment)
+	}
+	if event.Name != "page_view" {
+		t.Errorf("the event must still be processed, got name %q", event.Name)
+	}
+}
+
+func TestProcessRecord_KnownEnvironmentAliasIsCanonicalised(t *testing.T) {
+	body := base64.StdEncoding.EncodeToString([]byte(
+		`{"name":"page_view","environment":"STG"}`))
+	event, err := ProcessRecord(spool.Record{
+		IngestID: "ingest-env-2", ReceivedAt: time.Now().UTC(), BodyBase64: body,
+	})
+	if err != nil {
+		t.Fatalf("ProcessRecord: %v", err)
+	}
+	if event.Environment != environment.Staging {
+		t.Errorf("environment: want %q, got %q", environment.Staging, event.Environment)
 	}
 }

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -24,6 +24,9 @@ func main() {
         APIKey:      "your-api-key",
         Endpoint:    "https://funnelbarn.example.com",
         ProjectName: "my-app",
+        // Tags every event, so one key and project can be reused across
+        // deployments and filtered apart in the dashboard.
+        Environment: "production",
     })
     defer funnelbarn.Shutdown(5 * time.Second)
 

--- a/sdks/go/env_test.go
+++ b/sdks/go/env_test.go
@@ -1,0 +1,65 @@
+package funnelbarn
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// The environment option was documented and silently dropped, so events
+// arrived untagged and the dashboard filter had nothing to filter on. Every
+// event the SDK sends must carry it.
+func TestTrackAndPage_TagEnvironment(t *testing.T) {
+	bodies := make(chan map[string]any, 4)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var b map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&b)
+		bodies <- b
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	Init(Options{APIKey: "k", Endpoint: srv.URL, ProjectName: "p", Environment: "staging"})
+	Track("signup", nil)
+	Page("https://example.com/", "")
+	if err := Shutdown(3 * time.Second); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		select {
+		case b := <-bodies:
+			if b["environment"] != "staging" {
+				t.Errorf("event %d: environment = %v, want staging", i, b["environment"])
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatalf("timed out waiting for event %d", i)
+		}
+	}
+}
+
+func TestTrack_OmitsEnvironmentWhenUnset(t *testing.T) {
+	bodies := make(chan map[string]any, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var b map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&b)
+		bodies <- b
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	Init(Options{APIKey: "k", Endpoint: srv.URL})
+	Track("signup", nil)
+	_ = Shutdown(3 * time.Second)
+
+	select {
+	case b := <-bodies:
+		if _, present := b["environment"]; present {
+			t.Errorf("environment should be omitted when unset, got %v", b["environment"])
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out")
+	}
+}

--- a/sdks/go/funnelbarn.go
+++ b/sdks/go/funnelbarn.go
@@ -19,6 +19,12 @@ type Options struct {
 	ProjectName string
 	QueueSize   int // default 256
 
+	// Environment tags every event ("production", "staging", "test",
+	// "development"), so one key and project can be reused across deployments
+	// and filtered apart in the dashboard. Aliases are normalised server-side;
+	// an unrecognised value is filed under production and warned about.
+	Environment string
+
 	// FlagCacheTTL is how long a resolved flag is reused when the server sends
 	// no cache hint of its own. Zero means DefaultFlagCacheTTL; negative
 	// disables the cache entirely. A server that does advertise
@@ -43,6 +49,7 @@ type eventPayload struct {
 	UserID      string         `json:"user_id,omitempty"`
 	SessionID   string         `json:"session_id,omitempty"`
 	Timestamp   time.Time      `json:"timestamp"`
+	Environment string         `json:"environment,omitempty"`
 }
 
 var (
@@ -150,6 +157,9 @@ func newTransport(o Options) *transport {
 }
 
 func (t *transport) enqueue(e eventPayload) bool {
+	// Stamped here so no event can escape untagged — an option that reaches
+	// only some events makes the dashboard filter silently under-count.
+	e.Environment = t.opts.Environment
 	select {
 	case t.queue <- e:
 		return true

--- a/sdks/js/src/iife.ts
+++ b/sdks/js/src/iife.ts
@@ -31,7 +31,7 @@ function identify(userId: string): void {
 export { init, track, page, identify };
 
 // Auto-init from script tag data attributes:
-//   <script src="/sdk.js" data-api-key="fb_xxx"></script>
+//   <script src="/sdk.js" data-api-key="fb_xxx" data-environment="staging"></script>
 if (typeof document !== "undefined") {
   const script = document.currentScript as HTMLScriptElement | null;
   if (script) {
@@ -39,8 +39,9 @@ if (typeof document !== "undefined") {
     if (apiKey) {
       const endpoint = script.getAttribute("data-endpoint") || script.src.replace(/\/sdk\.js.*$/, "");
       const projectName = script.getAttribute("data-project-name") ?? undefined;
+      const environment = script.getAttribute("data-environment") ?? undefined;
       const recording = script.getAttribute("data-recording") === "true";
-      init({ apiKey, endpoint, projectName, recording });
+      init({ apiKey, endpoint, projectName, environment, recording });
       page();
     }
   }

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -18,6 +18,14 @@ export interface FunnelBarnOptions {
   endpoint: string;
   /** Optional project name sent as x-funnelbarn-project header */
   projectName?: string;
+  /**
+   * Deployment environment tagged on every event, so one API key and project
+   * can be reused across dev / staging / production and filtered apart in the
+   * dashboard. Aliases are normalised server-side ("prod" and "live" both mean
+   * production); an unrecognised value is treated as production, so a typo is
+   * worth avoiding.
+   */
+  environment?: string;
   /** Flush interval in ms (default: 5000) */
   flushInterval?: number;
   /** Session idle timeout in ms (default: 30 minutes) */
@@ -89,6 +97,7 @@ interface EventPayload {
   page_view_id?: string;
   session_signals?: Record<string, unknown>;
   vitals?: Record<string, number>;
+  environment?: string;
 }
 
 const SESSION_KEY = "funnelbarn_sid";
@@ -115,6 +124,7 @@ export class FunnelBarnClient {
   private readonly apiKey: string;
   private readonly endpoint: string;
   private readonly projectName?: string;
+  private readonly environment?: string;
   private readonly flushInterval: number;
   private readonly sessionTimeout: number;
 
@@ -162,6 +172,7 @@ export class FunnelBarnClient {
     this.apiKey = options.apiKey;
     this.endpoint = options.endpoint.replace(/\/$/, "");
     this.projectName = options.projectName;
+    this.environment = options.environment;
     this.flushInterval = options.flushInterval ?? 5000;
     this.sessionTimeout = options.sessionTimeout ?? SESSION_TIMEOUT_DEFAULT;
     this.recordingOptions = options;
@@ -177,7 +188,7 @@ export class FunnelBarnClient {
         if (this.vitalsFlushed || !this.vitalsPageViewId) return;
         if (Object.keys(this.pendingVitals).length === 0) return;
         this.vitalsFlushed = true;
-        this.queue.push({
+        this.enqueue({
           name: "web_vitals",
           page_view_id: this.vitalsPageViewId,
           session_id: this.getOrCreateSessionID(),
@@ -287,10 +298,22 @@ export class FunnelBarnClient {
       payload.vitals = vitalsForEvent;
     }
 
-    this.queue.push(payload);
+    this.enqueue(payload);
 
     // Start engagement tracking for this page view.
     this.startEngagementTracking();
+  }
+
+  /**
+   * Queue an event, stamping the configured environment on it.
+   *
+   * Every enqueue goes through here so no event can escape untagged — an
+   * option that only reaches some events is worse than no option at all,
+   * because the dashboard filter then silently under-counts.
+   */
+  private enqueue(payload: EventPayload): void {
+    if (this.environment) payload.environment = this.environment;
+    this.queue.push(payload);
   }
 
   /**
@@ -301,7 +324,7 @@ export class FunnelBarnClient {
     const url = this.detectURL();
     const utms = this.extractUTMs(url);
 
-    this.queue.push({
+    this.enqueue({
       name,
       url,
       ...utms,
@@ -492,7 +515,7 @@ export class FunnelBarnClient {
       if (this.engagementFired) return;
       this.engagementFired = true;
       this.cleanupEngagement();
-      this.queue.push({
+      this.enqueue({
         name: "page_engaged",
         page_view_id: pageViewId,
         session_id: this.getOrCreateSessionID(),

--- a/sdks/js/test/sdk.test.mjs
+++ b/sdks/js/test/sdk.test.mjs
@@ -52,6 +52,30 @@ describe('FunnelBarnClient', () => {
     assert.equal(body.name, 'page_view');
   });
 
+  it('tags every event with the configured environment', async () => {
+    // The guide documented an `environment` option the client silently
+    // dropped, so events arrived untagged and the dashboard filter had
+    // nothing to filter on. Every event the SDK sends must carry it.
+    const client = new FunnelBarnClient({
+      apiKey: 'test-key', endpoint: 'http://localhost:8080', environment: 'staging',
+    });
+    client.page();
+    client.track('signup');
+    await client.flush();
+
+    assert.equal(requests.length, 2);
+    for (const r of requests) {
+      assert.equal(JSON.parse(r.options.body).environment, 'staging');
+    }
+  });
+
+  it('omits environment when it is not configured', async () => {
+    const client = new FunnelBarnClient({ apiKey: 'test-key', endpoint: 'http://localhost:8080' });
+    client.track('signup');
+    await client.flush();
+    assert.equal(JSON.parse(requests[0].options.body).environment, undefined);
+  });
+
   it('identify() sets user_id on subsequent events', async () => {
     const client = new FunnelBarnClient({ apiKey: 'test-key', endpoint: 'http://localhost:8080' });
     client.identify('user-123');

--- a/site/src/content/docs/sdk-js.md
+++ b/site/src/content/docs/sdk-js.md
@@ -10,22 +10,27 @@ The `@funnelbarn/js` package works in all modern browsers (and Node.js — see t
 
 ## Installation
 
-### npm / yarn / pnpm
+### Script tag (recommended)
 
-```bash
-npm install @funnelbarn/js
-```
-
-### Script tag (no bundler)
-
-If you are not using a bundler, load the SDK from your FunnelBarn instance's built-in CDN path:
+Load the SDK from your FunnelBarn instance's built-in path:
 
 ```html
 <script src="https://funnelbarn.example.com/sdk.js"
-        data-api-key="your-ingest-api-key" defer></script>
+        data-api-key="your-ingest-api-key"
+        data-project-name="my-website"
+        data-environment="production" defer></script>
 ```
 
 The SDK auto-initialises from `data-api-key`, infers the endpoint from the script's `src` URL, and exposes a global `funnelbarn` object with `track()`, `page()`, and `identify()` methods.
+
+### npm / yarn / pnpm
+
+> **The package is not on the public npm registry yet.** `npm install
+> @funnelbarn/js` 404s today — the publish job in `binary-release.yml` is
+> skipped while the `NPM_TOKEN` secret is unset. Until it is published, load
+> the SDK from your instance's built-in path (below), which serves the same
+> build. In a bundler project you can also vendor `sdks/js` directly.
+
 
 ## Usage with a bundler
 
@@ -36,6 +41,7 @@ const analytics = new FunnelBarnClient({
   apiKey: 'your-ingest-api-key',
   endpoint: 'https://funnelbarn.example.com',
   projectName: 'my-website',   // optional but recommended
+  environment: 'production',   // tags every event; filter by it in the dashboard
 });
 
 // Track current page view (auto-reads window.location and document.referrer)

--- a/site/src/content/docs/sdk-node.md
+++ b/site/src/content/docs/sdk-node.md
@@ -14,6 +14,10 @@ The same `@funnelbarn/js` package works server-side in Node.js. It buffers event
 npm install @funnelbarn/js
 ```
 
+> **The package is not on the public npm registry yet** — the publish job in
+> `binary-release.yml` is skipped while the `NPM_TOKEN` secret is unset, so this
+> command 404s today. Vendor `sdks/js` from the repo in the meantime.
+
 ## Basic setup
 
 ```typescript
@@ -23,6 +27,7 @@ export const analytics = new FunnelBarnClient({
   apiKey: process.env.FUNNELBARN_API_KEY!,
   endpoint: process.env.FUNNELBARN_ENDPOINT!,
   projectName: 'my-api',
+  environment: process.env.NODE_ENV === 'production' ? 'production' : 'development',
   flushInterval: 2000,   // flush every 2 seconds (default 5s)
 });
 ```

--- a/web/src/components/settings/ApiKeySettings.test.ts
+++ b/web/src/components/settings/ApiKeySettings.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { scopeTone, scopeHint, formatLastUsed } from './ApiKeySettings'
+
+describe('scopeTone', () => {
+  it('marks scopes that can change state', () => {
+    expect(scopeTone('full')).toBe('write')
+    expect(scopeTone('flags:write')).toBe('write')
+  })
+
+  it('marks send-only and read-only scopes', () => {
+    expect(scopeTone('ingest')).toBe('read')
+    expect(scopeTone('flags:read')).toBe('read')
+  })
+
+  it('treats an unrecognised scope as read rather than implying power it lacks', () => {
+    expect(scopeTone('flags:admin')).toBe('read')
+  })
+})
+
+describe('scopeHint', () => {
+  it('says what each scope may do', () => {
+    expect(scopeHint('ingest')).toMatch(/Send events/)
+    expect(scopeHint('flags:read')).toMatch(/Cannot change/)
+    expect(scopeHint('flags:write')).toMatch(/Cannot create or delete/)
+    expect(scopeHint('full')).toMatch(/Full API access/)
+  })
+
+  it('is explicit that an unknown scope grants nothing', () => {
+    expect(scopeHint('flags:admin')).toMatch(/grants nothing/)
+  })
+})
+
+describe('formatLastUsed', () => {
+  it('reports never for a key that has not authenticated', () => {
+    expect(formatLastUsed(undefined)).toBe('never')
+    expect(formatLastUsed('')).toBe('never')
+  })
+
+  it('reports never rather than "Invalid Date" for junk', () => {
+    expect(formatLastUsed('not-a-date')).toBe('never')
+  })
+
+  it('formats a real timestamp', () => {
+    expect(formatLastUsed('2026-08-23T10:00:00Z')).not.toBe('never')
+  })
+})

--- a/web/src/components/settings/ApiKeySettings.tsx
+++ b/web/src/components/settings/ApiKeySettings.tsx
@@ -15,21 +15,49 @@ const C = {
   success: '#10b981',
 }
 
+// scopeTone colours a badge by how much the key can do: amber for
+// send-or-read-only, green for anything that can change state. The point is
+// that "this token can turn the outbound-email gate off" reads differently at
+// a glance from "this token sends page views".
+export function scopeTone(scope: string): 'read' | 'write' {
+  return scope === 'full' || scope === 'flags:write' ? 'write' : 'read'
+}
+
+// scopeHint explains, in one line, what a key with this scope may do.
+export function scopeHint(scope: string): string {
+  switch (scope) {
+    case 'ingest': return 'Send events. Cannot read or change anything.'
+    case 'flags:read': return "Read this project's flags. Cannot change them."
+    case 'flags:write': return "Read and update this project's flags. Cannot create or delete them."
+    case 'full': return 'Full API access to this project.'
+    default: return 'Unknown scope — this key grants nothing.'
+  }
+}
+
 function ScopeBadge({ scope }: { scope: string }) {
-  const isIngest = scope === 'ingest'
+  const write = scopeTone(scope) === 'write'
   return (
-    <span style={{
+    <span title={scopeHint(scope)} style={{
       fontSize: 12,
       fontWeight: 600,
-      background: isIngest ? 'rgba(245,158,11,0.1)' : 'rgba(16,185,129,0.1)',
-      color: isIngest ? C.amber : C.success,
-      border: `1px solid ${isIngest ? 'rgba(245,158,11,0.3)' : 'rgba(16,185,129,0.3)'}`,
+      background: write ? 'rgba(16,185,129,0.1)' : 'rgba(245,158,11,0.1)',
+      color: write ? C.success : C.amber,
+      border: `1px solid ${write ? 'rgba(16,185,129,0.3)' : 'rgba(245,158,11,0.3)'}`,
       borderRadius: 99,
       padding: '0.15rem 0.6rem',
+      whiteSpace: 'nowrap',
     }}>
       {scope}
     </span>
   )
+}
+
+// formatLastUsed distinguishes a token something depends on from one that was
+// issued and forgotten — the question you actually have before revoking.
+export function formatLastUsed(iso?: string): string {
+  if (!iso) return 'never'
+  const d = new Date(iso)
+  return isNaN(d.getTime()) ? 'never' : d.toLocaleString()
 }
 
 interface ApiKeySettingsProps {
@@ -106,7 +134,8 @@ export function ApiKeySettings({
         <div>
           <div style={{ fontWeight: 700, fontSize: 15 }}>API Keys</div>
           <div style={{ fontSize: 13, color: C.muted, marginTop: 2 }}>
-            Keys for sending events or full management access.
+            Keys for sending events, reading or toggling this project&apos;s
+            feature flags, or full management access.
           </div>
         </div>
       </div>
@@ -176,7 +205,7 @@ export function ApiKeySettings({
             <table style={{ width: '100%', borderCollapse: 'collapse' }}>
               <thead>
                 <tr style={{ borderBottom: `1px solid ${C.border}` }}>
-                  {['Name', 'Scope', 'Created', ''].map((h) => (
+                  {['Name', 'Scope', 'Created', 'Last used', ''].map((h) => (
                     <th key={h} style={{
                       textAlign: 'left',
                       padding: '0.75rem 1.5rem',
@@ -203,6 +232,9 @@ export function ApiKeySettings({
                     </td>
                     <td style={{ padding: '0.875rem 1.5rem', fontSize: 13, color: C.muted, whiteSpace: 'nowrap' }}>
                       {new Date(key.created_at).toLocaleDateString()}
+                    </td>
+                    <td style={{ padding: '0.875rem 1.5rem', fontSize: 13, color: key.last_used_at ? C.muted : '#4a4d5a', whiteSpace: 'nowrap' }}>
+                      {formatLastUsed(key.last_used_at)}
                     </td>
                     <td style={{ padding: '0.875rem 1.5rem', textAlign: 'right', whiteSpace: 'nowrap' }}>
                       {deleteConfirm === key.id ? (
@@ -274,7 +306,7 @@ export function ApiKeySettings({
                 </div>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                   <span style={{ fontSize: 12, color: C.muted }}>
-                    Created: {new Date(key.created_at).toLocaleDateString()}
+                    Created: {new Date(key.created_at).toLocaleDateString()} · Last used: {formatLastUsed(key.last_used_at)}
                   </span>
                   {deleteConfirm === key.id ? (
                     <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
@@ -390,8 +422,10 @@ export function ApiKeySettings({
               outline: 'none',
             }}
           >
-            <option value="ingest">ingest</option>
-            <option value="full">full</option>
+            <option value="ingest">ingest — send events</option>
+            <option value="flags:read">flags:read — read this project&apos;s flags</option>
+            <option value="flags:write">flags:write — read and toggle flags</option>
+            <option value="full">full — everything</option>
           </select>
           <button
             onClick={handleCreate}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -566,8 +566,11 @@ export interface Segment {
 export interface ApiKey {
   id: string
   name: string
+  /** 'ingest' | 'flags:read' | 'flags:write' | 'full' */
   scope: string
   created_at: string
+  /** Absent when the key has never authenticated a request. */
+  last_used_at?: string
 }
 
 // Feature-flag shapes live in ./api.flags and are re-exported here so every


### PR DESCRIPTION
Every flag route was `requireSession`, so nothing but a browser could read or
change a flag. rapid-root's operator surface on `main.wiebe.xyz` is stuck
read-only with `editable: false`, and turning the outbound-email gate off means
leaving the admin surface, opening the FunnelBarn dashboard, and finding the
right one of eleven projects. Splitting one deliberate action across two
systems is how "we thought it was off" happens.

Read matters just as much: the surface currently reports what the *client*
resolved, so it can't tell "the flag is off" from "the flag doesn't exist and
you're seeing your own default".

## Scopes

Two new API key scopes on the existing `api_keys` table, so dashboard issuance,
revocation, hashing at rest and `last_used_at` all come for free:

| Scope | May |
|---|---|
| `flags:read` | list and read the bound project's flags |
| `flags:write` | the above, plus update an existing flag |

Read is implied by write; `full` covers both; `ingest` covers neither; an
unknown scope covers nothing and is refused at issuance.

**Create and delete stay session-only**, per the issue — auto-registration
already covers creation, and a token that can turn a gate off shouldn't also be
able to delete the gate.

## The scoping is real, not decorative

- The instance-wide `FUNNELBARN_API_KEY` resolves with **no** project, which
  would make it a master key for every project's flags. Refused, with a message
  naming the fix (same lesson as #188).
- A token whose project differs from the URL's gets a 403 — scherpstel's token
  cannot touch places.
- **New `flagInProject`**: `GET`/`PUT`/`DELETE` on `/projects/{id}/flags/{fid}`
  never verified that the flag belonged to `{id}`. A scoped token could
  otherwise reach any flag in the instance by ID and the URL's project would be
  decoration. Now 404 (not 403 — a caller scoped elsewhere shouldn't learn the
  ID exists). This closes the same hole for session callers.
- A request carrying an API key is authenticated as a token **and nothing
  else**. Falling through to the session path on a bad token would turn a
  revoked credential into a silent success for whoever is logged in on that
  browser.
- No CSRF check on the token path: the request is authenticated by a header a
  browser never attaches on its own.

`handleUpdateFlag` now preserves every field the caller omits, so a toggle is
`{"status":"paused"}` and nothing else rather than a read-modify-write of the
whole flag.

## Dashboard

New scopes in the key picker with one-line explanations of what each may do, a
**Last used** column (a token something depends on looks different from one
issued and forgotten — the question you actually have before revoking), and
badge colours by whether the scope can change state.

## The two smaller items from the issue

**1. `@funnelbarn/js` isn't published.** The publish job in
`binary-release.yml` is gated on `if: env.NPM_TOKEN != ''` and that secret
isn't set, so it silently no-ops and `npm install @funnelbarn/js` 404s. Since I
can't add the token, I've taken the issue's other option: the setup doc and the
site's JS/Node guides no longer tell people to install it, and the script tag
is presented as the supported path. Adding `NPM_TOKEN` is all that's needed to
turn the publish job back on, at which point the notes can come out.

**2. The SDK now supports `environment`.** It was documented in the guide and
silently dropped by the client, and no event carried the field. It's stamped in
a single `enqueue` helper so *no* event can escape untagged — an option that
reaches only some events is worse than none, because the dashboard filter then
under-counts silently. Also exposed as a `data-environment` script-tag
attribute.

**And the typo note.** `environment: "not-a-real-env"` still gets a 202 and is
still filed under production — dropping an event over a typo is worse than
mis-filing it — but the worker now warns once per distinct unrecognised value
(bounded set, so a caller sending a random value per event can't grow it)
instead of letting `prodution` silently pollute production reporting forever.

## CI

`sdks/js` was built in CI but never tested. The `frontend-test` job now runs
its suite.

Closes #210