### PR TITLE
feat(sdks/go): reach every event field via TrackEvent, and surface dropped events

### DIFF
--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -40,6 +40,54 @@ func main() {
 }
 ```
 
+### Fully-specified events
+
+`Track` and `Page` are conveniences over `TrackEvent`, which reaches every field
+the payload carries:
+
+```go
+funnelbarn.TrackEvent(funnelbarn.Event{
+    Name:        "outreach_opened",
+    UTMSource:   "outreach",
+    UTMMedium:   "email",
+    UTMCampaign: "nl-intro",
+    Properties:  map[string]any{"step": "intro-1"},
+    UserID:      "lead-77607",
+    SessionID:   "send-abc123",
+    Timestamp:   openedAt, // zero means now
+})
+```
+
+**`SessionID` is what funnel reports group on.** An event sent without one is
+still recorded, but it cannot take part in a funnel — so a server-side sequence
+(`sent` → `opened` → `clicked` → `converted`) must set it to something stable
+for the subject being followed: a recipient, an order, a job. Browser traffic
+gets this from the JS SDK; a Go service has to supply it.
+
+Set `Timestamp` explicitly for anything replayed from a spool or a retry queue.
+Left zero it stamps at enqueue, which records when you got around to sending the
+event rather than when it happened.
+
+### Knowing when events are dropped
+
+Enqueueing is non-blocking: when the buffer (`Options.QueueSize`, default 256)
+is full the event is discarded rather than stalling the caller. That is the
+right trade for page views and the wrong one for a funnel-critical step — a lost
+`converted` looks exactly like a conversion that never happened.
+
+```go
+funnelbarn.Init(funnelbarn.Options{
+    // ...
+    OnDrop: func(e funnelbarn.Event) {
+        slog.Warn("funnelbarn dropped an event", "name", e.Name)
+    },
+})
+
+funnelbarn.Dropped() // cumulative since the last Init
+```
+
+`OnDrop` runs on the caller's goroutine — keep it non-blocking.
+
 ## Feature flags
 
 ```go

