### PR TITLE
fix(observability): stop double-sampling browser traces

### DIFF
--- a/.spanbarn.json
+++ b/.spanbarn.json
@@ -1,0 +1,3 @@
+{
+  "project": "funnelbarn"
+}

--- a/web/src/lib/instrumentation.test.ts
+++ b/web/src/lib/instrumentation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import {
-  initInstrumentation, shutdownInstrumentation, shouldSampleTrace, traceparent,
+  initInstrumentation, shutdownInstrumentation, traceparent,
   requestURL, currentTraceId, markTraceError, __resetForTests, __bufferedSpans,
   type SpanPayload,
 } from './instrumentation'
@@ -41,24 +41,6 @@ describe('traceparent', () => {
   it('builds a sampled W3C header', () => {
     expect(traceparent('4bf92f3577b34da6a3ce929d0e0e4736', '00f067aa0ba902b7'))
       .toBe('00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01')
-  })
-})
-
-describe('shouldSampleTrace', () => {
-  it('is deterministic — the same trace ID always decides the same way', () => {
-    const id = 'ff'.repeat(16)
-    expect(shouldSampleTrace(id, 50)).toBe(shouldSampleTrace(id, 50))
-  })
-
-  it('keeps everything at 100 and nothing at 0', () => {
-    const id = '0123456789abcdef' + '0'.repeat(16)
-    expect(shouldSampleTrace(id, 100)).toBe(true)
-    expect(shouldSampleTrace(id, 0)).toBe(false)
-  })
-
-  it('drops rather than throwing on a malformed trace ID', () => {
-    expect(shouldSampleTrace('', 100)).toBe(false)
-    expect(shouldSampleTrace('zzzz', 100)).toBe(false)
   })
 })
 
@@ -174,31 +156,29 @@ describe('navigation', () => {
   })
 })
 
