### PR TITLE
fix(web): stop reporting network blips and expired sessions to BugBarn

### DIFF
--- a/web/src/lib/api-error.test.ts
+++ b/web/src/lib/api-error.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { ApiError, isNonActionableError } from './api-error'
+
+describe('isNonActionableError', () => {
+  it('skips a browser-level network failure (status 0)', () => {
+    // The API client wraps a thrown fetch as ApiError(0) and documents it as
+    // "the user's network, not our code" — this is what makes every call site
+    // honour that instead of only the two that remembered to.
+    expect(isNonActionableError(new ApiError(0, 'Failed to fetch'))).toBe(true)
+  })
+
+  it('skips a 401 — api.request already redirects to /login', () => {
+    expect(isNonActionableError(new ApiError(401, 'unauthorized'))).toBe(true)
+  })
+
+  it('reports every other status, because those are ours', () => {
+    for (const status of [400, 403, 404, 409, 422, 429, 500, 502, 503]) {
+      expect(isNonActionableError(new ApiError(status, 'boom'))).toBe(false)
+    }
+  })
+
+  it('skips a bare fetch TypeError across browsers', () => {
+    expect(isNonActionableError(new TypeError('Failed to fetch'))).toBe(true)
+    expect(isNonActionableError(new TypeError('Load failed'))).toBe(true)
+    expect(isNonActionableError(
+      new TypeError('NetworkError when attempting to fetch resource.'))).toBe(true)
+  })
+
+  it('does not swallow an ordinary TypeError — that is a real defect', () => {
+    expect(isNonActionableError(
+      new TypeError("Cannot read properties of null (reading 'map')"))).toBe(false)
+  })
+
+  it('reports anything that is not an error object at all', () => {
+    expect(isNonActionableError(new Error('boom'))).toBe(false)
+    expect(isNonActionableError('boom')).toBe(false)
+    expect(isNonActionableError(null)).toBe(false)
+    expect(isNonActionableError(undefined)).toBe(false)
+  })
+})
+
+describe('cross-boundary identity', () => {
+  it('recognises an ApiError-shaped object from another module instance', () => {
+    // Two copies of the class (separate bundles, or a vi.resetModules reload)
+    // make `instanceof` false for the same shape. Failing open there would
+    // report exactly the noise this filter exists to suppress.
+    const fromElsewhere = Object.assign(new Error('Failed to fetch'), {
+      name: 'ApiError',
+      status: 0,
+    })
+    expect(isNonActionableError(fromElsewhere)).toBe(true)
+  })
+
+  it('does not treat an unrelated object with a status as an ApiError', () => {
+    expect(isNonActionableError({ name: 'Error', status: 0 })).toBe(false)
+    expect(isNonActionableError({ status: 401 })).toBe(false)
+  })
+})

--- a/web/src/lib/api-error.ts
+++ b/web/src/lib/api-error.ts
@@ -1,0 +1,48 @@
+/**
+ * ApiError lives in its own module so the error reporter can recognise it
+ * without importing the API client — api.ts already imports the reporter, and
+ * a cycle between them makes `instanceof` depend on module evaluation order.
+ */
+export class ApiError extends Error {
+  constructor(public status: number, message: string) {
+    super(message)
+    this.name = 'ApiError'
+  }
+}
+
+/**
+ * isNonActionableError reports whether a failure is a condition of the user's
+ * session or network rather than a defect in our code, and so should not become
+ * a BugBarn issue.
+ *
+ *  - status 0 — the fetch itself threw (offline, DNS, TLS, connection reset).
+ *    The API client already documents this as "the user's network, not our
+ *    code"; this is what makes every call site honour that.
+ *  - status 401 — the session expired. api.request redirects to /login, so it
+ *    is an expected transition, not a fault.
+ *  - a bare fetch TypeError, for paths that call fetch directly and never wrap
+ *    it in an ApiError.
+ *
+ * Deliberately narrow: 4xx other than 401 and every 5xx still report, because
+ * those are ours.
+ *
+ * Matched structurally rather than with `instanceof`. An error that crossed a
+ * bundle or realm boundary carries a different class identity for the same
+ * shape, and failing open there would report exactly the noise this exists to
+ * suppress.
+ */
+export function isNonActionableError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false
+  const { name, message, status } = error as { name?: unknown; message?: unknown; status?: unknown }
+
+  if (name === 'ApiError' && typeof status === 'number') {
+    return status === 0 || status === 401
+  }
+  if (name === 'TypeError' && typeof message === 'string') {
+    const m = message.toLowerCase()
+    // "Failed to fetch" (Chromium), "Load failed" (Safari),
+    // "NetworkError when attempting to fetch resource" (Firefox).
+    return m.includes('failed to fetch') || m.includes('load failed') || m.includes('networkerror')
+  }
+  return false
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,14 +1,10 @@
 // Typed API client with 401 interceptor and BugBarn 5xx reporting
 import { reportError } from './bugbarn'