--- a/sdks/go/event_test.go
+++ b/sdks/go/event_test.go
@@ -1,0 +1,254 @@
+package funnelbarn
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// bodyCollector spins up an ingest stub and returns the channel decoded bodies
+// land on. Mirrors the shape used in env_test.go.
+func bodyCollector(t *testing.T, n int) (chan map[string]any, *httptest.Server) {
+	t.Helper()
+	bodies := make(chan map[string]any, n)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var b map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&b)
+		bodies <- b
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(srv.Close)
+	return bodies, srv
+}
+
+func recv(t *testing.T, bodies chan map[string]any) map[string]any {
+	t.Helper()
+	select {
+	case b := <-bodies:
+		return b
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for an event")
+		return nil
+	}
+}
+
+// The whole point of Event: every field the payload carries must be reachable.
+// Before this, session_id / user_id / utm_* were marshalled but unsettable, so
+// a server-sent event could never join a funnel (funnels group on session_id).
+func TestTrackEvent_CarriesEveryField(t *testing.T) {
+	bodies, srv := bodyCollector(t, 1)
+	Init(Options{APIKey: "k", Endpoint: srv.URL, ProjectName: "p"})
+
+	when := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+	TrackEvent(Event{
+		Name:        "outreach_opened",
+		URL:         "https://example.com/landing",
+		Referrer:    "https://mail.example.com/",
+		UTMSource:   "outreach",
+		UTMMedium:   "email",
+		UTMCampaign: "nl-intro",
+		UTMTerm:     "intro-1",
+		UTMContent:  "hero-cta",
+		Properties:  map[string]any{"step": "intro-1"},
+		UserID:      "lead-77607",
+		SessionID:   "send-abc123",
+		Timestamp:   when,
+	})
+	if err := Shutdown(3 * time.Second); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	b := recv(t, bodies)
+	for _, tc := range []struct{ key, want string }{
+		{"name", "outreach_opened"},
+		{"url", "https://example.com/landing"},
+		{"referrer", "https://mail.example.com/"},
+		{"utm_source", "outreach"},
+		{"utm_medium", "email"},
+		{"utm_campaign", "nl-intro"},
+		{"utm_term", "intro-1"},
+		{"utm_content", "hero-cta"},
+		{"user_id", "lead-77607"},
+		{"session_id", "send-abc123"},
+	} {
+		if got := b[tc.key]; got != tc.want {
+			t.Errorf("%s = %v, want %q", tc.key, got, tc.want)
+		}
+	}
+	props, ok := b["properties"].(map[string]any)
+	if !ok || props["step"] != "intro-1" {
+		t.Errorf("properties = %v, want step=intro-1", b["properties"])
+	}
+	// An explicit timestamp must survive: an event replayed from a spool is
+	// about when it happened, not when we got around to sending it.
+	ts, err := time.Parse(time.RFC3339Nano, b["timestamp"].(string))
+	if err != nil {
+		t.Fatalf("parse timestamp: %v", err)
+	}
+	if !ts.Equal(when) {
+		t.Errorf("timestamp = %s, want %s", ts, when)
+	}
+}
+
+func TestTrackEvent_ZeroTimestampMeansNow(t *testing.T) {
+	bodies, srv := bodyCollector(t, 1)
+	Init(Options{APIKey: "k", Endpoint: srv.URL, ProjectName: "p"})
+
+	before := time.Now().UTC().Add(-time.Second)
+	TrackEvent(Event{Name: "ping"})
+	if err := Shutdown(3 * time.Second); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	ts, err := time.Parse(time.RFC3339Nano, recv(t, bodies)["timestamp"].(string))
+	if err != nil {
+		t.Fatalf("parse timestamp: %v", err)
+	}
+	if ts.Before(before) || ts.After(time.Now().UTC().Add(time.Second)) {
+		t.Errorf("timestamp = %s, want ~now", ts)
+	}
+}
+
+// Track and Page are now wrappers. They must be indistinguishable on the wire
+// from what they sent before, or this is a breaking change wearing a bow tie.
+func TestTrackAndPage_UnchangedOnTheWire(t *testing.T) {
+	bodies, srv := bodyCollector(t, 2)
+	Init(Options{APIKey: "k", Endpoint: srv.URL, ProjectName: "p"})
+
+	Track("signup_completed", map[string]any{"plan": "pro"})
+	Page("https://example.com/pricing", "https://google.com/")
+	if err := Shutdown(3 * time.Second); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	got := map[string]map[string]any{}
+	for i := 0; i < 2; i++ {
+		b := recv(t, bodies)
+		got[b["name"].(string)] = b
+	}
+
+	tr, ok := got["signup_completed"]
+	if !ok {
+		t.Fatal("no signup_completed event")
+	}
+	if props := tr["properties"].(map[string]any); props["plan"] != "pro" {
+		t.Errorf("Track properties = %v", tr["properties"])
+	}
+	// Track never set these, and must still not.
+	for _, k := range []string{"url", "referrer", "user_id", "session_id", "utm_source"} {
+		if _, present := tr[k]; present {
+			t.Errorf("Track set %s = %v, want it omitted", k, tr[k])
+		}
+	}
+
+	pg, ok := got["page_view"]
+	if !ok {
+		t.Fatal("no page_view event")
+	}
+	if pg["url"] != "https://example.com/pricing" || pg["referrer"] != "https://google.com/" {
+		t.Errorf("Page url/referrer = %v / %v", pg["url"], pg["referrer"])
+	}
+	if _, present := pg["properties"]; present {
+		t.Errorf("Page set properties = %v, want omitted", pg["properties"])
+	}
+}
+
+func TestTrackEvent_RefusesEmptyName(t *testing.T) {
+	_, srv := bodyCollector(t, 1)
+	Init(Options{APIKey: "k", Endpoint: srv.URL, ProjectName: "p"})
+	defer func() { _ = Shutdown(time.Second) }()
+
+	if TrackEvent(Event{Name: ""}) {
+		t.Error("TrackEvent with an empty Name returned true, want false")
+	}
+}
+
+// "Not initialised" means analytics was never switched on. That is not a lost
+// event and must not be counted as one, or the drop counter alarms on every
+// process that simply has no API key.
+func TestTrackEvent_UninitialisedIsNotADrop(t *testing.T) {
+	if err := Shutdown(time.Second); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	before := Dropped()
+	if TrackEvent(Event{Name: "ping"}) {
+		t.Error("TrackEvent on an uninitialised SDK returned true, want false")
+	}
+	if got := Dropped(); got != before {
+		t.Errorf("Dropped() = %d, want %d — uninitialised must not count as a drop", got, before)
+	}
+}
+
+// A full queue silently discarded the event and the bool return was ignored by
+// every caller in practice. Dropped() and OnDrop are how that loss becomes
+// visible.
+func TestTrackEvent_FullQueueCountsAndReportsTheDrop(t *testing.T) {
+	// A server that never answers keeps the single sender goroutine busy, so
+	// the queue fills and stays full.
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block
+	}))
+	defer srv.Close()
+	defer close(block)
+
+	var mu sync.Mutex
+	var dropsSeen []Event
+	Init(Options{
+		APIKey: "k", Endpoint: srv.URL, ProjectName: "p", QueueSize: 1,
+		OnDrop: func(e Event) {
+			mu.Lock()
+			defer mu.Unlock()
+			dropsSeen = append(dropsSeen, e)
+		},
+	})
+
+	// Enqueue well past the capacity; at least one must be refused.
+	var refused int
+	for i := 0; i < 50; i++ {
+		if !TrackEvent(Event{Name: "flood", SessionID: "s1"}) {
+			refused++
+		}
+	}
+	if refused == 0 {
+		t.Fatal("nothing was refused with QueueSize=1 and a blocked sender")
+	}
+	if got := Dropped(); got != uint64(refused) {
+		t.Errorf("Dropped() = %d, want %d", got, refused)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(dropsSeen) != refused {
+		t.Fatalf("OnDrop fired %d times, want %d", len(dropsSeen), refused)
+	}
+	// The hook must receive the event that was lost, not a placeholder.
+	if dropsSeen[0].Name != "flood" || dropsSeen[0].SessionID != "s1" {
+		t.Errorf("OnDrop got %+v, want the original event", dropsSeen[0])
+	}
+}
+
+func TestInit_ResetsTheDropCounter(t *testing.T) {
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block
+	}))
+	defer srv.Close()
+	defer close(block)
+
+	Init(Options{APIKey: "k", Endpoint: srv.URL, ProjectName: "p", QueueSize: 1})
+	for i := 0; i < 50; i++ {
+		TrackEvent(Event{Name: "flood"})
+	}
+	if Dropped() == 0 {
+		t.Fatal("expected drops before re-Init")
+	}
+
+	Init(Options{APIKey: "k", Endpoint: srv.URL, ProjectName: "p", QueueSize: 1})
+	if got := Dropped(); got != 0 {
+		t.Errorf("Dropped() after Init = %d, want 0", got)
+	}
+}