-describe('sampling', () => {
-  it('drops an unsampled, error-free trace whole rather than in part', async () => {
+describe('delivery', () => {
+  // SpanBarn samples again at ingest (1-in-1000 by default, errors always
+  // kept). Sampling here too multiplied the two into roughly 1 trace in
+  // 20,000 — a dashboard with a handful of daily visits never produced one.
+  it('sends every trace, leaving the sampling decision to SpanBarn', async () => {
     installFetch()
     initInstrumentation()
     await window.fetch('/api/v1/funnels')
-
-    // Force the commit path without an error. Whether this trace was sampled
-    // is decided by its ID, so assert the invariant: a batch is either sent
-    // in full or not at all — never a partial trace.
-    const before = sent.length
     shutdownInstrumentation()
-    const batches = sent.slice(before).filter((s) => s.url === '/api/v1/telemetry')
-    if (batches.length > 0) {
-      const spans = batches.flatMap((b) => b.body.spans ?? [])
-      expect(spans.some((s) => s.kind === 'INTERNAL')).toBe(true) // the page span came too
-    }
+
+    const spans = sent.filter((s) => s.url === '/api/v1/telemetry').flatMap((b) => b.body.spans ?? [])
+    expect(spans.some((s) => s.kind === 'CLIENT')).toBe(true)
+    expect(spans.some((s) => s.kind === 'INTERNAL')).toBe(true) // the page span too
     expect(__bufferedSpans()).toHaveLength(0)
   })
 
-  it('always keeps a trace that hit an error', async () => {
+  it('flushes immediately when a trace hits an error, so it survives the page closing', async () => {
     installFetch((url) =>
       url === '/api/v1/boom' ? new Response('', { status: 500 }) : new Response('{}', { status: 200 }))
     initInstrumentation()
     await window.fetch('/api/v1/boom')
 
+    // Sent without waiting for the flush timer or a navigation.
     const spans = sent.filter((s) => s.url === '/api/v1/telemetry').flatMap((b) => b.body.spans ?? [])
     expect(spans.some((s) => s.status === 'ERROR')).toBe(true)
   })

--- a/web/src/lib/instrumentation.ts
+++ b/web/src/lib/instrumentation.ts
@@ -13,10 +13,15 @@ const TELEMETRY_ENDPOINT = '/api/v1/telemetry'
 const CLIENT_ERRORS_ENDPOINT = '/api/v1/client-errors'
 const SERVICE_NAME = 'funnelbarn-web'
 
-/** Percent of traces kept. Errors are always kept regardless. */
-const SAMPLE_PERCENT = 5
+// No client-side sampling. SpanBarn samples again at ingest — it buffers each
+// trace and keeps it only if the trace errored or its ID falls in
+// 1-in-ingest.sample_ratio (default 1000, i.e. 0.1%). Sampling here too made
+// the two multiply: a 5% client rate against that 0.1% left roughly 1 trace in
+// 20,000, which on a dashboard with a handful of daily visits means you never
+// see one. SpanBarn is the single sampling authority; adjust
+// `ingest.sample_ratio.project.<id>` there to see more.
 const FLUSH_INTERVAL_MS = 5000
-/** Flush threshold for a sampled trace, to keep batches small. */
+/** Flush threshold, to keep batches small. */
 const FLUSH_AT_SPANS = 25
 /** Hard ceiling so a long-lived page can't grow the buffer without bound. */
 const MAX_BUFFERED_SPANS = 100
@@ -45,7 +50,6 @@ let flushTimer: ReturnType<typeof setInterval> | null = null
 let pageTraceId = ''
 let pageSpanId = ''
 let pendingPageSpan: SpanPayload | null = null
-let traceSampled = false
 let traceHasError = false
 
 // ---------------------------------------------------------------------------
@@ -65,26 +69,16 @@ export function traceparent(traceId: string, spanId: string): string {
   return `00-${traceId}-${spanId}-01`
 }
 
-/**
- * Deterministic sampler over the trace ID's first 8 bytes. Deterministic rather
- * than random so the same trace ID yields the same decision wherever it is
- * evaluated — a sampled-here / dropped-there split produces traces with holes.
- */
-export function shouldSampleTrace(traceId: string, percent = SAMPLE_PERCENT): boolean {
-  if (traceId.length < 16) return false
-  try {
-    return BigInt('0x' + traceId.slice(0, 16)) % 100n < BigInt(percent)
-  } catch {
-    return false
-  }
-}
-
 /** The current page trace's ID, for correlating an error report with the trace. */
 export function currentTraceId(): string {
   return pageTraceId
 }
 
-/** Marks the current trace as containing an error, so it is never sampled out. */
+/**
+ * Marks the current trace as containing an error. SpanBarn keeps error traces
+ * unconditionally, and this also flushes the buffer immediately so the trace
+ * survives the page closing.
+ */
 export function markTraceError(): void {
   traceHasError = true
 }
@@ -124,18 +118,10 @@ function finalizePageSpan(): void {
   pendingPageSpan = null
 }
 
-/**
- * Ends the current page trace. Buffered spans are sent only if the trace was
- * sampled or hit an error — an unsampled, clean trace is dropped whole rather
- * than partially, so SpanBarn never shows a trace with missing children.
- */
+/** Ends the current page trace and sends whatever it collected. */
 function commitTrace(): void {
   finalizePageSpan()
   if (spanQueue.length === 0) return
-  if (!traceSampled && !traceHasError) {
-    spanQueue.length = 0
-    return
-  }
   sendBatch(spanQueue.splice(0))
 }
 
@@ -144,7 +130,6 @@ function startPageTrace(path: string, fromPath?: string): void {
 
   pageTraceId = hex(16)
   pageSpanId = hex(8)
-  traceSampled = shouldSampleTrace(pageTraceId)
   traceHasError = false
 
   const attributes: Record<string, string | number | boolean> = { 'navigation.to': path }
@@ -174,7 +159,7 @@ function enqueueSpan(span: SpanPayload): void {
     sendBatch(spanQueue.splice(0))
     return
   }
-  if (traceSampled && spanQueue.length >= FLUSH_AT_SPANS) {
+  if (spanQueue.length >= FLUSH_AT_SPANS) {
     flushSpans()
     return
   }
@@ -182,7 +167,6 @@ function enqueueSpan(span: SpanPayload): void {
 }
 
 function flushSpans(): void {
-  if (!traceSampled) return
   finalizePageSpan()
   if (spanQueue.length === 0) return
   sendBatch(spanQueue.splice(0, 50))
@@ -359,7 +343,6 @@ export function __resetForTests(fetchImpl?: typeof fetch): void {
   pendingPageSpan = null
   pageTraceId = ''
   pageSpanId = ''
-  traceSampled = false
   traceHasError = false
   if (flushTimer) {
     clearInterval(flushTimer)


### PR DESCRIPTION
No `funnelbarn-web` traces have shown up in SpanBarn since #218 shipped.

## What I checked

| Link in the chain | Result |
|---|---|
| Instrumentation in the deployed bundle | ✅ `/api/v1/telemetry`, `funnelbarn-web`, `traceparent` all present in `index-BzJAPi7y.js` |
| Relay configured in prod | ✅ `"spanbarn telemetry enabled" signals=traces,metrics,logs,browser-spans` |
| Relay URL + credential | ✅ probe POST to `https://spanbarn.wiebe.xyz/api/v1/spans` → `202 {"accepted":2}` |
| Relay errors in prod logs | ✅ none |
| `/api/v1/telemetry` requests | **0** |
| Probe trace queryable afterwards | ❌ not found |

Two separate things.

## 1. Nobody has opened the dashboard since the deploy

The production pod's request log has no session-authed traffic at all — only
ingest (`/api/v1/events`, `/api/v1/recordings/chunk`), plus kube-probes. The
instrumentation only runs in the dashboard SPA, so there was nothing to send.
Not a bug, but it's why the count is exactly zero rather than merely low.

## 2. The traces were being sampled away twice — this is the bug

My probe was accepted and then vanished, which is the tell. SpanBarn samples at
**ingest**: `TraceBuffer.keep` holds each trace up to 10 minutes and keeps it
only if it errored, or `traceID % ratio == 0` with
`DefaultSampleRatio = 1000` — 0.1%.

Sampling at 5% in the browser on top of that leaves ~**1 trace in 20,000**. On
a dashboard with a handful of daily visits, that's never.

I mirrored SpanBarn's own frontend sampler without checking that SpanBarn
samples the same traces again downstream. That's my error.

**Fix:** remove the client-side sampler. SpanBarn is the single sampling
authority — it already keeps every error trace unconditionally, and its ratio
is tunable per project (`ingest.sample_ratio.project.<id>`) where the browser's
was a hard-coded constant nobody could reach.

Storage in SpanBarn is unaffected: it drops the same share at ingest either
way. What changes is that the traces it keeps are a sample of *all* dashboard
activity rather than of the 5% that happened to survive the browser first.

Batching, the buffer ceiling and the immediate flush on error are unchanged.

## Seeing traces reliably

Even after this, the default 0.1% means a clean dashboard trace is unlikely to
be kept. To actually watch traces during development, set
`ingest.sample_ratio.project.3` to `1` in SpanBarn's settings (ratio ≤ 1 keeps
everything). That's a SpanBarn-side change, not this repo's — happy to make it
if you want it on.