+import { ApiError } from './api-error'
 import type { IambarnConfig } from './iambarn-config'
 import type { LogoutResponse } from './auth-types'
 
-export class ApiError extends Error {
-  constructor(public status: number, message: string) {
-    super(message)
-    this.name = 'ApiError'
-  }
-}
+export { ApiError }
 
 function getCookie(name: string): string | undefined {
   const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'))

--- a/web/src/lib/bugbarn.test.ts
+++ b/web/src/lib/bugbarn.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { ApiError } from './api-error'
+
+/**
+ * bugbarn.ts fetches its config on import, so each case re-imports the module
+ * with a stubbed fetch and lets that settle before asserting.
+ */
+async function loadReporter(): Promise<typeof import('./bugbarn')> {
+  vi.resetModules()
+  const mod = await import('./bugbarn')
+  // Let the config fetch resolve so reports are sent rather than queued.
+  await new Promise((r) => setTimeout(r, 0))
+  return mod
+}
+
+let posts: { url: string; body: Record<string, unknown> }[]
+let realFetch: typeof fetch
+
+beforeEach(() => {
+  posts = []
+  realFetch = globalThis.fetch
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input)
+    if (url.includes('/api/v1/client-config')) {
+      return new Response(JSON.stringify({
+        bugbarn_endpoint: 'https://bugbarn.test',
+        bugbarn_ingest_key: 'k',
+        bugbarn_project: 'funnelbarn',
+      }), { status: 200 })
+    }
+    posts.push({ url, body: JSON.parse(String(init?.body ?? '{}')) })
+    return new Response('', { status: 202 })
+  }) as unknown as typeof fetch
+})
+
+afterEach(() => {
+  globalThis.fetch = realFetch
+  vi.restoreAllMocks()
+})
+
+describe('reportError', () => {
+  it('reports a real application error', async () => {
+    const { reportError } = await loadReporter()
+    reportError(new TypeError("Cannot read properties of null (reading 'map')"), {
+      source: 'Insights',
+    })
+    expect(posts).toHaveLength(1)
+    expect(posts[0].body).toMatchObject({ name: 'error' })
+  })
+
+  it('does not report a dropped connection — the user’s network, not our code', async () => {
+    const { reportError } = await loadReporter()
+    // FUN-6: Dashboard.getDashboard reported ApiError(0) because the noise
+    // filter lived in ProjectProvider instead of at the reporting boundary.
+    reportError(new ApiError(0, 'Failed to fetch'), { source: 'Dashboard.getDashboard' })
+    expect(posts).toHaveLength(0)
+  })
+
+  it('does not report an expired session', async () => {
+    const { reportError } = await loadReporter()
+    reportError(new ApiError(401, 'unauthorized'), { source: 'anything' })
+    expect(posts).toHaveLength(0)
+  })
+
+  it('still reports a server fault', async () => {
+    const { reportError } = await loadReporter()
+    reportError(new ApiError(500, 'internal'), { source: 'anything' })
+    expect(posts).toHaveLength(1)
+  })
+})

--- a/web/src/lib/bugbarn.ts
+++ b/web/src/lib/bugbarn.ts
@@ -1,4 +1,5 @@
 import { currentTraceId, markTraceError } from './instrumentation'
+import { isNonActionableError } from './api-error'
 
 // BugBarn error reporting utility.
 // Config is fetched from /api/v1/client-config at runtime so the Docker image
@@ -76,6 +77,12 @@ export function reportError(
   error: unknown,
   context: Record<string, unknown> = {},
 ): void {
+  // Filter at the reporting boundary, not per call site. The API client already
+  // documents a status-0 failure as "the user's network, not our code", but
+  // only 2 of 25 call sites acted on that — so a dropped connection on any of
+  // the other 23 opened a BugBarn issue nobody could fix.
+  if (isNonActionableError(error)) return
+
   const message = error instanceof Error ? error.message : String(error)
   const stack = error instanceof Error ? (error.stack ?? '') : ''
 

--- a/web/src/lib/projects.tsx
+++ b/web/src/lib/projects.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useState, ReactNode, useCallback } from 'react'
-import { api, ApiError, Project } from './api'
+import { api, Project } from './api'
 import { reportError } from './bugbarn'
 
 const STORAGE_KEY = 'funnelbarn_default_project'
