### PR TITLE
feat(observability): browser-to-backend distributed tracing

### DIFF
--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -225,8 +225,14 @@ func run() error {
 	}
 	defer shutdownMetrics(context.Background())
 
+	// Relays the dashboard's own browser spans to SpanBarn, so a trace shows the
+	// page and the client-side view of each API call above the server spans that
+	// already join it via the traceparent header.
+	spanRelay := tracing.NewSpanRelay(otelCfg)
+	defer spanRelay.Shutdown()
+
 	if cfg.SpanBarnEndpoint != "" {
-		slog.Info("spanbarn telemetry enabled", "endpoint", cfg.SpanBarnEndpoint, "signals", "traces,metrics,logs")
+		slog.Info("spanbarn telemetry enabled", "endpoint", cfg.SpanBarnEndpoint, "signals", "traces,metrics,logs,browser-spans")
 	}
 
 	store, err := repository.Open(cfg.DBPath)
@@ -392,6 +398,7 @@ func run() error {
 		RecordingSettings:     store,
 		ProjectHealth:         healthSvc,
 		FlagAutoRegisterMax:   cfg.AutoRegisterMaxFlags,
+		SpanRelay:             spanRelay,
 	})
 	if cfg.MetricsToken != "" {
 		apiServer.SetMetricsToken(cfg.MetricsToken)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -14,8 +14,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/sync/singleflight"
 
-	"go.opentelemetry.io/otel/attribute"
-
 	"github.com/wiebe-xyz/funnelbarn/internal/auth"
 	"github.com/wiebe-xyz/funnelbarn/internal/domain"
 	"github.com/wiebe-xyz/funnelbarn/internal/environment"
@@ -106,6 +104,10 @@ type ServerConfig struct {
 	RecordingSettings ProjectRecordingSettingsRepo
 	ProjectHealth     service.ProjectHealth
 
+	// SpanRelay forwards the dashboard's own browser spans to SpanBarn. Nil when
+	// telemetry export is not configured; the endpoint then accepts and drops.
+	SpanRelay *tracing.SpanRelay
+
 	// FlagAutoRegisterMax caps auto-created flags per project on the SDK evaluate
 	// endpoint (0 disables auto-registration).
 	FlagAutoRegisterMax int
@@ -171,6 +173,7 @@ type Server struct {
 	recordingSettings   ProjectRecordingSettingsRepo
 	projectHealth       service.ProjectHealth
 	flagAutoRegisterMax int
+	spanRelay           *tracing.SpanRelay
 
 	loginLimiter  *rateLimiter
 	eventsLimiter *rateLimiter
@@ -237,6 +240,7 @@ func NewServer(cfg ServerConfig) *Server {
 		recordingSettings:   cfg.RecordingSettings,
 		projectHealth:       cfg.ProjectHealth,
 		flagAutoRegisterMax: cfg.FlagAutoRegisterMax,
+		spanRelay:           cfg.SpanRelay,
 	}
 	if s.oidcRefreshGrace <= 0 {
 		s.oidcRefreshGrace = time.Hour
@@ -374,6 +378,11 @@ func (s *Server) registerRoutes() {
 	// Dogfooding playground — same flag-eval logic as the customer endpoint
 	// but session-authed so the dashboard can call it without an API key in the browser.
 	s.mux.HandleFunc("POST /api/v1/projects/{id}/flags/evaluate", s.requireSession(s.handlePlaygroundEvaluateFlag))
+
+	// Dashboard self-instrumentation. Session-authed so the browser never holds
+	// a telemetry or BugBarn key — see internal/api/telemetry.go.
+	s.mux.HandleFunc("POST /api/v1/telemetry", s.requireSession(s.handleTelemetry))
+	s.mux.HandleFunc("POST /api/v1/client-errors", s.requireSession(s.handleClientError))
 
 	// Flag evaluation (API key required, like ingest)
 	s.mux.Handle("POST /api/v1/evaluate", s.limit(s.eventsLimiter, http.HandlerFunc(s.handleEvaluateFlag)))
@@ -605,190 +614,6 @@ func (s *Server) setCORSHeaders(w http.ResponseWriter, r *http.Request) {
 // slightly BEFORE it actually expires — a request must never go out the door
 // authorized by a token that dies mid-flight.
 const accessTokenSkew = 30 * time.Second
-
-// requireSession wraps a handler to enforce server-side session authentication.
-// The cookie is an opaque handle; the session row (username, expiry, iambarn
-// tokens) lives in web_sessions. For OIDC sessions with an expired access
-// token it runs the refresh_token grant (singleflight per session) before
-// serving. It also applies the apiLimiter rate limit and CSRF validation on
-// mutating methods.
-//
-// The no-auth pass-through below is a development convenience only: in
-// production, startup refuses to boot with no authentication mechanism
-// configured (cmd/funnelbarn), so this branch is unreachable there.
-func (s *Server) requireSession(next http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		// authConfigured must reflect EVERY way a user can obtain a session:
-		// the env-var admin, the confidential OIDC client, AND local/DB users.
-		// Missing any of these would leave every route below served
-		// unauthenticated on a deployment that authenticates only that way.
-		authConfigured := s.userAuth.Enabled() || s.oidc != nil || s.localUsersExist
-		if s.sessionManager == nil || s.webSessions == nil || !authConfigured {
-			if !s.apiLimiter.allow(s.clientIP(r)) {
-				jsonError(w, "too many requests", http.StatusTooManyRequests)
-				return
-			}
-			next(w, r)
-			return
-		}
-
-		cookie, err := r.Cookie("funnelbarn_session")
-		if err != nil {
-			jsonError(w, "unauthorized", http.StatusUnauthorized)
-			return
-		}
-		idHash := auth.HashSessionToken(cookie.Value)
-		ws, err := s.webSessions.GetWebSession(r.Context(), idHash)
-		if err != nil {
-			// Unknown handle: revoked, pruned, or forged. Same response either
-			// way — nothing to enumerate.
-			jsonError(w, "session expired", http.StatusUnauthorized)
-			return
-		}
-		now := time.Now()
-		if ws.AbsoluteExpiresAt <= now.Unix() {
-			_ = s.webSessions.DeleteWebSession(r.Context(), idHash)
-			jsonError(w, "session expired", http.StatusUnauthorized)
-			return
-		}
-
-		// OIDC sessions are refresh-gated: session validity tracks the ~15m
-		// access token, so central revocation bites at the next refresh.
-		if ws.AuthMethod == "oidc" && s.oidc != nil && accessTokenExpired(ws, now) {
-			ws, err = s.refreshSession(r.Context(), idHash)
-			if err != nil {
-				jsonError(w, "session expired", http.StatusUnauthorized)
-				return
-			}
-		}
-
-		if isMutating(r.Method) {
-			expected := s.sessionManager.CSRFToken(cookie.Value)
-			got := r.Header.Get("X-FunnelBarn-CSRF")
-			// Constant-time compare so the CSRF token can't be recovered by timing.
-			if got == "" || subtle.ConstantTimeCompare([]byte(got), []byte(expected)) != 1 {
-				jsonError(w, "csrf token invalid", http.StatusForbidden)
-				return
-			}
-		}
-
-		if !s.apiLimiter.allow(s.clientIP(r)) {
-			jsonError(w, "too many requests", http.StatusTooManyRequests)
-			return
-		}
-
-		slog.Debug("session valid", "username", ws.Username)
-		next(w, r.WithContext(withSessionUser(r.Context(), ws.Username)))
-	}
-}
-
-// accessTokenExpired reports whether the session's access token is past (or
-// within accessTokenSkew of) its expiry. Sessions without a known expiry
-// (no expires_in in the token response) are never treated as expired.
-func accessTokenExpired(ws repository.WebSession, now time.Time) bool {
-	return ws.AccessExpiresAt != 0 && now.Unix() >= ws.AccessExpiresAt-int64(accessTokenSkew.Seconds())
-}
-
-// refreshSession runs the refresh_token grant for one session, singleflighted
-// per session row so concurrent requests cannot replay the single-use refresh
-// token (a replay revokes the whole token family at the IdP).
-//
-// Outcomes:
-//   - success: tokens rotated + claims re-snapshotted in the row
-//   - invalid_grant: the session is dead centrally → row deleted, error
-//   - transient failure (IdP down): serve stale within the grace window
-//     measured from the FIRST failure; past the window → row deleted, error
-func (s *Server) refreshSession(ctx context.Context, idHash string) (repository.WebSession, error) {
-	ctx, span := tracing.StartSpan(ctx, "oidc.refresh_session")
-	defer span.End()
-
-	// The refresh must complete even if the triggering request is canceled
-	// mid-rotation — losing the rotated refresh token kills the session.
-	// Waiting singleflight sharers also must not inherit a canceled context.
-	bgCtx := context.WithoutCancel(ctx)
-	v, err, _ := s.refreshGroup.Do(idHash, func() (any, error) {
-		ws, err := s.webSessions.GetWebSession(bgCtx, idHash)
-		if err != nil {
-			return nil, err
-		}
-		span.SetAttributes(attribute.String("oidc.sub", ws.IdpSub))
-		now := time.Now()
-		if !accessTokenExpired(ws, now) {
-			// Another flight already refreshed while we waited.
-			span.SetAttributes(attribute.String("oidc.refresh_outcome", "already_refreshed"))
-			return ws, nil
-		}
-
-		refreshed, err := s.oidc.Refresh(bgCtx, ws.RefreshToken)
-		if errors.Is(err, auth.ErrRefreshInvalid) {
-			// Revoked / rotated-elsewhere / user suspended: kill the session
-			// immediately. invalid_grant never gets grace.
-			span.SetAttributes(attribute.String("oidc.refresh_outcome", "invalid_grant"))
-			slog.InfoContext(bgCtx, "session refresh: invalid_grant, session revoked",
-				"username", ws.Username, "sub", ws.IdpSub)
-			_ = s.webSessions.DeleteWebSession(bgCtx, idHash)
-			return nil, err
-		}
-		if err != nil {
-			// Transient (network, IdP 5xx): serve stale within the grace
-			// window, measured from the first failure.
-			failingSince := ws.RefreshFailingSince
-			if failingSince == 0 {
-				failingSince = now.Unix()
-				if markErr := s.webSessions.MarkWebSessionRefreshFailing(bgCtx, idHash, failingSince); markErr != nil {
-					slog.WarnContext(bgCtx, "session refresh: mark failing", "err", markErr)
-				}
-				ws.RefreshFailingSince = failingSince
-			}
-			if now.Unix()-failingSince > int64(s.oidcRefreshGrace.Seconds()) {
-				span.SetAttributes(attribute.String("oidc.refresh_outcome", "grace_exceeded"))
-				tracing.RecordError(span, err)
-				slog.WarnContext(bgCtx, "session refresh: grace exceeded, session cut off",
-					"username", ws.Username, "failing_for", now.Unix()-failingSince)
-				_ = s.webSessions.DeleteWebSession(bgCtx, idHash)
-				return nil, err
-			}
-			span.SetAttributes(attribute.String("oidc.refresh_outcome", "stale_within_grace"))
-			slog.WarnContext(bgCtx, "session refresh failed, serving stale within grace",
-				"err", err, "username", ws.Username)
-			return ws, nil
-		}
-
-		claimsJSON := ""
-		if refreshed.Claims != nil {
-			// Re-snapshot groups/roles so central role changes propagate now,
-			// not at the next login.
-			claimsJSON = marshalClaims(*refreshed.Claims)
-		}
-		if err := s.webSessions.UpdateWebSessionTokens(bgCtx, idHash,
-			refreshed.IDToken, refreshed.AccessToken, refreshed.RefreshToken,
-			unixOrZero(refreshed.ExpiresAt), claimsJSON, now.Unix()); err != nil {
-			// The old refresh token is already burned; failing to store the new
-			// one makes the session unrenewable. Fail the request rather than
-			// pretend the session is healthy.
-			span.SetAttributes(attribute.String("oidc.refresh_outcome", "persist_error"))
-			tracing.RecordError(span, err)
-			slog.ErrorContext(bgCtx, "session refresh: persist rotated tokens",
-				"err", err, "handled", false)
-			return nil, err
-		}
-		span.SetAttributes(attribute.String("oidc.refresh_outcome", "rotated"))
-		ws.IDToken = refreshed.IDToken
-		ws.AccessToken = refreshed.AccessToken
-		ws.RefreshToken = refreshed.RefreshToken
-		ws.AccessExpiresAt = unixOrZero(refreshed.ExpiresAt)
-		if claimsJSON != "" {
-			ws.ClaimsJSON = claimsJSON
-		}
-		ws.LastRefreshAt = now.Unix()
-		ws.RefreshFailingSince = 0
-		return ws, nil
-	})
-	if err != nil {
-		return repository.WebSession{}, err
-	}
-	return v.(repository.WebSession), nil
-}
 
 func isMutating(method string) bool {
 	return method == http.MethodPost || method == http.MethodPut || method == http.MethodDelete || method == http.MethodPatch

--- a/internal/api/session_mw.go
+++ b/internal/api/session_mw.go
@@ -1,0 +1,204 @@
+package api
+
+// Session authentication for the dashboard's own routes. Split out of
+// server.go so that file stays under its length ratchet; the behaviour is
+// unchanged.
+
+import (
+	"context"
+	"crypto/subtle"
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/wiebe-xyz/funnelbarn/internal/auth"
+	"github.com/wiebe-xyz/funnelbarn/internal/repository"
+	"github.com/wiebe-xyz/funnelbarn/internal/tracing"
+)
+
+// requireSession wraps a handler to enforce server-side session authentication.
+// The cookie is an opaque handle; the session row (username, expiry, iambarn
+// tokens) lives in web_sessions. For OIDC sessions with an expired access
+// token it runs the refresh_token grant (singleflight per session) before
+// serving. It also applies the apiLimiter rate limit and CSRF validation on
+// mutating methods.
+//
+// The no-auth pass-through below is a development convenience only: in
+// production, startup refuses to boot with no authentication mechanism
+// configured (cmd/funnelbarn), so this branch is unreachable there.
+func (s *Server) requireSession(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// authConfigured must reflect EVERY way a user can obtain a session:
+		// the env-var admin, the confidential OIDC client, AND local/DB users.
+		// Missing any of these would leave every route below served
+		// unauthenticated on a deployment that authenticates only that way.
+		authConfigured := s.userAuth.Enabled() || s.oidc != nil || s.localUsersExist
+		if s.sessionManager == nil || s.webSessions == nil || !authConfigured {
+			if !s.apiLimiter.allow(s.clientIP(r)) {
+				jsonError(w, "too many requests", http.StatusTooManyRequests)
+				return
+			}
+			next(w, r)
+			return
+		}
+
+		cookie, err := r.Cookie("funnelbarn_session")
+		if err != nil {
+			jsonError(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		idHash := auth.HashSessionToken(cookie.Value)
+		ws, err := s.webSessions.GetWebSession(r.Context(), idHash)
+		if err != nil {
+			// Unknown handle: revoked, pruned, or forged. Same response either
+			// way — nothing to enumerate.
+			jsonError(w, "session expired", http.StatusUnauthorized)
+			return
+		}
+		now := time.Now()
+		if ws.AbsoluteExpiresAt <= now.Unix() {
+			_ = s.webSessions.DeleteWebSession(r.Context(), idHash)
+			jsonError(w, "session expired", http.StatusUnauthorized)
+			return
+		}
+
+		// OIDC sessions are refresh-gated: session validity tracks the ~15m
+		// access token, so central revocation bites at the next refresh.
+		if ws.AuthMethod == "oidc" && s.oidc != nil && accessTokenExpired(ws, now) {
+			ws, err = s.refreshSession(r.Context(), idHash)
+			if err != nil {
+				jsonError(w, "session expired", http.StatusUnauthorized)
+				return
+			}
+		}
+
+		if isMutating(r.Method) {
+			expected := s.sessionManager.CSRFToken(cookie.Value)
+			got := r.Header.Get("X-FunnelBarn-CSRF")
+			// Constant-time compare so the CSRF token can't be recovered by timing.
+			if got == "" || subtle.ConstantTimeCompare([]byte(got), []byte(expected)) != 1 {
+				jsonError(w, "csrf token invalid", http.StatusForbidden)
+				return
+			}
+		}
+
+		if !s.apiLimiter.allow(s.clientIP(r)) {
+			jsonError(w, "too many requests", http.StatusTooManyRequests)
+			return
+		}
+
+		slog.Debug("session valid", "username", ws.Username)
+		next(w, r.WithContext(withSessionUser(r.Context(), ws.Username)))
+	}
+}
+
+// accessTokenExpired reports whether the session's access token is past (or
+// within accessTokenSkew of) its expiry. Sessions without a known expiry
+// (no expires_in in the token response) are never treated as expired.
+func accessTokenExpired(ws repository.WebSession, now time.Time) bool {
+	return ws.AccessExpiresAt != 0 && now.Unix() >= ws.AccessExpiresAt-int64(accessTokenSkew.Seconds())
+}
+
+// refreshSession runs the refresh_token grant for one session, singleflighted
+// per session row so concurrent requests cannot replay the single-use refresh
+// token (a replay revokes the whole token family at the IdP).
+//
+// Outcomes:
+//   - success: tokens rotated + claims re-snapshotted in the row
+//   - invalid_grant: the session is dead centrally → row deleted, error
+//   - transient failure (IdP down): serve stale within the grace window
+//     measured from the FIRST failure; past the window → row deleted, error
+func (s *Server) refreshSession(ctx context.Context, idHash string) (repository.WebSession, error) {
+	ctx, span := tracing.StartSpan(ctx, "oidc.refresh_session")
+	defer span.End()
+
+	// The refresh must complete even if the triggering request is canceled
+	// mid-rotation — losing the rotated refresh token kills the session.
+	// Waiting singleflight sharers also must not inherit a canceled context.
+	bgCtx := context.WithoutCancel(ctx)
+	v, err, _ := s.refreshGroup.Do(idHash, func() (any, error) {
+		ws, err := s.webSessions.GetWebSession(bgCtx, idHash)
+		if err != nil {
+			return nil, err
+		}
+		span.SetAttributes(attribute.String("oidc.sub", ws.IdpSub))
+		now := time.Now()
+		if !accessTokenExpired(ws, now) {
+			// Another flight already refreshed while we waited.
+			span.SetAttributes(attribute.String("oidc.refresh_outcome", "already_refreshed"))
+			return ws, nil
+		}
+
+		refreshed, err := s.oidc.Refresh(bgCtx, ws.RefreshToken)
+		if errors.Is(err, auth.ErrRefreshInvalid) {
+			// Revoked / rotated-elsewhere / user suspended: kill the session
+			// immediately. invalid_grant never gets grace.
+			span.SetAttributes(attribute.String("oidc.refresh_outcome", "invalid_grant"))
+			slog.InfoContext(bgCtx, "session refresh: invalid_grant, session revoked",
+				"username", ws.Username, "sub", ws.IdpSub)
+			_ = s.webSessions.DeleteWebSession(bgCtx, idHash)
+			return nil, err
+		}
+		if err != nil {
+			// Transient (network, IdP 5xx): serve stale within the grace
+			// window, measured from the first failure.
+			failingSince := ws.RefreshFailingSince
+			if failingSince == 0 {
+				failingSince = now.Unix()
+				if markErr := s.webSessions.MarkWebSessionRefreshFailing(bgCtx, idHash, failingSince); markErr != nil {
+					slog.WarnContext(bgCtx, "session refresh: mark failing", "err", markErr)
+				}
+				ws.RefreshFailingSince = failingSince
+			}
+			if now.Unix()-failingSince > int64(s.oidcRefreshGrace.Seconds()) {
+				span.SetAttributes(attribute.String("oidc.refresh_outcome", "grace_exceeded"))
+				tracing.RecordError(span, err)
+				slog.WarnContext(bgCtx, "session refresh: grace exceeded, session cut off",
+					"username", ws.Username, "failing_for", now.Unix()-failingSince)
+				_ = s.webSessions.DeleteWebSession(bgCtx, idHash)
+				return nil, err
+			}
+			span.SetAttributes(attribute.String("oidc.refresh_outcome", "stale_within_grace"))
+			slog.WarnContext(bgCtx, "session refresh failed, serving stale within grace",
+				"err", err, "username", ws.Username)
+			return ws, nil
+		}
+
+		claimsJSON := ""
+		if refreshed.Claims != nil {
+			// Re-snapshot groups/roles so central role changes propagate now,
+			// not at the next login.
+			claimsJSON = marshalClaims(*refreshed.Claims)
+		}
+		if err := s.webSessions.UpdateWebSessionTokens(bgCtx, idHash,
+			refreshed.IDToken, refreshed.AccessToken, refreshed.RefreshToken,
+			unixOrZero(refreshed.ExpiresAt), claimsJSON, now.Unix()); err != nil {
+			// The old refresh token is already burned; failing to store the new
+			// one makes the session unrenewable. Fail the request rather than
+			// pretend the session is healthy.
+			span.SetAttributes(attribute.String("oidc.refresh_outcome", "persist_error"))
+			tracing.RecordError(span, err)
+			slog.ErrorContext(bgCtx, "session refresh: persist rotated tokens",
+				"err", err, "handled", false)
+			return nil, err
+		}
+		span.SetAttributes(attribute.String("oidc.refresh_outcome", "rotated"))
+		ws.IDToken = refreshed.IDToken
+		ws.AccessToken = refreshed.AccessToken
+		ws.RefreshToken = refreshed.RefreshToken
+		ws.AccessExpiresAt = unixOrZero(refreshed.ExpiresAt)
+		if claimsJSON != "" {
+			ws.ClaimsJSON = claimsJSON
+		}
+		ws.LastRefreshAt = now.Unix()
+		ws.RefreshFailingSince = 0
+		return ws, nil
+	})
+	if err != nil {
+		return repository.WebSession{}, err
+	}
+	return v.(repository.WebSession), nil
+}

--- a/internal/api/telemetry.go
+++ b/internal/api/telemetry.go
@@ -1,0 +1,123 @@
+package api
+
+import (
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/wiebe-xyz/funnelbarn/internal/tracing"
+)
+
+// The dashboard is instrumented, but a browser must never hold a telemetry API
+// key: anything shipped to the page is readable by anyone who opens devtools.
+// These two endpoints are the session-authenticated seam — the browser posts to
+// its own origin with the cookie it already has, and the server forwards using
+// credentials that never leave the cluster.
+
+const (
+	// maxTelemetryBodyBytes bounds a span batch. The instrumentation flushes at
+	// 50 spans, so this is roughly 20x headroom.
+	maxTelemetryBodyBytes = 256 << 10
+	// maxSpansPerBatch bounds what one request may enqueue regardless of size.
+	maxSpansPerBatch = 200
+	// maxClientErrorField truncates browser-supplied strings. A stack from a
+	// minified bundle can be long, and this is logged, not stored.
+	maxClientErrorField = 4096
+)
+
+// handleTelemetry accepts a batch of spans from the dashboard's instrumentation
+// and relays them to SpanBarn, so a trace shows the browser half — the page
+// span and the client-side view of each API call — above the server spans that
+// already join it via the traceparent header.
+func (s *Server) handleTelemetry(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxTelemetryBodyBytes)
+
+	var body struct {
+		Spans []tracing.BrowserSpan `json:"spans"`
+	}
+	if err := readJSON(r, &body); err != nil {
+		jsonError(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	if len(body.Spans) > maxSpansPerBatch {
+		body.Spans = body.Spans[:maxSpansPerBatch]
+	}
+
+	valid := body.Spans[:0]
+	for _, sp := range body.Spans {
+		if validBrowserSpan(sp) {
+			valid = append(valid, sp)
+		}
+	}
+
+	// Accepted either way. Telemetry is not worth an error the dashboard has to
+	// handle, and a 4xx here would show up in the very instrumentation that
+	// produced it.
+	s.spanRelay.Enqueue(valid)
+	w.WriteHeader(http.StatusAccepted)
+}
+
+// validBrowserSpan rejects spans that could not join a trace anyway. IDs are
+// checked for shape rather than trusted: they are browser-supplied and end up
+// in SpanBarn's index.
+func validBrowserSpan(sp tracing.BrowserSpan) bool {
+	return isHex(sp.TraceID, 32) && isHex(sp.SpanID, 16) &&
+		(sp.ParentSpanID == "" || isHex(sp.ParentSpanID, 16)) &&
+		sp.Name != "" && sp.StartTime > 0
+}
+
+func isHex(s string, n int) bool {
+	if len(s) != n {
+		return false
+	}
+	for _, c := range s {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
+}
+
+// handleClientError records a failure the browser saw. It logs at error level,
+// which is what the BugBarn slog handler forwards, so a dashboard error becomes
+// an issue without the page ever holding a BugBarn key.
+func (s *Server) handleClientError(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxTelemetryBodyBytes)
+
+	var body struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+		Stack   string `json:"stack"`
+		URL     string `json:"url"`
+		TraceID string `json:"trace_id"`
+	}
+	if err := readJSON(r, &body); err != nil {
+		jsonError(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(body.Message) == "" {
+		jsonError(w, "message is required", http.StatusUnprocessableEntity)
+		return
+	}
+
+	// handled=false so this is triaged as a real defect: by the time the
+	// browser reports it, a user has already seen it.
+	slog.ErrorContext(r.Context(), "dashboard client error",
+		"err", truncate(body.Message, maxClientErrorField),
+		"handled", false,
+		"error_type", truncate(body.Type, 128),
+		"stack", truncate(body.Stack, maxClientErrorField),
+		"page_url", truncate(body.URL, 2048),
+		"trace_id", truncate(body.TraceID, 32),
+		"user_agent", r.Header.Get("User-Agent"),
+		"request_id", RequestIDFromContext(r.Context()),
+	)
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/internal/api/telemetry_test.go
+++ b/internal/api/telemetry_test.go
@@ -1,0 +1,172 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/wiebe-xyz/funnelbarn/internal/tracing"
+)
+
+func postTelemetry(t *testing.T, srv *Server, path string, body any, cookie *http.Cookie, csrf string) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(body); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, path, &buf)
+	req.Header.Set("Content-Type", "application/json")
+	if csrf != "" {
+		req.Header.Set("X-FunnelBarn-CSRF", csrf)
+	}
+	if cookie != nil {
+		req.AddCookie(cookie)
+	}
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	return w
+}
+
+func validSpan() map[string]any {
+	return map[string]any{
+		"traceId":   "4bf92f3577b34da6a3ce929d0e0e4736",
+		"spanId":    "00f067aa0ba902b7",
+		"name":      "page /overview",
+		"service":   "funnelbarn-web",
+		"kind":      "INTERNAL",
+		"status":    "OK",
+		"startTime": 1700000000000000,
+		"duration":  1234,
+	}
+}
+
+// A browser must never hold a telemetry key, which is the entire reason these
+// endpoints exist — so they must actually require the session.
+func TestTelemetry_RequiresSession(t *testing.T) {
+	srv, _ := newAuthedServer(t)
+	for _, path := range []string{"/api/v1/telemetry", "/api/v1/client-errors"} {
+		w := postTelemetry(t, srv, path, map[string]any{"spans": []any{}, "message": "x"}, nil, "")
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("%s: want 401 without a session, got %d", path, w.Code)
+		}
+	}
+}
+
+func TestTelemetry_AcceptsSpanBatch(t *testing.T) {
+	srv, _ := newAuthedServer(t)
+	cookie, csrf := sessionAndCSRF(t, srv, "u")
+
+	w := postTelemetry(t, srv, "/api/v1/telemetry",
+		map[string]any{"spans": []any{validSpan()}}, cookie, csrf)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("want 202, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+// Telemetry with no relay configured must still be accepted: the dashboard
+// runs fine without SpanBarn, and a 4xx here would surface inside the very
+// instrumentation that produced the request.
+func TestTelemetry_AcceptedWithoutRelay(t *testing.T) {
+	srv, _ := newAuthedServer(t)
+	cookie, csrf := sessionAndCSRF(t, srv, "u")
+
+	w := postTelemetry(t, srv, "/api/v1/telemetry",
+		map[string]any{"spans": []any{validSpan(), map[string]any{"traceId": "junk"}}}, cookie, csrf)
+	if w.Code != http.StatusAccepted {
+		t.Errorf("want 202, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestTelemetry_RejectsInvalidJSON(t *testing.T) {
+	srv, _ := newAuthedServer(t)
+	cookie, csrf := sessionAndCSRF(t, srv, "u")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/telemetry", strings.NewReader(`{"spans":`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-FunnelBarn-CSRF", csrf)
+	req.AddCookie(cookie)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("want 400, got %d", w.Code)
+	}
+}
+
+// IDs are browser-supplied and end up in SpanBarn's index, so they are checked
+// for shape rather than trusted.
+func TestValidBrowserSpan(t *testing.T) {
+	base := tracing.BrowserSpan{
+		TraceID: "4bf92f3577b34da6a3ce929d0e0e4736", SpanID: "00f067aa0ba902b7",
+		Name: "page /x", StartTime: 1,
+	}
+	if !validBrowserSpan(base) {
+		t.Fatal("a well-formed span should be valid")
+	}
+
+	withParent := base
+	withParent.ParentSpanID = "0102030405060708"
+	if !validBrowserSpan(withParent) {
+		t.Error("a well-formed parent span ID should be valid")
+	}
+
+	cases := map[string]func(s *tracing.BrowserSpan){
+		"short trace id":     func(s *tracing.BrowserSpan) { s.TraceID = "abcd" },
+		"uppercase trace id": func(s *tracing.BrowserSpan) { s.TraceID = strings.ToUpper(s.TraceID) },
+		"non-hex trace id":   func(s *tracing.BrowserSpan) { s.TraceID = strings.Repeat("z", 32) },
+		"short span id":      func(s *tracing.BrowserSpan) { s.SpanID = "00f0" },
+		"bad parent id":      func(s *tracing.BrowserSpan) { s.ParentSpanID = "nope" },
+		"no name":            func(s *tracing.BrowserSpan) { s.Name = "" },
+		"no start time":      func(s *tracing.BrowserSpan) { s.StartTime = 0 },
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			sp := base
+			mutate(&sp)
+			if validBrowserSpan(sp) {
+				t.Errorf("expected %+v to be rejected", sp)
+			}
+		})
+	}
+}
+
+func TestClientError_RequiresMessage(t *testing.T) {
+	srv, _ := newAuthedServer(t)
+	cookie, csrf := sessionAndCSRF(t, srv, "u")
+
+	w := postTelemetry(t, srv, "/api/v1/client-errors",
+		map[string]any{"message": "  ", "type": "TypeError"}, cookie, csrf)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("want 422 for an empty message, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestClientError_Accepted(t *testing.T) {
+	srv, _ := newAuthedServer(t)
+	cookie, csrf := sessionAndCSRF(t, srv, "u")
+
+	w := postTelemetry(t, srv, "/api/v1/client-errors", map[string]any{
+		"message":  "Cannot read properties of undefined",
+		"type":     "TypeError",
+		"stack":    "at Foo (bundle.js:1:2)",
+		"url":      "https://funnelbarn.example.com/funnels",
+		"trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+	}, cookie, csrf)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("want 202, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+// A minified stack can be enormous, and this goes into a log line.
+func TestTruncate(t *testing.T) {
+	if got := truncate("abc", 10); got != "abc" {
+		t.Errorf("short strings pass through, got %q", got)
+	}
+	got := truncate(strings.Repeat("x", 20), 5)
+	if len([]rune(got)) != 6 || !strings.HasSuffix(got, "…") {
+		t.Errorf("truncate should cut and mark, got %q", got)
+	}
+}

--- a/internal/tracing/relay.go
+++ b/internal/tracing/relay.go
@@ -1,0 +1,153 @@
+package tracing
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// BrowserSpan is one span produced by the dashboard's own instrumentation.
+// The shape is SpanBarn's native JSON ingest format, so a batch is relayed
+// through untouched rather than round-tripped via the OTel SDK — which cannot
+// emit a span with a caller-chosen span ID, and a browser CLIENT span must keep
+// the exact ID it put in the traceparent header or the server span it parents
+// would not join up.
+type BrowserSpan struct {
+	TraceID      string         `json:"traceId"`
+	SpanID       string         `json:"spanId"`
+	ParentSpanID string         `json:"parentSpanId,omitempty"`
+	Name         string         `json:"name"`
+	Service      string         `json:"service"`
+	Kind         string         `json:"kind"`
+	Status       string         `json:"status"`
+	StartTime    int64          `json:"startTime"` // microseconds since epoch
+	Duration     int64          `json:"duration"`  // microseconds
+	Attributes   map[string]any `json:"attributes,omitempty"`
+}
+
+// spansURL derives SpanBarn's native span-ingest URL from the configured OTLP
+// traces endpoint (".../v1/traces" -> ".../api/v1/spans"). The native endpoint
+// takes the same JSON the browser produces, so no OTLP encoding is involved.
+func spansURL(tracesEndpoint string) string {
+	base := strings.TrimSuffix(strings.TrimRight(tracesEndpoint, "/"), "/v1/traces")
+	return strings.TrimRight(base, "/") + "/api/v1/spans"
+}
+
+// SpanRelay forwards browser spans to SpanBarn.
+//
+// It is deliberately fire-and-forget with a bounded queue: telemetry must never
+// slow down or fail a dashboard request, and a SpanBarn outage must cost a few
+// dropped spans rather than back-pressure into the API.
+type SpanRelay struct {
+	url    string
+	apiKey string
+	client *http.Client
+
+	queue chan []BrowserSpan
+	wg    sync.WaitGroup
+
+	mu      sync.Mutex
+	dropped int
+}
+
+// NewSpanRelay returns a relay, or nil when telemetry export is not configured
+// (a nil *SpanRelay is safe to call — Enqueue is a no-op).
+func NewSpanRelay(cfg Config) *SpanRelay {
+	if cfg.Endpoint == "" || cfg.APIKey == "" {
+		return nil
+	}
+	r := &SpanRelay{
+		url:    spansURL(cfg.Endpoint),
+		apiKey: cfg.APIKey,
+		client: &http.Client{Timeout: 5 * time.Second},
+		queue:  make(chan []BrowserSpan, 64),
+	}
+	r.wg.Add(1)
+	go r.run()
+	return r
+}
+
+// Enabled reports whether spans will actually be forwarded.
+func (r *SpanRelay) Enabled() bool { return r != nil }
+
+// Enqueue hands a batch to the relay. It never blocks: a full queue drops the
+// batch and counts it, because holding the request open to deliver telemetry
+// would make the dashboard slower exactly when the backend is already strained.
+func (r *SpanRelay) Enqueue(spans []BrowserSpan) {
+	if r == nil || len(spans) == 0 {
+		return
+	}
+	select {
+	case r.queue <- spans:
+	default:
+		r.mu.Lock()
+		r.dropped += len(spans)
+		n := r.dropped
+		r.mu.Unlock()
+		slog.Warn("telemetry relay queue full, dropping browser spans",
+			"handled", true, "spans", len(spans), "dropped_total", n)
+	}
+}
+
+// Dropped returns how many spans have been dropped for lack of queue space.
+func (r *SpanRelay) Dropped() int {
+	if r == nil {
+		return 0
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.dropped
+}
+
+func (r *SpanRelay) run() {
+	defer r.wg.Done()
+	for batch := range r.queue {
+		if err := r.send(batch); err != nil {
+			// Warn, not error: losing browser telemetry is not a user-visible
+			// fault, and erroring here would report a SpanBarn outage into
+			// BugBarn once per batch.
+			slog.Warn("telemetry relay send failed", "err", err, "handled", true, "spans", len(batch))
+		}
+	}
+}
+
+func (r *SpanRelay) send(spans []BrowserSpan) error {
+	body, err := json.Marshal(map[string]any{"spans": spans})
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, r.url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+r.apiKey)
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("spanbarn ingest returned %s", resp.Status)
+	}
+	return nil
+}
+
+// Shutdown stops the relay after draining what is already queued.
+func (r *SpanRelay) Shutdown() {
+	if r == nil {
+		return
+	}
+	close(r.queue)
+	r.wg.Wait()
+}

--- a/internal/tracing/relay_test.go
+++ b/internal/tracing/relay_test.go
@@ -1,0 +1,126 @@
+package tracing
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestSpansURL(t *testing.T) {
+	cases := map[string]string{
+		"https://spanbarn.wiebe.xyz/v1/traces":  "https://spanbarn.wiebe.xyz/api/v1/spans",
+		"https://spanbarn.wiebe.xyz/v1/traces/": "https://spanbarn.wiebe.xyz/api/v1/spans",
+		"https://spanbarn.wiebe.xyz":            "https://spanbarn.wiebe.xyz/api/v1/spans",
+		"http://localhost:4318/v1/traces":       "http://localhost:4318/api/v1/spans",
+	}
+	for in, want := range cases {
+		if got := spansURL(in); got != want {
+			t.Errorf("spansURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// Telemetry export off means the relay is nil, and a nil relay must be safe to
+// call — the dashboard still runs when SpanBarn is not configured.
+func TestNewSpanRelay_NilWhenUnconfigured(t *testing.T) {
+	for _, cfg := range []Config{{}, {Endpoint: "x"}, {APIKey: "y"}} {
+		r := NewSpanRelay(cfg)
+		if r != nil {
+			t.Fatalf("expected nil relay for %+v", cfg)
+		}
+		r.Enqueue([]BrowserSpan{{TraceID: "t"}}) // must not panic
+		if r.Enabled() {
+			t.Error("a nil relay is not enabled")
+		}
+		if r.Dropped() != 0 {
+			t.Error("a nil relay drops nothing")
+		}
+		r.Shutdown()
+	}
+}
+
+// The browser's span IDs must survive the relay untouched: a CLIENT span whose
+// ID was rewritten would no longer parent the server span that quoted it in
+// the traceparent header, and the trace would come apart.
+func TestSpanRelay_ForwardsSpansVerbatim(t *testing.T) {
+	type batch struct {
+		Spans []BrowserSpan `json:"spans"`
+	}
+	got := make(chan batch, 1)
+	var auth, path string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth = r.Header.Get("Authorization")
+		path = r.URL.Path
+		var b batch
+		_ = json.NewDecoder(r.Body).Decode(&b)
+		got <- b
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	relay := NewSpanRelay(Config{Endpoint: srv.URL + "/v1/traces", APIKey: "secret"})
+	if relay == nil {
+		t.Fatal("expected a relay")
+	}
+	span := BrowserSpan{
+		TraceID: "4bf92f3577b34da6a3ce929d0e0e4736", SpanID: "00f067aa0ba902b7",
+		ParentSpanID: "0102030405060708", Name: "GET /api/v1/funnels",
+		Service: "funnelbarn-web", Kind: "CLIENT", Status: "OK",
+		StartTime: 1_700_000_000_000_000, Duration: 1234,
+		Attributes: map[string]any{"http.status_code": float64(200)},
+	}
+	relay.Enqueue([]BrowserSpan{span})
+	relay.Shutdown()
+
+	select {
+	case b := <-got:
+		if len(b.Spans) != 1 {
+			t.Fatalf("want 1 span, got %d", len(b.Spans))
+		}
+		if !reflect.DeepEqual(b.Spans[0], span) {
+			t.Errorf("span mutated in transit:\n got %+v\nwant %+v", b.Spans[0], span)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for the relayed batch")
+	}
+
+	if auth != "Bearer secret" {
+		t.Errorf("Authorization: got %q", auth)
+	}
+	if path != "/api/v1/spans" {
+		t.Errorf("path: want SpanBarn's native ingest, got %q", path)
+	}
+}
+
+// A SpanBarn outage must cost dropped telemetry, not a failed dashboard request.
+func TestSpanRelay_SurvivesIngestFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	relay := NewSpanRelay(Config{Endpoint: srv.URL + "/v1/traces", APIKey: "k"})
+	relay.Enqueue([]BrowserSpan{{TraceID: "t", SpanID: "s"}})
+	relay.Shutdown() // must return rather than hang or panic
+}
+
+func TestSpanRelay_EmptyBatchIsNotSent(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	relay := NewSpanRelay(Config{Endpoint: srv.URL + "/v1/traces", APIKey: "k"})
+	relay.Enqueue(nil)
+	relay.Enqueue([]BrowserSpan{})
+	relay.Shutdown()
+
+	if calls != 0 {
+		t.Errorf("an empty batch must not be sent, got %d calls", calls)
+	}
+}

--- a/web/src/lib/bugbarn.ts
+++ b/web/src/lib/bugbarn.ts
@@ -1,3 +1,5 @@
+import { currentTraceId, markTraceError } from './instrumentation'
+
 // BugBarn error reporting utility.
 // Config is fetched from /api/v1/client-config at runtime so the Docker image
 // is environment-agnostic. Errors arriving before config loads are queued and
@@ -76,12 +78,27 @@ export function reportError(
 ): void {
   const message = error instanceof Error ? error.message : String(error)
   const stack = error instanceof Error ? (error.stack ?? '') : ''
+
+  // Tagging the report with the current page trace is what makes the two
+  // halves navigable: a BugBarn issue names the SpanBarn trace that produced
+  // it, and that trace already carries the server spans and the DB query.
+  // Also keeps the trace off the sampling floor, so the trace behind an error
+  // is always kept.
+  let traceId = ''
+  try {
+    markTraceError()
+    traceId = currentTraceId()
+  } catch {
+    // Instrumentation not started (very early failure) — report without it.
+  }
+
   reportToBugBarn({
     name: 'error',
     properties: {
       message,
       stack,
       url: typeof window !== 'undefined' ? window.location.href : '',
+      ...(traceId ? { trace_id: traceId } : {}),
       ...context,
     },
   })

--- a/web/src/lib/instrumentation.test.ts
+++ b/web/src/lib/instrumentation.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import {
+  initInstrumentation, shutdownInstrumentation, shouldSampleTrace, traceparent,
+  requestURL, currentTraceId, markTraceError, __resetForTests, __bufferedSpans,
+  type SpanPayload,
+} from './instrumentation'
+
+type Sent = { url: string; body: { spans?: SpanPayload[]; message?: string; trace_id?: string } }
+
+let sent: Sent[]
+let realFetch: typeof fetch
+
+/** installFetch replaces window.fetch with a recorder and returns it. */
+function installFetch(responder: (url: string) => Response = () => new Response('{}', { status: 200 })) {
+  const impl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = requestURL(input)
+    if (url.startsWith('/api/v1/telemetry') || url.startsWith('/api/v1/client-errors')) {
+      sent.push({ url, body: JSON.parse(String(init?.body ?? '{}')) })
+      return new Response('', { status: 202 })
+    }
+    return responder(url)
+  })
+  window.fetch = impl as unknown as typeof fetch
+  return impl
+}
+
+beforeEach(() => {
+  sent = []
+  realFetch = window.fetch
+  document.cookie = 'funnelbarn_csrf=tok'
+  window.history.replaceState({}, '', '/overview')
+  __resetForTests()
+})
+
+afterEach(() => {
+  shutdownInstrumentation()
+  window.fetch = realFetch
+})
+
+describe('traceparent', () => {
+  it('builds a sampled W3C header', () => {
+    expect(traceparent('4bf92f3577b34da6a3ce929d0e0e4736', '00f067aa0ba902b7'))
+      .toBe('00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01')
+  })
+})
+
+describe('shouldSampleTrace', () => {
+  it('is deterministic — the same trace ID always decides the same way', () => {
+    const id = 'ff'.repeat(16)
+    expect(shouldSampleTrace(id, 50)).toBe(shouldSampleTrace(id, 50))
+  })
+
+  it('keeps everything at 100 and nothing at 0', () => {
+    const id = '0123456789abcdef' + '0'.repeat(16)
+    expect(shouldSampleTrace(id, 100)).toBe(true)
+    expect(shouldSampleTrace(id, 0)).toBe(false)
+  })
+
+  it('drops rather than throwing on a malformed trace ID', () => {
+    expect(shouldSampleTrace('', 100)).toBe(false)
+    expect(shouldSampleTrace('zzzz', 100)).toBe(false)
+  })
+})
+
+describe('fetch instrumentation', () => {
+  it('injects traceparent so the server span joins the browser trace', async () => {
+    let seen: string | null = null
+    installFetch()
+    const inner = window.fetch
+    window.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = requestURL(input)
+      if (!url.startsWith('/api/v1/telemetry') && !url.startsWith('/api/v1/client-errors')) {
+        seen = new Headers(init?.headers).get('traceparent')
+      }
+      return inner(input, init)
+    }) as typeof fetch
+
+    initInstrumentation()
+    await window.fetch('/api/v1/funnels')
+
+    expect(seen).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-01$/)
+    expect(seen).toContain(currentTraceId())
+  })
+
+  it('records a CLIENT span parented to the page span', async () => {
+    installFetch()
+    initInstrumentation()
+    await window.fetch('/api/v1/funnels')
+
+    const spans = __bufferedSpans()
+    const client = spans.find((s) => s.kind === 'CLIENT')
+    expect(client).toBeDefined()
+    expect(client!.name).toBe('GET /api/v1/funnels')
+    expect(client!.service).toBe('funnelbarn-web')
+    expect(client!.status).toBe('OK')
+    expect(client!.parentSpanId).toBeTruthy()
+    expect(client!.traceId).toBe(currentTraceId())
+    expect(client!.attributes['http.status_code']).toBe(200)
+  })
+
+  it('never traces its own telemetry delivery', async () => {
+    installFetch()
+    initInstrumentation()
+    markTraceError() // force a flush
+    await window.fetch('/api/v1/funnels')
+
+    for (const s of __bufferedSpans()) {
+      expect(s.name).not.toContain('/api/v1/telemetry')
+      expect(s.name).not.toContain('/api/v1/client-errors')
+    }
+  })
+
+  it('marks a failed response ERROR and reports a 5xx nothing else would see', async () => {
+    installFetch((url) =>
+      url === '/api/v1/boom' ? new Response('', { status: 503 }) : new Response('{}', { status: 200 }))
+    initInstrumentation()
+    await window.fetch('/api/v1/boom')
+
+    const errors = sent.filter((s) => s.url === '/api/v1/client-errors')
+    expect(errors).toHaveLength(1)
+    expect(errors[0].body.message).toContain('HTTP 503')
+    expect(errors[0].body.trace_id).toBe(currentTraceId())
+  })
+
+  it('re-throws a network failure after recording it', async () => {
+    installFetch()
+    const inner = window.fetch
+    window.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = requestURL(input)
+      if (url === '/api/v1/down') throw new TypeError('Failed to fetch')
+      return inner(input, init)
+    }) as typeof fetch
+
+    initInstrumentation()
+    await expect(window.fetch('/api/v1/down')).rejects.toThrow('Failed to fetch')
+
+    // The error flushes the trace immediately so it survives the page closing.
+    const batches = sent.filter((s) => s.url === '/api/v1/telemetry')
+    const spans = batches.flatMap((b) => b.body.spans ?? [])
+    const failed = spans.find((s) => s.name === 'GET /api/v1/down')
+    expect(failed?.status).toBe('ERROR')
+    expect(failed?.attributes['error.message']).toBe('Failed to fetch')
+  })
+
+  it('sends the CSRF header the session-authed endpoint requires', async () => {
+    const impl = installFetch()
+    initInstrumentation()
+    markTraceError()
+    await window.fetch('/api/v1/funnels')
+
+    const call = impl.mock.calls.find(([input]) => requestURL(input as RequestInfo) === '/api/v1/telemetry')
+    expect(call).toBeDefined()
+    expect((call![1] as RequestInit).headers).toMatchObject({ 'X-FunnelBarn-CSRF': 'tok' })
+  })
+})
+
+describe('navigation', () => {
+  it('opens a new trace per navigation', async () => {
+    installFetch()
+    initInstrumentation()
+    const first = currentTraceId()
+    expect(first).toMatch(/^[0-9a-f]{32}$/)
+
+    window.history.pushState({}, '', '/funnels')
+    expect(currentTraceId()).not.toBe(first)
+  })
+
+  it('ignores a pushState that does not change the path', () => {
+    installFetch()
+    initInstrumentation()
+    const first = currentTraceId()
+    window.history.pushState({}, '', '/overview?tab=2')
+    expect(currentTraceId()).toBe(first)
+  })
+})
+
+describe('sampling', () => {
+  it('drops an unsampled, error-free trace whole rather than in part', async () => {
+    installFetch()
+    initInstrumentation()
+    await window.fetch('/api/v1/funnels')
+
+    // Force the commit path without an error. Whether this trace was sampled
+    // is decided by its ID, so assert the invariant: a batch is either sent
+    // in full or not at all — never a partial trace.
+    const before = sent.length
+    shutdownInstrumentation()
+    const batches = sent.slice(before).filter((s) => s.url === '/api/v1/telemetry')
+    if (batches.length > 0) {
+      const spans = batches.flatMap((b) => b.body.spans ?? [])
+      expect(spans.some((s) => s.kind === 'INTERNAL')).toBe(true) // the page span came too
+    }
+    expect(__bufferedSpans()).toHaveLength(0)
+  })
+
+  it('always keeps a trace that hit an error', async () => {
+    installFetch((url) =>
+      url === '/api/v1/boom' ? new Response('', { status: 500 }) : new Response('{}', { status: 200 }))
+    initInstrumentation()
+    await window.fetch('/api/v1/boom')
+
+    const spans = sent.filter((s) => s.url === '/api/v1/telemetry').flatMap((b) => b.body.spans ?? [])
+    expect(spans.some((s) => s.status === 'ERROR')).toBe(true)
+  })
+})
+
+describe('requestURL', () => {
+  it('reads the URL from every fetch input shape', () => {
+    expect(requestURL('/a')).toBe('/a')
+    expect(requestURL(new URL('https://x.test/b'))).toBe('https://x.test/b')
+    expect(requestURL(new Request('https://x.test/c'))).toBe('https://x.test/c')
+  })
+})

--- a/web/src/lib/instrumentation.ts
+++ b/web/src/lib/instrumentation.ts
@@ -1,0 +1,374 @@
+// Browser-side tracing for the dashboard.
+//
+// Each navigation opens a trace. Every fetch made during that navigation
+// carries its `traceparent`, so the Go server's spans become children of the
+// browser's — one trace in SpanBarn from the click through the API call to the
+// database query, instead of two disconnected halves.
+//
+// Spans are posted to this origin's own /api/v1/telemetry, which relays them
+// with credentials that never reach the page. A browser must never hold a
+// telemetry key.
+
+const TELEMETRY_ENDPOINT = '/api/v1/telemetry'
+const CLIENT_ERRORS_ENDPOINT = '/api/v1/client-errors'
+const SERVICE_NAME = 'funnelbarn-web'
+
+/** Percent of traces kept. Errors are always kept regardless. */
+const SAMPLE_PERCENT = 5
+const FLUSH_INTERVAL_MS = 5000
+/** Flush threshold for a sampled trace, to keep batches small. */
+const FLUSH_AT_SPANS = 25
+/** Hard ceiling so a long-lived page can't grow the buffer without bound. */
+const MAX_BUFFERED_SPANS = 100
+
+export type SpanKind = 'INTERNAL' | 'CLIENT' | 'SERVER'
+export type SpanStatus = 'OK' | 'ERROR'
+
+export interface SpanPayload {
+  traceId: string
+  spanId: string
+  parentSpanId?: string
+  name: string
+  service: string
+  kind: SpanKind
+  status: SpanStatus
+  /** Microseconds since the epoch. */
+  startTime: number
+  /** Microseconds. */
+  duration: number
+  attributes: Record<string, string | number | boolean>
+}
+
+const spanQueue: SpanPayload[] = []
+let flushTimer: ReturnType<typeof setInterval> | null = null
+
+let pageTraceId = ''
+let pageSpanId = ''
+let pendingPageSpan: SpanPayload | null = null
+let traceSampled = false
+let traceHasError = false
+
+// ---------------------------------------------------------------------------
+// Primitives
+// ---------------------------------------------------------------------------
+
+function hex(bytes: number): string {
+  const arr = crypto.getRandomValues(new Uint8Array(bytes))
+  return Array.from(arr, (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+function nowUs(): number {
+  return Math.round(performance.timeOrigin * 1000 + performance.now() * 1000)
+}
+
+export function traceparent(traceId: string, spanId: string): string {
+  return `00-${traceId}-${spanId}-01`
+}
+
+/**
+ * Deterministic sampler over the trace ID's first 8 bytes. Deterministic rather
+ * than random so the same trace ID yields the same decision wherever it is
+ * evaluated — a sampled-here / dropped-there split produces traces with holes.
+ */
+export function shouldSampleTrace(traceId: string, percent = SAMPLE_PERCENT): boolean {
+  if (traceId.length < 16) return false
+  try {
+    return BigInt('0x' + traceId.slice(0, 16)) % 100n < BigInt(percent)
+  } catch {
+    return false
+  }
+}
+
+/** The current page trace's ID, for correlating an error report with the trace. */
+export function currentTraceId(): string {
+  return pageTraceId
+}
+
+/** Marks the current trace as containing an error, so it is never sampled out. */
+export function markTraceError(): void {
+  traceHasError = true
+}
+
+// ---------------------------------------------------------------------------
+// Buffering
+// ---------------------------------------------------------------------------
+
+function getCookie(name: string): string {
+  const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'))
+  return match ? decodeURIComponent(match[2]) : ''
+}
+
+function sendBatch(spans: SpanPayload[]): void {
+  if (spans.length === 0) return
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  // The endpoint is session-authed, so mutating requests carry CSRF like the
+  // rest of the API client.
+  const csrf = getCookie('funnelbarn_csrf')
+  if (csrf) headers['X-FunnelBarn-CSRF'] = csrf
+
+  // originalFetch, not window.fetch: the instrumented wrapper would trace its
+  // own delivery and never settle.
+  originalFetch(TELEMETRY_ENDPOINT, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ spans }),
+    credentials: 'same-origin',
+    keepalive: true,
+  }).catch(() => {})
+}
+
+function finalizePageSpan(): void {
+  if (!pendingPageSpan) return
+  pendingPageSpan.duration = nowUs() - pendingPageSpan.startTime
+  spanQueue.push(pendingPageSpan)
+  pendingPageSpan = null
+}
+
+/**
+ * Ends the current page trace. Buffered spans are sent only if the trace was
+ * sampled or hit an error — an unsampled, clean trace is dropped whole rather
+ * than partially, so SpanBarn never shows a trace with missing children.
+ */
+function commitTrace(): void {
+  finalizePageSpan()
+  if (spanQueue.length === 0) return
+  if (!traceSampled && !traceHasError) {
+    spanQueue.length = 0
+    return
+  }
+  sendBatch(spanQueue.splice(0))
+}
+
+function startPageTrace(path: string, fromPath?: string): void {
+  commitTrace()
+
+  pageTraceId = hex(16)
+  pageSpanId = hex(8)
+  traceSampled = shouldSampleTrace(pageTraceId)
+  traceHasError = false
+
+  const attributes: Record<string, string | number | boolean> = { 'navigation.to': path }
+  if (fromPath) attributes['navigation.from'] = fromPath
+
+  pendingPageSpan = {
+    traceId: pageTraceId,
+    spanId: pageSpanId,
+    name: `page ${path}`,
+    service: SERVICE_NAME,
+    kind: 'INTERNAL',
+    status: 'OK',
+    startTime: nowUs(),
+    duration: 0,
+    attributes,
+  }
+}
+
+function enqueueSpan(span: SpanPayload): void {
+  if (span.status === 'ERROR') traceHasError = true
+  spanQueue.push(span)
+
+  // Send immediately on an error so the whole trace — including the spans
+  // buffered before it — reaches SpanBarn while the page may still be closing.
+  if (traceHasError) {
+    finalizePageSpan()
+    sendBatch(spanQueue.splice(0))
+    return
+  }
+  if (traceSampled && spanQueue.length >= FLUSH_AT_SPANS) {
+    flushSpans()
+    return
+  }
+  if (spanQueue.length >= MAX_BUFFERED_SPANS) spanQueue.length = 0
+}
+
+function flushSpans(): void {
+  if (!traceSampled) return
+  finalizePageSpan()
+  if (spanQueue.length === 0) return
+  sendBatch(spanQueue.splice(0, 50))
+}
+
+// ---------------------------------------------------------------------------
+// Error reporting
+// ---------------------------------------------------------------------------
+
+/**
+ * Reports a failure the browser saw, tagged with the current trace so the
+ * BugBarn issue and the SpanBarn trace point at each other.
+ */
+export function reportClientError(error: Error, extra?: Record<string, string>): void {
+  markTraceError()
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  const csrf = getCookie('funnelbarn_csrf')
+  if (csrf) headers['X-FunnelBarn-CSRF'] = csrf
+
+  originalFetch(CLIENT_ERRORS_ENDPOINT, {
+    method: 'POST',
+    headers,
+    credentials: 'same-origin',
+    keepalive: true,
+    body: JSON.stringify({
+      message: error.message,
+      type: extra?.type ?? error.name ?? 'Error',
+      stack: error.stack ?? '',
+      url: location.href,
+      trace_id: pageTraceId,
+    }),
+  }).catch(() => {})
+}
+
+// ---------------------------------------------------------------------------
+// Fetch instrumentation
+// ---------------------------------------------------------------------------
+
+// Captured before wrapping so telemetry delivery is never itself traced —
+// an instrumented delivery would trace its own delivery and never settle.
+let originalFetch: typeof fetch = () =>
+  Promise.reject(new Error('instrumentation: fetch unavailable'))
+
+function isInstrumentationUrl(url: string): boolean {
+  return url.includes(TELEMETRY_ENDPOINT) || url.includes(CLIENT_ERRORS_ENDPOINT)
+}
+
+export function requestURL(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input
+  if (input instanceof URL) return input.href
+  return input.url
+}
+
+function spanName(method: string, url: string): string {
+  try {
+    return `${method} ${new URL(url, location.origin).pathname}`
+  } catch {
+    return `${method} ${url}`
+  }
+}
+
+function instrumentFetch(): void {
+  originalFetch = window.fetch.bind(window)
+
+  window.fetch = function instrumentedFetch(
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> {
+    const url = requestURL(input)
+    if (isInstrumentationUrl(url)) return originalFetch(input, init)
+
+    const method = (init?.method ?? 'GET').toUpperCase()
+    const spanId = hex(8)
+    const startTime = nowUs()
+
+    // Injecting traceparent is what joins the halves: the Go middleware
+    // extracts it and its server span becomes a child of this one.
+    const headers = new Headers(init?.headers)
+    if (pageTraceId) headers.set('traceparent', traceparent(pageTraceId, spanId))
+
+    const record = (status: SpanStatus, attributes: Record<string, string | number | boolean>) => {
+      enqueueSpan({
+        traceId: pageTraceId,
+        spanId,
+        parentSpanId: pageSpanId,
+        name: spanName(method, url),
+        service: SERVICE_NAME,
+        kind: 'CLIENT',
+        status,
+        startTime,
+        duration: nowUs() - startTime,
+        attributes: { 'http.method': method, 'http.url': url, ...attributes },
+      })
+    }
+
+    return originalFetch(input, { ...init, headers }).then(
+      (response) => {
+        record(response.ok ? 'OK' : 'ERROR', { 'http.status_code': response.status })
+        // A 5xx is a server defect the user just hit. The app may handle it
+        // gracefully, which is exactly why nothing else would report it.
+        if (response.status >= 500) {
+          reportClientError(new Error(`HTTP ${response.status} ${method} ${url}`), {
+            type: 'http_error',
+          })
+        }
+        return response
+      },
+      (error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error)
+        record('ERROR', { 'error.message': message })
+        throw error
+      },
+    )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Navigation
+// ---------------------------------------------------------------------------
+
+function instrumentNavigation(): void {
+  let lastPath = location.pathname
+  startPageTrace(lastPath)
+
+  const originalPushState = history.pushState.bind(history)
+  const originalReplaceState = history.replaceState.bind(history)
+
+  const onNav = () => {
+    if (location.pathname === lastPath) return
+    const fromPath = lastPath
+    lastPath = location.pathname
+    startPageTrace(lastPath, fromPath)
+  }
+
+  history.pushState = function (...args: Parameters<typeof history.pushState>) {
+    originalPushState(...args)
+    onNav()
+  }
+  history.replaceState = function (...args: Parameters<typeof history.replaceState>) {
+    originalReplaceState(...args)
+    onNav()
+  }
+  window.addEventListener('popstate', onNav)
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+export function initInstrumentation(): void {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return
+  instrumentFetch()
+  instrumentNavigation()
+  flushTimer = setInterval(flushSpans, FLUSH_INTERVAL_MS)
+
+  // A backgrounded tab may never come back, so commit what we have. This is
+  // the only reliable "page is going away" signal across browsers.
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') commitTrace()
+  })
+}
+
+export function shutdownInstrumentation(): void {
+  if (flushTimer) {
+    clearInterval(flushTimer)
+    flushTimer = null
+  }
+  commitTrace()
+}
+
+/** Test seam: resets module state between cases. */
+export function __resetForTests(fetchImpl?: typeof fetch): void {
+  spanQueue.length = 0
+  pendingPageSpan = null
+  pageTraceId = ''
+  pageSpanId = ''
+  traceSampled = false
+  traceHasError = false
+  if (flushTimer) {
+    clearInterval(flushTimer)
+    flushTimer = null
+  }
+  if (fetchImpl) originalFetch = fetchImpl
+}
+
+/** Test seam: the spans currently buffered. */
+export function __bufferedSpans(): SpanPayload[] {
+  return [...spanQueue]
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -3,6 +3,11 @@ import ReactDOM from 'react-dom/client'
 import './index.css'
 import App from './App'
 import { reportError } from './lib/bugbarn'
+import { initInstrumentation } from './lib/instrumentation'
+
+// Started before anything else so the very first API call already carries a
+// traceparent — the header is what joins the browser's spans to the server's.
+initInstrumentation()
 
 // Global unhandled error handler — catches errors outside React's tree.
 window.onerror = (message, source, lineno, colno, error) => {


### PR DESCRIPTION
## What was actually missing

The issue says the backend has no `otelhttp` middleware and doesn't extract
incoming `traceparent` headers. That's out of date — `tracing.Middleware` sets
the composite W3C propagator, extracts the header, and starts its server span
as a child of the caller's. `TestMiddleware_AdoptsIncomingTraceparent` already
covers it.

What was missing was a **browser that produces trace context at all**, so every
SpanBarn trace began at the Go handler with no idea which page interaction
caused it.

## Frontend — `web/src/lib/instrumentation.ts`

- **A trace per navigation**, including SPA route changes
  (`pushState`/`replaceState`/`popstate`).
- **`window.fetch` wrapped** to inject `traceparent` and record a CLIENT span
  parented to the page span. That header is the join: the Go middleware
  extracts it and its SERVER span nests underneath.
- **Batching** — flushed every 5s and on `visibilitychange`, the only reliable
  "page is going away" signal across browsers.
- **5% deterministic sampling** keyed on the trace ID, so the same trace decides
  the same way wherever it's evaluated — a sampled-here/dropped-there split
  produces traces with holes. An unsampled trace is dropped *whole*, never
  partially.
- **Errors always survive**: a trace that hits one is kept regardless of
  sampling and flushed immediately, so it reaches SpanBarn while the page may
  already be closing.
- **A 5xx seen on the wire is reported even when the app handles it
  gracefully** — which is precisely why nothing else would report it today.

## Backend

- **`POST /api/v1/telemetry`** (session-authed) validates browser-supplied span
  IDs for shape — they end up in SpanBarn's index — and relays the batch. It
  accepts even when nothing is configured: a 4xx here would surface inside the
  very instrumentation that produced the request.
- **`tracing.SpanRelay`** forwards to SpanBarn's native JSON ingest
  (`/api/v1/spans`) rather than re-encoding through the OTel SDK. The SDK
  cannot emit a span with a caller-chosen ID, and a CLIENT span whose ID was
  rewritten would no longer parent the server span that quoted it in the
  `traceparent` header — the trace would come apart. Fire-and-forget with a
  bounded queue: telemetry must never slow down or fail a dashboard request,
  and a SpanBarn outage costs a few dropped spans rather than back-pressure
  into the API.
- **`POST /api/v1/client-errors`** (session-authed) logs at error level, which
  the BugBarn slog handler forwards — so a dashboard error becomes an issue
  without the page ever holding a BugBarn key.

Both are session-authed for the reason the issue gives: anything shipped to the
page is readable by anyone who opens devtools. The instrumentation sends the
same CSRF token the rest of the API client sends, so neither route needs a CSRF
carve-out.

`reportError` now tags BugBarn reports with the current trace ID and marks the
trace as errored, so the issue and the trace that produced it point at each
other.

## Result

```
page /funnels                          (funnelbarn-web, INTERNAL)
├── GET /api/v1/funnels                (funnelbarn-web, CLIENT)
│   └── GET /api/v1/projects/{id}/funnels  (funnelbarn, SERVER)
│       └── repo.ListFunnels           (funnelbarn, INTERNAL)
└── GET /api/v1/events                 (funnelbarn-web, CLIENT)
    └── …
```

## Tests

15 frontend cases (traceparent injection and shape, CLIENT span parentage,
never tracing its own delivery, 5xx reporting, network failures re-thrown after
recording, CSRF header, per-navigation traces, sampling invariants) and Go
cases for span validation, both endpoints' auth, the relay forwarding spans
verbatim to the right URL with the right credential, and surviving an ingest
failure.

`server.go` crossed its file-length ratchet, so the session middleware moves to
`internal/api/session_mw.go` unchanged.

Closes #93