--- a/sdks/go/funnelbarn.go
+++ b/sdks/go/funnelbarn.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -35,6 +36,20 @@ type Options struct {
 	// call auto-registers a flag that does not exist yet: "config" for a
 	// singleton value this service polls, "" or "experiment" otherwise.
 	FlagKind string
+
+	// OnDrop, when set, is called with the event that could not be queued
+	// because the buffer was full.
+	//
+	// Dropping is the correct trade for page views and the wrong one for a
+	// funnel-critical step: a discarded "converted" is indistinguishable from a
+	// conversion that never happened. The bool return already reports it, but
+	// in practice every caller ignores it, so the loss is invisible. This hook
+	// (and Dropped) make it observable.
+	//
+	// It runs on the CALLER's goroutine, so keep it non-blocking — a hook that
+	// does I/O turns a full buffer into backpressure on the very code path the
+	// non-blocking enqueue exists to protect.
+	OnDrop func(Event)
 }
 
 // eventPayload is the JSON body sent to POST /api/v1/events.
@@ -45,6 +60,8 @@ type eventPayload struct {
 	UTMSource   string         `json:"utm_source,omitempty"`
 	UTMMedium   string         `json:"utm_medium,omitempty"`
 	UTMCampaign string         `json:"utm_campaign,omitempty"`
+	UTMTerm     string         `json:"utm_term,omitempty"`
+	UTMContent  string         `json:"utm_content,omitempty"`
 	Properties  map[string]any `json:"properties,omitempty"`
 	UserID      string         `json:"user_id,omitempty"`
 	SessionID   string         `json:"session_id,omitempty"`
@@ -70,37 +87,111 @@ func Init(o Options) {
 	}
 	opts = o
 	tp = newTransport(o)
+	dropped.Store(0)
+}
+
+// Event is a fully-specified analytics event.
+//
+// It exists because Track and Page between them could only reach five of the
+// fields the payload already carries. Everything else — session_id, user_id and
+// the utm_* set — was marshalled and stored but unreachable from Go, which made
+// one whole class of analytics impossible to build from a server: funnel
+// reports key their steps on session_id, so events emitted without one can be
+// recorded but never assembled into a funnel. See issue #223.
+//
+// A zero field is omitted from the payload, so the zero Event plus a Name
+// behaves exactly like the old Track.
+type Event struct {
+	// Name is the event name, snake_case by convention. Required; an empty
+	// Name is refused, matching Track.
+	Name string
+
+	URL      string
+	Referrer string
+
+	UTMSource   string
+	UTMMedium   string
+	UTMCampaign string
+	UTMTerm     string
+	UTMContent  string
+
+	Properties map[string]any
+
+	// UserID and SessionID are the join keys. SessionID is the one funnel
+	// reports group on; a server-sent event that wants to take part in a funnel
+	// must set it to something stable for the subject being followed (a
+	// recipient, an order, a job) rather than leaving it empty.
+	UserID    string
+	SessionID string
+
+	// Timestamp is when the event happened. Zero means now.
+	//
+	// Worth setting explicitly for anything replayed from a spool or a retry
+	// queue: stamping at enqueue records when we got around to sending it, not
+	// when it occurred.
+	Timestamp time.Time
+}
+
+// payload converts to the wire shape, defaulting the timestamp.
+func (e Event) payload() eventPayload {
+	ts := e.Timestamp
+	if ts.IsZero() {
+		ts = time.Now()
+	}
+	return eventPayload{
+		Name:        e.Name,
+		URL:         e.URL,
+		Referrer:    e.Referrer,
+		UTMSource:   e.UTMSource,
+		UTMMedium:   e.UTMMedium,
+		UTMCampaign: e.UTMCampaign,
+		UTMTerm:     e.UTMTerm,
+		UTMContent:  e.UTMContent,
+		Properties:  e.Properties,
+		UserID:      e.UserID,
+		SessionID:   e.SessionID,
+		Timestamp:   ts.UTC(),
+	}
+}
+
+// dropped counts events discarded because the queue was full. Reset by Init.
+var dropped atomic.Uint64
+
+// Dropped returns how many events have been discarded because the queue was
+// full since the last Init. Enqueueing is non-blocking by design, so a busy
+// producer loses events rather than stalling; this is how you find out.
+func Dropped() uint64 { return dropped.Load() }
+
+// TrackEvent sends a fully-specified event. Returns false if the SDK is not
+// initialised, the Name is empty, or the queue was full.
+func TrackEvent(e Event) bool {
+	mu.Lock()
+	t := tp
+	onDrop := opts.OnDrop
+	mu.Unlock()
+	if t == nil || e.Name == "" {
+		return false
+	}
+	if t.enqueue(e.payload()) {
+		return true
+	}
+	// A full queue is a real loss, unlike "not initialised" above, which means
+	// analytics was never switched on. Only the former is counted.
+	dropped.Add(1)
+	if onDrop != nil {
+		onDrop(e)
+	}
+	return false
 }
 
 // Track sends a custom event.
 func Track(name string, properties map[string]any) bool {
-	mu.Lock()
-	t := tp
-	mu.Unlock()
-	if t == nil || name == "" {
-		return false
-	}
-	return t.enqueue(eventPayload{
-		Name:       name,
-		Properties: properties,
-		Timestamp:  time.Now().UTC(),
-	})
+	return TrackEvent(Event{Name: name, Properties: properties})
 }
 
 // Page sends a page_view event.
 func Page(url, referrer string) bool {
-	mu.Lock()
-	t := tp
-	mu.Unlock()
-	if t == nil {
-		return false
-	}
-	return t.enqueue(eventPayload{
-		Name:      "page_view",
-		URL:       url,
-		Referrer:  referrer,
-		Timestamp: time.Now().UTC(),
-	})
+	return TrackEvent(Event{Name: "page_view", URL: url, Referrer: referrer})
 }
 
 // Flush waits for queued events to drain within the timeout.


