### PR TITLE
Closes #237: stop reporting rejected events as delivered in the Go SDK

### DIFF
--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -204,6 +204,14 @@ func run() error {
 			APIKey:      cfg.DogfoodAPIKey,
 			Endpoint:    strings.TrimRight(cfg.PublicURL, "/"),
 			ProjectName: cfg.DogfoodProject,
+			// Without this the SDK falls back to its own log.Printf, which
+			// bypasses slog and so never reaches BugBarn. A dogfood key minted
+			// for the wrong project rejects every event permanently; that has
+			// to look like a problem, not like silence.
+			OnError: func(e selfsdk.Event, err error) {
+				slog.Warn("dogfood analytics event was rejected",
+					"event", e.Name, "err", err, "handled", true)
+			},
 		})
 		defer selfsdk.Shutdown(2 * time.Second)
 	} else if cfg.DogfoodAPIKey != "" {

--- a/internal/api/setup.go
+++ b/internal/api/setup.go
@@ -94,7 +94,12 @@ func (s *Server) handleSetup(w http.ResponseWriter, r *http.Request) {
 		publicURL = "https://funnelbarn.wiebe.xyz"
 	}
 
-	endpoint := publicURL + "/api/v1/events"
+	// Two different things, and conflating them is what made funnelbarn#237
+	// expensive: every SDK takes the BASE url and appends the path itself, while
+	// curl and the header docs want the full ingest URL. Naming them apart here
+	// keeps an SDK example from ever being handed ingestURL again.
+	baseURL := publicURL
+	ingestURL := publicURL + "/api/v1/events"
 	sdkURL := publicURL + "/sdk.js"
 	setupURL := publicURL + "/api/v1/setup/" + slug
 	now := time.Now().UTC().Format(time.RFC3339)
@@ -108,11 +113,12 @@ func (s *Server) handleSetup(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(b, "## Project Configuration\n\n")
 	fmt.Fprintf(b, "| Key        | Value |\n")
 	fmt.Fprintf(b, "|------------|-------|\n")
-	fmt.Fprintf(b, "| Endpoint   | %s |\n", endpoint)
+	fmt.Fprintf(b, "| Endpoint   | %s |\n", baseURL)
 	fmt.Fprintf(b, "| Project    | %s |\n", slug)
 	fmt.Fprintf(b, "| API Key    | %s |\n", plaintext)
 	fmt.Fprintf(b, "| Status     | %s |\n", project.Status)
 	fmt.Fprintf(b, "| Setup URL  | %s |\n\n", setupURL)
+	fmt.Fprintf(b, "> **Endpoint is the base URL**, not the ingest path. Every SDK appends `/api/v1/events` itself — pass `%s`, not `%s`. (Posting to the doubled path 404s, and older SDK versions reported that as success.) Only the raw `curl` example below uses the full URL.\n\n", baseURL, ingestURL)
 	fmt.Fprintf(b, "> The API key above is scoped to **ingest** only (event tracking). It is deterministic and will be identical on every visit. No plaintext is stored server-side.\n\n")
 	fmt.Fprintf(b, "> **One key, all environments.** Use the same API key and project across development, staging, and production. Tag each event with `\"environment\": \"dev\"` (or `\"staging\"`, `\"prod\"`, etc.) — aliases are normalised server-side. The dashboard lets you filter to a single environment so your dev traffic never pollutes production numbers.\n\n---\n\n")
 
@@ -174,7 +180,7 @@ func (s *Server) handleSetup(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(b, "```typescript\n")
 	fmt.Fprintf(b, "import { FunnelBarnClient } from '@funnelbarn/js'\n\n")
 	fmt.Fprintf(b, "const fb = new FunnelBarnClient({\n")
-	fmt.Fprintf(b, "  endpoint:    '%s',\n", endpoint)
+	fmt.Fprintf(b, "  endpoint:    '%s',\n", baseURL)
 	fmt.Fprintf(b, "  projectName: '%s',\n", slug)
 	fmt.Fprintf(b, "  apiKey:      '%s',\n", plaintext)
 	fmt.Fprintf(b, "  // Tag every event with the deployment environment.\n")
@@ -301,7 +307,7 @@ func (s *Server) handleSetup(w http.ResponseWriter, r *http.Request) {
 
 	fmt.Fprintf(b, "## HTTP API (curl)\n\n")
 	fmt.Fprintf(b, "```bash\n")
-	fmt.Fprintf(b, "curl -s -X POST '%s' \\\n", endpoint)
+	fmt.Fprintf(b, "curl -s -X POST '%s' \\\n", ingestURL)
 	fmt.Fprintf(b, "  -H 'Content-Type: application/json' \\\n")
 	fmt.Fprintf(b, "  -H '%s: %s' \\\n", keyHeader, plaintext)
 	fmt.Fprintf(b, "  -H '%s: %s' \\\n", projHeader, slug)

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -68,6 +68,48 @@ Set `Timestamp` explicitly for anything replayed from a spool or a retry queue.
 Left zero it stamps at enqueue, which records when you got around to sending the
 event rather than when it happened.
 
+### `Endpoint` is a base URL
+
+```go
+Endpoint: "https://funnelbarn.example.com"   // the SDK appends /api/v1/events
+```
+
+The full ingest URL is accepted too — a trailing `/api/v1/events` is stripped
+before the path is appended, so one config value can feed this SDK and a browser
+SDK without either of them 404ing. (It used to produce
+`/api/v1/events/api/v1/events`, which 404s on every event and reported success.)
+
+### Knowing when events are rejected
+
+**Delivery is best-effort, not guaranteed — but it is no longer silent.** A
+non-2xx response or a failed request is counted, and either handed to `OnError`
+or, if you set no hook, written to the standard logger once per `Init`:
+
+```go
+funnelbarn.Init(funnelbarn.Options{
+    // ...
+    OnError: func(e funnelbarn.Event, err error) {
+        slog.Error("funnelbarn rejected an event", "name", e.Name, "err", err)
+    },
+})
+
+funnelbarn.Rejected() // cumulative since the last Init
+```
+
+This exists because it didn't. `send` used to discard the status code, so a
+`404` (wrong endpoint), a `401` (wrong key) and a `403` (key minted for another
+project) all returned success — a whole app's server-side events went nowhere
+for two months with nothing logged, counted or returned ([#237][issue-237]).
+
+`Rejected()` is the number to alert on. A count that tracks everything you send
+is a configuration bug, not a blip: 4xx will not clear on its own, and the SDK
+does not retry.
+
+`OnError` runs on the SDK's background goroutine, once per failed event — it may
+block, but a slow hook stalls delivery and fills the queue.
+
+[issue-237]: https://github.com/webwiebe/funnelbarn/issues/237
+
 ### Knowing when events are dropped
 
 Enqueueing is non-blocking: when the buffer (`Options.QueueSize`, default 256)
@@ -87,6 +129,10 @@ funnelbarn.Dropped() // cumulative since the last Init
 ```
 
 `OnDrop` runs on the caller's goroutine — keep it non-blocking.
+
+`Dropped` and `Rejected` are different failures: `Dropped` means you produced
+faster than the queue drained, `Rejected` means FunnelBarn would not take what
+did get sent.
 
 ## Feature flags
 

--- a/sdks/go/delivery_test.go
+++ b/sdks/go/delivery_test.go
@@ -1,0 +1,306 @@
+package funnelbarn
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The regression this whole file exists for: before #237 every one of these
+// statuses returned nil from send, so a permanently misconfigured SDK reported
+// success on every event it never delivered.
+func TestSend_NonSuccessStatusIsAnError(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+		want   string
+	}{
+		{"wrong endpoint path", http.StatusNotFound, "404 page not found", "404"},
+		{"missing or wrong key", http.StatusUnauthorized, `{"error":"invalid api key"}`, "401"},
+		{"key for another project", http.StatusForbidden, "", "403"},
+		{"payload too large", http.StatusRequestEntityTooLarge, "", "413"},
+		{"server fault", http.StatusInternalServerError, "boom", "500"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			tr := newTransport(Options{APIKey: "k", Endpoint: srv.URL, QueueSize: 1})
+			defer tr.shutdown(time.Second)
+
+			err := tr.send(Event{Name: "signup"}.payload())
+			if err == nil {
+				t.Fatalf("send returned nil for %d — a rejected event must not look delivered", tc.status)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not mention status %s", err, tc.want)
+			}
+			// The status alone doesn't say which misconfiguration it is; the
+			// server's own words do.
+			if tc.body != "" && !strings.Contains(err.Error(), tc.body) {
+				t.Errorf("error %q drops the response body %q", err, tc.body)
+			}
+		})
+	}
+}
+
+func TestSend_2xxIsAccepted(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusAccepted, http.StatusNoContent} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(status)
+		}))
+		tr := newTransport(Options{APIKey: "k", Endpoint: srv.URL, QueueSize: 1})
+		if err := tr.send(Event{Name: "signup"}.payload()); err != nil {
+			t.Errorf("status %d: send = %v, want nil", status, err)
+		}
+		tr.shutdown(time.Second)
+		srv.Close()
+	}
+}
+
+// OnError is the hook a caller wires to find out. It must carry the event back
+// intact — knowing "something failed" without knowing what is barely better
+// than the old silence.
+func TestOnError_ReceivesTheRejectedEvent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no such route", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	var mu sync.Mutex
+	var got []Event
+	var errs []error
+	done := make(chan struct{}, 2)
+
+	Init(Options{
+		APIKey:   "k",
+		Endpoint: srv.URL,
+		OnError: func(e Event, err error) {
+			mu.Lock()
+			got = append(got, e)
+			errs = append(errs, err)
+			mu.Unlock()
+			done <- struct{}{}
+		},
+	})
+
+	when := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	TrackEvent(Event{
+		Name:      "converted",
+		UserID:    "lead-77607",
+		SessionID: "send-abc123",
+		Timestamp: when,
+	})
+	Track("signup", map[string]any{"plan": "pro"})
+	if err := Shutdown(3 * time.Second); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Fatal("timed out waiting for OnError")
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(got) != 2 {
+		t.Fatalf("OnError called %d times, want 2", len(got))
+	}
+	first := got[0]
+	if first.Name != "converted" || first.SessionID != "send-abc123" || first.UserID != "lead-77607" {
+		t.Errorf("OnError event = %+v, want the converted event with its join keys", first)
+	}
+	if !first.Timestamp.Equal(when) {
+		t.Errorf("OnError timestamp = %v, want %v", first.Timestamp, when)
+	}
+	if !strings.Contains(errs[0].Error(), "404") {
+		t.Errorf("OnError err = %v, want it to mention the 404", errs[0])
+	}
+
+	// Track's bool return only ever reported a full queue, so the counter is
+	// the only place a rejection shows up for callers who don't set the hook.
+	if n := Rejected(); n != 2 {
+		t.Errorf("Rejected() = %d, want 2", n)
+	}
+	if n := Dropped(); n != 0 {
+		t.Errorf("Dropped() = %d, want 0 — nothing was queue-dropped", n)
+	}
+}
+
+func TestRejected_StaysZeroWhenEventsAreAccepted(t *testing.T) {
+	bodies, srv := bodyCollector(t, 1)
+	Init(Options{APIKey: "k", Endpoint: srv.URL})
+	Track("signup", nil)
+	if err := Shutdown(3 * time.Second); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	recv(t, bodies)
+	if n := Rejected(); n != 0 {
+		t.Errorf("Rejected() = %d, want 0", n)
+	}
+}
+
+func TestInit_ResetsRejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	failed := make(chan struct{}, 1)
+	Init(Options{APIKey: "k", Endpoint: srv.URL, OnError: func(Event, error) { failed <- struct{}{} }})
+	Track("signup", nil)
+	<-failed
+	if n := Rejected(); n == 0 {
+		t.Fatal("Rejected() = 0 after a rejected event")
+	}
+
+	Init(Options{APIKey: "k", Endpoint: srv.URL})
+	if n := Rejected(); n != 0 {
+		t.Errorf("Rejected() = %d after Init, want 0", n)
+	}
+	_ = Shutdown(time.Second)
+}
+
+// Without a hook the SDK still has to say something once. A single stderr line
+// is what would have caught two months of 404s.
+func TestFirstFailureIsLoggedOnceWhenNoHookIsSet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "no such route", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	// Retire any transport a previous test left running against a closed
+	// server, so its own (correct) first-failure line can't land in our buffer.
+	_ = Shutdown(2 * time.Second)
+
+	var buf bytes.Buffer
+	oldOut, oldFlags := log.Writer(), log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	defer func() { log.SetOutput(oldOut); log.SetFlags(oldFlags) }()
+
+	Init(Options{APIKey: "k", Endpoint: srv.URL})
+	for i := 0; i < 5; i++ {
+		Track("signup", nil)
+	}
+	if err := Shutdown(3 * time.Second); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "404") {
+		t.Errorf("log = %q, want the 404 reported", out)
+	}
+	if n := strings.Count(out, "ingest rejected"); n != 1 {
+		t.Errorf("logged %d times, want exactly 1 — a broken endpoint must not spam the log", n)
+	}
+	if Rejected() != 5 {
+		t.Errorf("Rejected() = %d, want 5 — every failure counts even though only one is logged", Rejected())
+	}
+}
+
+func TestNoLogWhenOnErrorIsSet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_ = Shutdown(2 * time.Second)
+
+	var buf bytes.Buffer
+	oldOut := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(oldOut)
+
+	seen := make(chan struct{}, 1)
+	Init(Options{APIKey: "k", Endpoint: srv.URL, OnError: func(Event, error) { seen <- struct{}{} }})
+	Track("signup", nil)
+	<-seen
+	if err := Shutdown(3 * time.Second); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	if out := buf.String(); strings.Contains(out, "ingest rejected") {
+		t.Errorf("log = %q, want silence — the caller took ownership by setting OnError", out)
+	}
+}
+
+// The misconfiguration that started this: one config value for "the FunnelBarn
+// endpoint", fed to a browser SDK and to this one. Both spellings must land on
+// the same URL rather than one of them 404ing forever.
+func TestNormaliseEndpoint(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"https://f.example.com", "https://f.example.com"},
+		{"https://f.example.com/", "https://f.example.com"},
+		{"  https://f.example.com  ", "https://f.example.com"},
+		{"https://f.example.com/api/v1/events", "https://f.example.com"},
+		{"https://f.example.com/api/v1/events/", "https://f.example.com"},
+		{"https://f.example.com/api/v1/evaluate", "https://f.example.com"},
+		{"https://f.example.com/funnelbarn/api/v1/events", "https://f.example.com/funnelbarn"},
+		// Only the SDK's own suffix is stripped; an unrelated path is the
+		// caller's mount point and must survive.
+		{"https://f.example.com/events", "https://f.example.com/events"},
+		{"", ""},
+	} {
+		if got := normaliseEndpoint(tc.in); got != tc.want {
+			t.Errorf("normaliseEndpoint(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestFullIngestURLAsEndpointStillDelivers(t *testing.T) {
+	var paths []string
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+		if r.URL.Path != "/api/v1/events" {
+			http.Error(w, "no such route", http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	Init(Options{APIKey: "k", Endpoint: srv.URL + "/api/v1/events"})
+	Track("signup", nil)
+	if err := Shutdown(3 * time.Second); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(paths) != 1 || paths[0] != "/api/v1/events" {
+		t.Fatalf("posted to %v, want a single /api/v1/events", paths)
+	}
+	if n := Rejected(); n != 0 {
+		t.Errorf("Rejected() = %d, want 0", n)
+	}
+}
+
+func TestUnconfiguredEndpointIsReported(t *testing.T) {
+	errs := make(chan error, 1)
+	Init(Options{APIKey: "k", OnError: func(_ Event, err error) { errs <- err }})
+	Track("signup", nil)
+	select {
+	case err := <-errs:
+		if !strings.Contains(err.Error(), "endpoint") {
+			t.Errorf("err = %v, want it to name the endpoint", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for OnError")
+	}
+	_ = Shutdown(time.Second)
+}

--- a/sdks/go/flags.go
+++ b/sdks/go/flags.go
@@ -78,7 +78,7 @@ func Evaluate(ctx context.Context, key string, def any, evalCtx map[string]any) 
 	if key == "" {
 		return EvalResult{FlagKey: key, Value: def, Reason: "ERROR", ErrorCode: "GENERAL"}
 	}
-	if t == nil || o.Endpoint == "" {
+	if t == nil || t.opts.Endpoint == "" {
 		// Not initialised: behave exactly like an outage.
 		return EvalResult{FlagKey: key, Value: def, Reason: "ERROR", ErrorCode: "TRANSPORT"}
 	}
@@ -202,7 +202,8 @@ func (t *transport) evaluate(ctx context.Context, key string, def any, evalCtx m
 	ctx, cancel := context.WithTimeout(ctx, flagEvalTimeout)
 	defer cancel()
 
-	url := strings.TrimRight(t.opts.Endpoint, "/") + "/api/v1/evaluate"
+	// Endpoint is normalised by newTransport, so it is a bare base URL here.
+	url := t.opts.Endpoint + "/api/v1/evaluate"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return fail("TRANSPORT")

--- a/sdks/go/funnelbarn.go
+++ b/sdks/go/funnelbarn.go
@@ -7,7 +7,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"log"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -15,8 +18,18 @@ import (
 
 // Options configures the SDK.
 type Options struct {
-	APIKey      string
-	Endpoint    string
+	APIKey string
+
+	// Endpoint is the FunnelBarn base URL — "https://funnelbarn.example.com".
+	// The SDK appends the API paths itself.
+	//
+	// A full ingest URL is accepted too: a trailing "/api/v1/events" is
+	// stripped before the path is appended. Handing the same config value to
+	// this SDK and to a browser SDK is the natural thing to do, and getting it
+	// wrong used to produce ".../api/v1/events/api/v1/events" — a 404 on every
+	// event, reported as success. See issue #237.
+	Endpoint string
+
 	ProjectName string
 	QueueSize   int // default 256
 
@@ -50,6 +63,20 @@ type Options struct {
 	// does I/O turns a full buffer into backpressure on the very code path the
 	// non-blocking enqueue exists to protect.
 	OnDrop func(Event)
+
+	// OnError, when set, is called with an event the server did not accept and
+	// the reason: a non-2xx response, or a transport error.
+	//
+	// OnDrop's argument applies here with more force. A queue-full drop needs a
+	// busy producer to happen at all; a misconfigured endpoint or a key minted
+	// for the wrong project rejects *every* event, forever, and until this hook
+	// existed the SDK reported that identically to success. Two months of
+	// events went to a 404 that way (issue #237).
+	//
+	// It runs on the SDK's background goroutine, not the caller's, so it may
+	// block — but it is called once per failed event, so a slow hook stalls
+	// delivery and fills the queue. Rate-limit anything expensive.
+	OnError func(Event, error)
 }
 
 // eventPayload is the JSON body sent to POST /api/v1/events.
@@ -88,6 +115,7 @@ func Init(o Options) {
 	opts = o
 	tp = newTransport(o)
 	dropped.Store(0)
+	rejected.Store(0)
 }
 
 // Event is a fully-specified analytics event.
@@ -154,13 +182,45 @@ func (e Event) payload() eventPayload {
 	}
 }
 
+// event converts back to the caller-facing shape for OnError. Every Event field
+// round-trips; Environment is transport-owned and has no Event field to land in.
+func (p eventPayload) event() Event {
+	return Event{
+		Name:        p.Name,
+		URL:         p.URL,
+		Referrer:    p.Referrer,
+		UTMSource:   p.UTMSource,
+		UTMMedium:   p.UTMMedium,
+		UTMCampaign: p.UTMCampaign,
+		UTMTerm:     p.UTMTerm,
+		UTMContent:  p.UTMContent,
+		Properties:  p.Properties,
+		UserID:      p.UserID,
+		SessionID:   p.SessionID,
+		Timestamp:   p.Timestamp,
+	}
+}
+
 // dropped counts events discarded because the queue was full. Reset by Init.
 var dropped atomic.Uint64
+
+// rejected counts events that left the queue but were never accepted. Reset by
+// Init.
+var rejected atomic.Uint64
 
 // Dropped returns how many events have been discarded because the queue was
 // full since the last Init. Enqueueing is non-blocking by design, so a busy
 // producer loses events rather than stalling; this is how you find out.
 func Dropped() uint64 { return dropped.Load() }
+
+// Rejected returns how many events left the queue but were not accepted since
+// the last Init — the server answered non-2xx, or the request never completed.
+//
+// Read it alongside Dropped. A non-zero Dropped means you are producing faster
+// than the queue drains; a Rejected that tracks everything you send means
+// FunnelBarn is refusing the lot, which is a configuration bug (wrong endpoint,
+// wrong key, wrong project) and not something that will clear on its own.
+func Rejected() uint64 { return rejected.Load() }
 
 // TrackEvent sends a fully-specified event. Returns false if the SDK is not
 // initialised, the Name is empty, or the queue was full.
@@ -233,9 +293,16 @@ type transport struct {
 	done   chan struct{}
 	client *http.Client
 	flags  *flagCache
+
+	// loggedErr guards the one-line stderr warning on the first failed send.
+	// A library should not narrate, but silence is what let a permanent 404 run
+	// for two months; one line, once, is the cheapest thing that would have
+	// caught it. Callers who wire OnError get that instead.
+	loggedErr atomic.Bool
 }
 
 func newTransport(o Options) *transport {
+	o.Endpoint = normaliseEndpoint(o.Endpoint)
 	t := &transport{
 		opts:   o,
 		queue:  make(chan eventPayload, o.QueueSize),
@@ -245,6 +312,23 @@ func newTransport(o Options) *transport {
 	}
 	go t.run()
 	return t
+}
+
+// normaliseEndpoint reduces whatever the caller configured to a base URL.
+//
+// The setup page hands out the full ingest URL, and an app that keeps a single
+// "FunnelBarn endpoint" value naturally feeds it to every SDK. Appending the
+// path to that produces "/api/v1/events/api/v1/events", which 404s. Accepting
+// both spellings costs a TrimSuffix and removes a whole class of silent
+// misconfiguration.
+func normaliseEndpoint(endpoint string) string {
+	e := strings.TrimRight(strings.TrimSpace(endpoint), "/")
+	for _, path := range []string{"/api/v1/events", "/api/v1/evaluate"} {
+		if strings.HasSuffix(e, path) {
+			return strings.TrimRight(strings.TrimSuffix(e, path), "/")
+		}
+	}
+	return e
 }
 
 func (t *transport) enqueue(e eventPayload) bool {
@@ -263,9 +347,22 @@ func (t *transport) run() {
 	defer close(t.done)
 	for e := range t.queue {
 		if err := t.send(e); err != nil {
-			// Best-effort: drop on error.
-			_ = err
+			t.reportErr(e, err)
 		}
+	}
+}
+
+// reportErr accounts for an event the server never took. Delivery stays
+// best-effort — there is still no retry — but the loss is no longer invisible.
+func (t *transport) reportErr(e eventPayload, err error) {
+	rejected.Add(1)
+	if t.opts.OnError != nil {
+		t.opts.OnError(e.event(), err)
+		return
+	}
+	if t.loggedErr.CompareAndSwap(false, true) {
+		log.Printf("funnelbarn: %v (event %q was not delivered; further send errors are silent — "+
+			"set Options.OnError or read Rejected() to observe them)", err, e.Name)
 	}
 }
 
@@ -295,7 +392,21 @@ func (t *transport) send(e eventPayload) error {
 	if err != nil {
 		return err
 	}
-	resp.Body.Close()
+	defer resp.Body.Close()
+
+	// A 404 (wrong endpoint), a 401 (missing or wrong key) and a 403 (key
+	// minted for another project) are permanent, and every one of them used to
+	// return nil. The body carries the server's own explanation, so include a
+	// slice of it: "404 Not Found" alone does not say which of those it is.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		if detail := strings.TrimSpace(string(snippet)); detail != "" {
+			return fmt.Errorf("funnelbarn: ingest rejected the event: %s: %s", resp.Status, detail)
+		}
+		return fmt.Errorf("funnelbarn: ingest rejected the event: %s", resp.Status)
+	}
+	// Drained so the connection can be reused; nothing else reads the body.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
 	return nil
 }
 

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -120,6 +120,18 @@ interface RecordingState {
 /**
  * FunnelBarnClient is the main analytics client.
  */
+/**
+ * Reduces whatever was configured to a base URL. `endpoint` is the server root
+ * — the SDK appends `/api/v1/events` itself — but the setup page used to hand
+ * out the full ingest URL, so a config value copied from there produced
+ * `/api/v1/events/api/v1/events` and 404'd every event. Accepting both
+ * spellings costs one line and removes the whole failure mode. See #237.
+ */
+function normaliseEndpoint(endpoint: string): string {
+  const trimmed = endpoint.trim().replace(/\/+$/, "");
+  return trimmed.replace(/\/api\/v1\/events$/, "");
+}
+
 export class FunnelBarnClient {
   private readonly apiKey: string;
   private readonly endpoint: string;
@@ -170,7 +182,7 @@ export class FunnelBarnClient {
 
   constructor(options: FunnelBarnOptions) {
     this.apiKey = options.apiKey;
-    this.endpoint = options.endpoint.replace(/\/$/, "");
+    this.endpoint = normaliseEndpoint(options.endpoint);
     this.projectName = options.projectName;
     this.environment = options.environment;
     this.flushInterval = options.flushInterval ?? 5000;

--- a/sdks/js/test/sdk.test.mjs
+++ b/sdks/js/test/sdk.test.mjs
@@ -145,6 +145,22 @@ describe('FunnelBarnClient', () => {
     assert.equal(requests[0].url, 'http://example.com/api/v1/events');
   });
 
+  // The setup page used to print the full ingest URL in the JS example, so a
+  // config value copied from it doubled the path and 404'd every event. See #237.
+  it('accepts the full ingest URL as the endpoint', async () => {
+    const client = new FunnelBarnClient({ apiKey: 'k', endpoint: 'http://example.com/api/v1/events' });
+    client.track('test');
+    await client.flush();
+    assert.equal(requests[0].url, 'http://example.com/api/v1/events');
+  });
+
+  it('leaves an unrelated mount path alone', async () => {
+    const client = new FunnelBarnClient({ apiKey: 'k', endpoint: 'http://example.com/funnelbarn' });
+    client.track('test');
+    await client.flush();
+    assert.equal(requests[0].url, 'http://example.com/funnelbarn/api/v1/events');
+  });
+
   it('event timestamp is a valid ISO string', async () => {
     const client = new FunnelBarnClient({ apiKey: 'k', endpoint: 'http://localhost:8080' });
     client.track('ts-test');

--- a/sdks/python/funnelbarn/__init__.py
+++ b/sdks/python/funnelbarn/__init__.py
@@ -44,7 +44,13 @@ class FunnelBarnClient:
         timeout: float = 5.0,
     ) -> None:
         self._api_key = api_key
-        self._endpoint = endpoint.rstrip("/")
+        # endpoint is the server root — the client appends the API path itself.
+        # The setup page used to print the full ingest URL, so a config value
+        # copied from there produced "/api/v1/events/api/v1/events" and 404'd
+        # every event, silently. Accept both spellings. See funnelbarn#237.
+        self._endpoint = endpoint.strip().rstrip("/")
+        if self._endpoint.endswith("/api/v1/events"):
+            self._endpoint = self._endpoint[: -len("/api/v1/events")].rstrip("/")
         self._project_name = project_name
         self._flush_interval = flush_interval
         self._timeout = timeout


### PR DESCRIPTION
## Summary

`transport.send` discarded the HTTP status, so a `404`, `401`, `403`, `413` or `500` all returned `nil` — and `run()` threw that `nil` away. Nothing in the SDK's surface distinguished *"FunnelBarn accepted this event"* from *"FunnelBarn has rejected every event you have ever sent"*: `Track`'s bool, `Dropped()` and `OnDrop` all report a **full queue**, which is decided before the send ever happens.

That cost `wiebe-xyz/professionals` two months of server-side events across three environments — `Endpoint` was set to the full ingest URL, so every event went to `/api/v1/events/api/v1/events` and 404'd, with nothing logged, counted or returned.

## Changes

**Go SDK — the rejection is now observable**

- `send` checks the status and returns an error naming it, plus a 512-byte slice of the response body: `404 Not Found` alone doesn't say whether it's the path, the key, or the project, and our case had two stacked misconfigurations that were both 4xx.
- `Options.OnError func(Event, error)` mirrors the existing `OnDrop` and carries the rejected event back intact (name, session/user id, timestamp) — knowing *something* failed without knowing *what* is barely better than the old silence.
- `Rejected() uint64` counts every event that left the queue unaccepted, reset by `Init` like `Dropped`. It's the number to alert on: a count that tracks everything you send is a configuration bug, not a blip.
- With no hook set, the **first failure per `Init`** goes to the standard logger, once. A permanent 4xx must not be silent by default; one line would have caught this in a day instead of two months. Setting `OnError` takes ownership and suppresses it.

Delivery is still best-effort — there is no retry — but the loss is no longer invisible.

**The endpoint asymmetry that produced the bad config**

Every SDK takes a **base URL** and appends the path itself, but the setup page printed the **full ingest URL** in its config table *and* in its JS example. A value copied from there doubled the path — in the JS SDK too, not just Go, so module-based JS consumers following the doc were 404ing the same way.

- All three SDKs (Go, JS, Python) now strip a trailing `/api/v1/events`, so both spellings land on the same URL. An unrelated mount path (`/funnelbarn`) is left alone.
- The setup page hands SDK examples the base URL and says so explicitly; only the raw `curl` example keeps the full URL.

**Dogfooding**

`cmd/funnelbarn` wires `OnError` to `slog`, so a rejected self-tracking event reaches BugBarn rather than the SDK's `log.Printf`, which bypasses slog entirely.

## Testing

- [x] `sdks/go`: new `delivery_test.go` — every rejected status is an error and names it, the body detail survives, 2xx still succeeds, `OnError` gets the event back with its join keys, `Rejected()` counts and resets, the no-hook log fires exactly once for five failures, `OnError` suppresses it, endpoint normalisation table, and a full-ingest-URL `Init` that still delivers to a single `/api/v1/events`. `go test -race -count=1 ./...` green.
- [x] `sdks/js`: two new cases for the full ingest URL and for an unrelated mount path. `npm test` — 31/31.
- [x] `sdks/python`: normalisation verified against both spellings.
- [x] Root module: `go test -race -count=1 ./...`, `go vet`, `gofmt`, and `scripts/go-quality-gates.sh` all green.
- [x] No breaking changes — `Options` gains a field, the package gains `Rejected()`, and `Endpoint` accepts strictly more than before.

One local-only note: `scripts/coverage-gate.py` flags `internal/geoip` at 27.6% against its 34% floor on this machine. That package is untouched by this PR and the gap is a Go 1.27-vs-1.26 statement-counting difference — CI (Go 1.26) is green on `main` at the same coverage.

Closes #237