### PR TITLE
chore: untrack and gitignore the sb CLI's project pin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,8 @@ cursor.json
 web/coverage/
 /funnelbarn
 
-# bb CLI project pin — written by the `bb` CLI on first use in this repo so
-# `bb issues` scopes to the funnelbarn project instead of the whole fleet.
-# Local convenience, not repo config.
+# barn CLI project pins — written by the `bb` / `sb` CLIs on first use in this
+# repo so their queries scope to the funnelbarn project instead of the whole
+# fleet. Local convenience, not repo config.
 .bugbarn.json
+.spanbarn.json

--- a/.spanbarn.json
+++ b/.spanbarn.json
@@ -1,3 +1,0 @@
-{
-  "project": "funnelbarn"
-}


### PR DESCRIPTION
`.spanbarn.json` is the `sb` CLI's equivalent of `.bugbarn.json` — written on
first use in a repo so `sb traces` / `sb services` scope to this project
instead of returning the whole fleet.

It got swept into #221 by a `git add -A` while I was diagnosing the missing
traces. It's local convenience rather than repo config, so it's untracked and
ignored the same way its bugbarn counterpart was in #220 — both now under one
comment.