### PR DESCRIPTION
Closes #223.

`Track` and `Page` between them could set five of the eleven fields `eventPayload` already puts on the wire. `session_id`, `user_id` and the `utm_*` set were marshalled and stored but unreachable from Go.

That made one class of analytics impossible to build from a server: funnel reports group their steps on `session_id`, so an event emitted without one is recorded but can never be assembled into a funnel. A server-side sequence — `sent → opened → clicked → converted` — was unbuildable, not because the data model lacked anything but because the SDK would not populate the join column.

## What changed

- **`Event` + `TrackEvent`**, with `Track`/`Page` retained as wrappers — purely additive, no breaking change.
- **`utm_term` / `utm_content`** added to the payload; the events table has always selected them.
- **`Timestamp` is settable.** Zero still means now. Worth setting for anything replayed from a spool or retry queue, where stamping at enqueue records when we got around to sending rather than when it happened.
- **Dropped events are now visible.** `Dropped()` counts events discarded because the buffer was full, and `Options.OnDrop` hands back the lost event. "Not initialised" is deliberately *not* counted — that means analytics was never switched on, and counting it would alarm every process without an API key.

## Testing

`sdks/go/event_test.go` covers every field reaching the wire, both timestamp paths, the drop counter and hook, empty-name refusal, and that `Track`/`Page` remain byte-identical on the wire.

Each assertion was mutation-tested — omitting `SessionID`, omitting `UTMTerm`, always stamping now, skipping the drop count, skipping the hook, skipping the `Init` reset, counting uninitialised as a drop, and leaking properties from `Page` — all eight mutants were killed.