@@ -46,13 +46,8 @@ export function ProjectProvider({ children }: { children: ReactNode }) {
     api.listProjects()
       .then((d) => setProjects(d.projects || []))
       .catch((e) => {
-        // Skip noise:
-        // - 401: expected when session expired / before login. api.request already redirects.
-        // - 0:   network failure (TypeError: Failed to fetch). User's network, not our code.
-        const isNoise = e instanceof ApiError && (e.status === 401 || e.status === 0)
-        if (!isNoise) {
-          reportError(e, { source: 'ProjectProvider.listProjects' })
-        }
+        // Expired sessions and network blips are filtered inside reportError.
+        reportError(e, { source: 'ProjectProvider.listProjects' })
         setProjects([])
       })
       .finally(() => setIsLoading(false))

--- a/web/src/pages/Funnels.tsx
+++ b/web/src/pages/Funnels.tsx
@@ -356,8 +356,11 @@ export default function Funnels() {
       })
       .catch((e) => {
         console.error(e)
-        const isNoise = e instanceof ApiError && (e.status === 404 || e.status === 0)
-        if (!isNoise) reportError(e, { source: 'Funnels.getFunnelAnalysis' })
+        // A 404 here is a funnel deleted in another tab — specific to this
+        // view, so it stays local. Network blips and expired sessions are
+        // filtered inside reportError.
+        const isStale = e instanceof ApiError && e.status === 404
+        if (!isStale) reportError(e, { source: 'Funnels.getFunnelAnalysis' })
         setAnalysisError(String(e))
       })
       .finally(() => setAnalysisLoading(false))

--- a/web/src/pages/Insights.tsx
+++ b/web/src/pages/Insights.tsx
@@ -29,7 +29,9 @@ export default function Insights() {
     if (!projectId) return
     try {
       const data = await api.getBatchBreakdowns(projectId)
-      setWidgets(data.results)
+      // A Go nil slice marshals as null, and `widgets.map` on null is what
+      // took the whole Insights page down behind an ErrorBoundary (FUN-8).
+      setWidgets(data.results ?? [])
     } catch (e) {
       reportError(e, { source: 'Insights.fetchAll' })
     } finally {


### PR DESCRIPTION
Closes two open BugBarn issues on the `funnelbarn` project.

## FUN-6 — "Failed to fetch" (unresolved, regressed 2026-07-06)

The API client wraps a thrown fetch as `ApiError(0)` and its own comment says
what that means:

```ts
// TypeError: Failed to fetch — browser-level network failure. Don't
// report (it's the user's network, not our code).
```

Nothing enforced it. The rule lived in **2 of 25** `reportError` call sites, so
the July event came from `Dashboard.getDashboard` — a user's connection
dropping, filed as a defect.

**Fix: move the filter to the reporting boundary.** `reportError` now skips
`ApiError` status `0` (offline / DNS / TLS / reset) and `401` (session expired;
`api.request` already redirects to `/login`). Every other 4xx and all 5xx still
report — those are ours.

Two details that matter:

- **Matched structurally, not with `instanceof`.** An error that crossed a
  bundle or realm boundary carries a different class identity for the same
  shape, and failing open there reports exactly the noise this exists to
  suppress. (A test covers it — it's also what made the first version of the
  reporter test fail.)
- **`ApiError` moves to `lib/api-error.ts`.** `api.ts` already imports the
  reporter, so having the reporter import `api.ts` would make `instanceof`
  depend on module evaluation order.

The redundant local filter in `ProjectProvider` is removed; `Funnels` keeps
only its 404 rule, which is specific to a funnel deleted in another tab.

## FUN-8 — "Cannot read properties of null (reading 'map')" (unresolved, last seen 2026-06-17)

Already fixed in production: this was a Go nil slice marshalling as `null` and
`.map` throwing on it, and cd218d8 guarded `AddWidgetModal` that same morning
(`d.event_names ?? []`, `d.properties ?? []`). Zero events since.

But `Insights.fetchAll` still assigned `data.results` straight into state, and
line 181 does `widgets.map(...)`. The backend happens to return `[]` today,
which makes it latent rather than safe — same class, one guard away. Guarded.

## Tests

12 new cases: the filter's inclusion/exclusion boundaries per status, the three
browsers' fetch-failure messages, that an ordinary `TypeError` is *not*
swallowed (it's a real defect — FUN-8 was one), cross-boundary identity, and
`reportError` itself sending or skipping accordingly.

43 files / 395 tests green, all web ratchets pass.