### PR TITLE
chore: gitignore the bb CLI's project pin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,8 @@ cursor.json
 *.coverage.out
 web/coverage/
 /funnelbarn
+
+# bb CLI project pin — written by the `bb` CLI on first use in this repo so
+# `bb issues` scopes to the funnelbarn project instead of the whole fleet.
+# Local convenience, not repo config.
+.bugbarn.json


### PR DESCRIPTION
The `bb` CLI writes `.bugbarn.json` (`{"project": "funnelbarn"}`) on first use
in a repo, which scopes `bb issues` to this project instead of returning every
barn project's issues — without it, a bare `bb issues` here lists ~100
unresolved issues belonging to leadgen, alpaca, rapidroot, brandtrace and
friends.

It is local convenience rather than repo config, so it is ignored instead of
committed. Previously it just sat there as untracked noise in every
`git status`.