### PR TITLE
Closes #235: add an analytics:read token scope and a documented read API

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,18 @@ funnelbarn user create --username admin --password yourpassword
 
 Authentication: session cookie (obtained via `POST /api/v1/login`) or API key (`X-FunnelBarn-Api-Key` header). Ingest also reads the project slug from `X-FunnelBarn-Project`. All project-scoped routes are under `/api/v1/projects/{id}/`. `/api/v1/health` returns DB connectivity status and server version.
 
+API keys are issued per project from Settings → API Keys with one of these scopes:
+
+| Scope | Grants |
+|---|---|
+| `ingest` | Send events. Cannot read or change anything. |
+| `analytics:read` | Read this project's events, event counts, funnels and funnel-step conversion. Read-only. |
+| `flags:read` | Read this project's feature flags. |
+| `flags:write` | Read and update (not create or delete) this project's feature flags. |
+| `full` | Everything, for this project. |
+
+Scopes do not imply each other across features: `flags:write` implies `flags:read`, but an `analytics:read` key cannot touch flags and a `flags:*` key cannot read analytics. The instance-wide `FUNNELBARN_API_KEY` resolves to no project and is rejected on every scoped route — use a project key.
+
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | `GET` | `/api/v1/health` | — | Health check + version |
@@ -149,14 +161,18 @@ Authentication: session cookie (obtained via `POST /api/v1/login`) or API key (`
 | `POST` | `/api/v1/login` | — | Dashboard login |
 | `POST` | `/api/v1/logout` | Session | Logout |
 | `GET` | `/api/v1/me` | Session | Current user |
-| `GET` | `/api/v1/projects` | Session | List projects |
+| `GET` | `/api/v1/projects` | Session or `analytics:read` | List projects (a token sees only its own) |
 | `POST` | `/api/v1/projects` | Session | Create project |
-| `GET` | `/api/v1/projects/{id}/dashboard` | Session | Dashboard stats |
-| `GET` | `/api/v1/projects/{id}/events` | Session | Paginated events |
+| `GET` | `/api/v1/projects/{id}/dashboard` | Session or `analytics:read` | Dashboard stats |
+| `GET` | `/api/v1/projects/{id}/events` | Session or `analytics:read` | Paginated events |
+| `GET` | `/api/v1/projects/{id}/event-names` | Session or `analytics:read` | Distinct event names |
+| `GET` | `/api/v1/projects/{id}/event-counts` | Session or `analytics:read` | Per-event counts over a date range |
 | `GET` | `/api/v1/projects/{id}/sessions` | Session | Paginated sessions |
-| `GET` | `/api/v1/projects/{id}/funnels` | Session | List funnels |
+| `GET` | `/api/v1/projects/{id}/funnels` | Session or `analytics:read` | List funnels |
 | `POST` | `/api/v1/projects/{id}/funnels` | Session | Create funnel |
-| `GET` | `/api/v1/projects/{id}/funnels/{fid}/analysis` | Session | Funnel analysis |
+| `GET` | `/api/v1/projects/{id}/funnels/{fid}/analysis` | Session or `analytics:read` | Funnel step conversion |
+| `GET` | `/api/v1/projects/{id}/flags` | Session or `flags:read` | List feature flags |
+| `PUT` | `/api/v1/projects/{id}/flags/{fid}` | Session or `flags:write` | Update a feature flag |
 | `GET` | `/api/v1/apikeys` | Session | List API keys |
 | `POST` | `/api/v1/apikeys` | Session | Create API key |
 

--- a/internal/api/analytics_tokens_test.go
+++ b/internal/api/analytics_tokens_test.go
@@ -1,0 +1,312 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/wiebe-xyz/funnelbarn/internal/repository"
+)
+
+// seedEvents writes n events with the given name into a project, spread one
+// minute apart ending now, so a range query has something to count.
+func seedEvents(t *testing.T, store *repository.Store, projectID, name string, n int) {
+	t.Helper()
+	now := time.Now().UTC()
+	for i := 0; i < n; i++ {
+		err := store.InsertEvent(context.Background(), repository.Event{
+			ID:         fmt.Sprintf("ev-%s-%s-%d", projectID, name, i),
+			ProjectID:  projectID,
+			SessionID:  fmt.Sprintf("sess-%s-%d", name, i),
+			Name:       name,
+			URL:        "https://example.test/" + name,
+			OccurredAt: now.Add(-time.Duration(i) * time.Minute),
+		})
+		if err != nil {
+			t.Fatalf("InsertEvent(%s): %v", name, err)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// What the scope is for: a scripted readout, no browser session anywhere.
+// ---------------------------------------------------------------------------
+
+func TestAnalyticsToken_ReadsTheRoutesAReadoutNeeds(t *testing.T) {
+	srv, store := newFlagTokenServer(t)
+	ctx := context.Background()
+	p, _ := store.CreateProject(ctx, "Professionals", "professionals")
+	seedEvents(t, store, p.ID, "first_run_started", 5)
+	seedEvents(t, store, p.ID, "first_run_completed", 2)
+	f, _ := store.CreateFunnel(ctx, repository.Funnel{
+		ProjectID: p.ID,
+		Name:      "First run",
+		Steps: []repository.FunnelStep{
+			{EventName: "first_run_started"},
+			{EventName: "first_run_completed"},
+		},
+	})
+	key := scopedKey(t, store, p.ID, "readout-key", repository.APIKeyScopeAnalyticsRead)
+
+	for _, path := range []string{
+		"/api/v1/projects",
+		"/api/v1/projects/" + p.ID + "/dashboard",
+		"/api/v1/projects/" + p.ID + "/events",
+		"/api/v1/projects/" + p.ID + "/event-names",
+		"/api/v1/projects/" + p.ID + "/event-counts",
+		"/api/v1/projects/" + p.ID + "/funnels",
+		"/api/v1/projects/" + p.ID + "/funnels/" + f.ID + "/analysis",
+	} {
+		if w := withKey(t, srv, http.MethodGet, path, key, nil); w.Code != http.StatusOK {
+			t.Errorf("GET %s: want 200, got %d (body: %s)", path, w.Code, w.Body.String())
+		}
+	}
+}
+
+// The list has no {id} for the middleware to check, so the handler has to
+// narrow it itself — otherwise one customer's readout token enumerates every
+// project on the instance.
+func TestAnalyticsToken_ProjectListIsNarrowedToTheToken(t *testing.T) {
+	srv, store := newFlagTokenServer(t)
+	ctx := context.Background()
+	mine, _ := store.CreateProject(ctx, "Mine", "mine")
+	other, _ := store.CreateProject(ctx, "Someone Else", "someone-else")
+	key := scopedKey(t, store, mine.ID, "readout-key", repository.APIKeyScopeAnalyticsRead)
+
+	w := withKey(t, srv, http.MethodGet, "/api/v1/projects", key, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Projects []repository.Project `json:"projects"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Projects) != 1 || resp.Projects[0].ID != mine.ID {
+		t.Fatalf("a token must see only its own project, got %+v", resp.Projects)
+	}
+	if resp.Projects[0].ID == other.ID {
+		t.Fatal("token leaked another project")
+	}
+
+	// A dashboard session still sees everything.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects", nil)
+	req.AddCookie(sessionCookieFor(t, srv, "admin"))
+	sw := httptest.NewRecorder()
+	srv.ServeHTTP(sw, req)
+	var all struct {
+		Projects []repository.Project `json:"projects"`
+	}
+	_ = json.Unmarshal(sw.Body.Bytes(), &all)
+	if len(all.Projects) != 2 {
+		t.Errorf("a session should still list every project, got %d", len(all.Projects))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The scope is read-only, and it is not a skeleton key.
+// ---------------------------------------------------------------------------
+
+func TestAnalyticsToken_CannotWriteOrTouchFlags(t *testing.T) {
+	srv, store := newFlagTokenServer(t)
+	ctx := context.Background()
+	p, _ := store.CreateProject(ctx, "P", "p")
+	flag := seedFlag(t, store, p.ID, "outbound_email")
+	key := scopedKey(t, store, p.ID, "readout-key", repository.APIKeyScopeAnalyticsRead)
+
+	// Flags are a different scope entirely — reading analytics grants nothing there.
+	if w := withKey(t, srv, http.MethodGet, "/api/v1/projects/"+p.ID+"/flags", key, nil); w.Code != http.StatusForbidden {
+		t.Errorf("flags read: want 403, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	w := withKey(t, srv, http.MethodPut, "/api/v1/projects/"+p.ID+"/flags/"+flag.ID, key,
+		map[string]any{"status": "paused"})
+	if w.Code != http.StatusForbidden {
+		t.Errorf("flag write: want 403, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	// Nor can it create a funnel on the project it can read.
+	w = withKey(t, srv, http.MethodPost, "/api/v1/projects/"+p.ID+"/funnels", key, map[string]any{
+		"name": "Sneaky", "steps": []map[string]any{{"event_name": "a"}},
+	})
+	if w.Code == http.StatusOK || w.Code == http.StatusCreated {
+		t.Errorf("a read-only token must not create a funnel, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestAnalyticsToken_CannotReadAnotherProject(t *testing.T) {
+	srv, store := newFlagTokenServer(t)
+	ctx := context.Background()
+	mine, _ := store.CreateProject(ctx, "Mine", "mine")
+	other, _ := store.CreateProject(ctx, "Other", "other")
+	seedEvents(t, store, other.ID, "secret_event", 3)
+	key := scopedKey(t, store, mine.ID, "readout-key", repository.APIKeyScopeAnalyticsRead)
+
+	w := withKey(t, srv, http.MethodGet, "/api/v1/projects/"+other.ID+"/event-counts", key, nil)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+// An ingest key is the one every project already has in production; it must not
+// have quietly become a read credential.
+func TestAnalyticsToken_IngestScopeCannotRead(t *testing.T) {
+	srv, store := newFlagTokenServer(t)
+	p, _ := store.CreateProject(context.Background(), "P", "p")
+	key := scopedKey(t, store, p.ID, "ingest-key", repository.APIKeyScopeIngest)
+
+	if w := withKey(t, srv, http.MethodGet, "/api/v1/projects/"+p.ID+"/event-counts", key, nil); w.Code != http.StatusForbidden {
+		t.Errorf("want 403, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+// The instance-wide FUNNELBARN_API_KEY resolves with no project, which would
+// make it a master read key for every project on the instance.
+func TestAnalyticsToken_GlobalKeyIsRefused(t *testing.T) {
+	srv, store := newFlagTokenServer(t)
+	p, _ := store.CreateProject(context.Background(), "P", "p")
+
+	w := withKey(t, srv, http.MethodGet, "/api/v1/projects/"+p.ID+"/event-counts", "global-instance-key", nil)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("want 401, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	if w := withKey(t, srv, http.MethodGet, "/api/v1/projects", "global-instance-key", nil); w.Code != http.StatusUnauthorized {
+		t.Errorf("project list with the global key: want 401, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/projects/{id}/event-counts
+// ---------------------------------------------------------------------------
+
+type eventCountsResponse struct {
+	ProjectID   string                     `json:"project_id"`
+	From        string                     `json:"from"`
+	To          string                     `json:"to"`
+	Limit       int                        `json:"limit"`
+	Events      []repository.EventNameStat `json:"events"`
+	TotalEvents int64                      `json:"total_events"`
+}
+
+func TestEventCounts_CountsPerNameOverRange(t *testing.T) {
+	srv, store := newFlagTokenServer(t)
+	p, _ := store.CreateProject(context.Background(), "P", "p")
+	seedEvents(t, store, p.ID, "first_run_started", 5)
+	seedEvents(t, store, p.ID, "first_run_completed", 2)
+	key := scopedKey(t, store, p.ID, "readout-key", repository.APIKeyScopeAnalyticsRead)
+
+	w := withKey(t, srv, http.MethodGet, "/api/v1/projects/"+p.ID+"/event-counts?range=24h", key, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var resp eventCountsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got := map[string]int64{}
+	for _, e := range resp.Events {
+		got[e.Name] = e.Count
+	}
+	if got["first_run_started"] != 5 || got["first_run_completed"] != 2 {
+		t.Fatalf("counts: %+v", got)
+	}
+	if resp.TotalEvents != 7 {
+		t.Errorf("total_events: want 7, got %d", resp.TotalEvents)
+	}
+	if resp.ProjectID != p.ID || resp.From == "" || resp.To == "" {
+		t.Errorf("the response must echo the window it answered for: %+v", resp)
+	}
+}
+
+// A window with nothing in it is an empty list, not null — a shell script
+// pipes this straight into jq.
+func TestEventCounts_EmptyWindowIsAnEmptyList(t *testing.T) {
+	srv, store := newFlagTokenServer(t)
+	p, _ := store.CreateProject(context.Background(), "P", "p")
+	seedEvents(t, store, p.ID, "signup", 3)
+	key := scopedKey(t, store, p.ID, "readout-key", repository.APIKeyScopeAnalyticsRead)
+
+	old := time.Now().UTC().AddDate(-1, 0, 0)
+	path := fmt.Sprintf("/api/v1/projects/%s/event-counts?from=%s&to=%s",
+		p.ID, old.Format(time.RFC3339), old.AddDate(0, 0, 1).Format(time.RFC3339))
+	w := withKey(t, srv, http.MethodGet, path, key, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	if body := w.Body.String(); !jsonHasEmptyEvents(t, body) {
+		t.Errorf(`want "events":[], got %s`, body)
+	}
+}
+
+func jsonHasEmptyEvents(t *testing.T, body string) bool {
+	t.Helper()
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return string(raw["events"]) == "[]"
+}
+
+// A readout that asked for last week and quietly got last month reports the
+// wrong number with no way to notice — so bad input is a 400, not a default.
+func TestEventCounts_RejectsUnparseableRange(t *testing.T) {
+	srv, store := newFlagTokenServer(t)
+	p, _ := store.CreateProject(context.Background(), "P", "p")
+	key := scopedKey(t, store, p.ID, "readout-key", repository.APIKeyScopeAnalyticsRead)
+
+	for _, q := range []string{
+		"?range=90d",
+		"?from=last-tuesday",
+		"?to=nope",
+		"?from=2026-01-02T00:00:00Z&to=2026-01-01T00:00:00Z",
+		"?limit=0",
+		"?limit=9000",
+		"?limit=lots",
+	} {
+		w := withKey(t, srv, http.MethodGet, "/api/v1/projects/"+p.ID+"/event-counts"+q, key, nil)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("%s: want 400, got %d (body: %s)", q, w.Code, w.Body.String())
+		}
+	}
+}
+
+func TestEventCounts_SessionStillWorks(t *testing.T) {
+	srv, store := newFlagTokenServer(t)
+	p, _ := store.CreateProject(context.Background(), "P", "p")
+	seedEvents(t, store, p.ID, "signup", 1)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+p.ID+"/event-counts", nil)
+	req.AddCookie(sessionCookieFor(t, srv, "admin"))
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Issuance
+// ---------------------------------------------------------------------------
+
+func TestCreateAPIKey_AcceptsAnalyticsReadScope(t *testing.T) {
+	srv, store := newAuthedServer(t)
+	p, _ := store.CreateProject(context.Background(), "P", "p")
+	cookie, csrf := sessionAndCSRF(t, srv, "u")
+
+	w := postJSONWithCSRF(t, srv, "/api/v1/apikeys", map[string]any{
+		"project_id": p.ID, "name": "weekly readout", "scope": repository.APIKeyScopeAnalyticsRead,
+	}, cookie, csrf)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("want 201, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	var body map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	apiKey, _ := body["api_key"].(map[string]any)
+	if apiKey["scope"] != repository.APIKeyScopeAnalyticsRead {
+		t.Errorf("scope: want %s, got %v", repository.APIKeyScopeAnalyticsRead, apiKey["scope"])
+	}
+}

--- a/internal/api/api_tokens.go
+++ b/internal/api/api_tokens.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 
@@ -8,38 +9,52 @@ import (
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 )
 
-// Flag CRUD used to be reachable only with a browser session, so no service
-// could read or toggle a flag — an operator surface had to send people to the
-// FunnelBarn dashboard to flip a switch. Splitting one deliberate action across
-// two systems is how "we thought it was off" happens.
+// Flag CRUD and analytics reads used to be reachable only with a browser
+// session, so no service could read or toggle a flag, and no scheduled job
+// could publish a funnel readout — an operator surface had to send people to
+// the FunnelBarn dashboard to flip a switch or copy numbers out by hand.
+// Splitting one deliberate action across two systems is how "we thought it was
+// off" happens.
 //
 // These routes therefore accept a project-scoped API token as well as a
 // session. The token is bound to one project, hashed at rest like every other
 // API key, issued and revoked from the dashboard, and carries a last-used
 // timestamp.
 
-// requireSessionOrFlagToken serves next to either a dashboard session or a
+// tokenProjectCtxKey carries the project a request was authenticated for when
+// it came in on an API token rather than a session.
+type tokenProjectCtxKey struct{}
+
+// tokenProjectFromContext returns the project an API token authenticated this
+// request for. It is empty for session-authenticated requests, which is the
+// difference between "show me my project" and "show me every project".
+func tokenProjectFromContext(ctx context.Context) string {
+	id, _ := ctx.Value(tokenProjectCtxKey{}).(string)
+	return id
+}
+
+// requireSessionOrToken serves next to either a dashboard session or a
 // project-scoped API token holding at least wantScope.
 //
 // When the request carries an API key it is authenticated as a token and
 // nothing else: falling back to the session path on a bad token would turn a
 // revoked credential into a silent success for whoever happened to be logged
 // in on the same browser.
-func (s *Server) requireSessionOrFlagToken(wantScope string, next http.HandlerFunc) http.HandlerFunc {
+func (s *Server) requireSessionOrToken(wantScope string, next http.HandlerFunc) http.HandlerFunc {
 	viaSession := s.requireSession(next)
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get(auth.HeaderAPIKey) == "" {
 			viaSession(w, r)
 			return
 		}
-		s.serveFlagToken(w, r, wantScope, next)
+		s.serveScopedToken(w, r, wantScope, next)
 	}
 }
 
-func (s *Server) serveFlagToken(w http.ResponseWriter, r *http.Request, wantScope string, next http.HandlerFunc) {
+func (s *Server) serveScopedToken(w http.ResponseWriter, r *http.Request, wantScope string, next http.HandlerFunc) {
 	projectID, scope, ok := s.ingest.APIKeyProjectScope(r)
 	if !ok {
-		slog.WarnContext(r.Context(), "flag token: unauthorized",
+		slog.WarnContext(r.Context(), "api token: unauthorized",
 			"path", r.URL.Path,
 			"request_id", RequestIDFromContext(r.Context()),
 		)
@@ -48,14 +63,14 @@ func (s *Server) serveFlagToken(w http.ResponseWriter, r *http.Request, wantScop
 	}
 
 	// The instance-wide env-var key resolves with an empty project ID, which
-	// would make it a master key for every project's flags. A flag token must
-	// name the project it is allowed to touch.
+	// would make it a master key for every project's flags and analytics. A
+	// scoped token must name the project it is allowed to touch.
 	if projectID == "" {
-		slog.WarnContext(r.Context(), "flag token: instance-wide key cannot be used for flag access",
+		slog.WarnContext(r.Context(), "api token: instance-wide key cannot be used for scoped access",
 			"path", r.URL.Path,
 			"request_id", RequestIDFromContext(r.Context()),
 		)
-		jsonError(w, "flag access requires a project-scoped API key from the project settings page, not the global FUNNELBARN_API_KEY", http.StatusUnauthorized)
+		jsonError(w, "this endpoint requires a project-scoped API key from the project settings page, not the global FUNNELBARN_API_KEY", http.StatusUnauthorized)
 		return
 	}
 
@@ -78,7 +93,11 @@ func (s *Server) serveFlagToken(w http.ResponseWriter, r *http.Request, wantScop
 
 	// No CSRF check: this request is authenticated by a header the browser
 	// never attaches on its own, so there is nothing to forge across origins.
-	next(w, r)
+	//
+	// Routes with no {id} in the path (GET /api/v1/projects) cannot be checked
+	// against the token's project above, so they read it back off the context
+	// and narrow their own answer to it instead.
+	next(w, r.WithContext(context.WithValue(r.Context(), tokenProjectCtxKey{}, projectID)))
 }
 
 // scopeAllows reports whether a key's scope covers the access a route needs.
@@ -93,6 +112,10 @@ func scopeAllows(have, want string) bool {
 		return have == repository.APIKeyScopeFlagsRead || have == repository.APIKeyScopeFlagsWrite
 	case repository.APIKeyScopeFlagsWrite:
 		return have == repository.APIKeyScopeFlagsWrite
+	case repository.APIKeyScopeAnalyticsRead:
+		// Deliberately not implied by flags:write — a token that can toggle a
+		// flag has no business reading the whole event stream.
+		return have == repository.APIKeyScopeAnalyticsRead
 	}
 	return false
 }

--- a/internal/api/api_tokens_test.go
+++ b/internal/api/api_tokens_test.go
@@ -338,6 +338,17 @@ func TestScopeAllows(t *testing.T) {
 		{repository.APIKeyScopeIngest, repository.APIKeyScopeFlagsRead, false},
 		{repository.APIKeyScopeIngest, repository.APIKeyScopeFlagsWrite, false},
 		{"something-new", repository.APIKeyScopeFlagsRead, false},
+
+		// analytics:read is its own axis: full covers it, flag scopes do not,
+		// and it grants nothing on the flag routes in return.
+		{repository.APIKeyScopeFull, repository.APIKeyScopeAnalyticsRead, true},
+		{repository.APIKeyScopeAnalyticsRead, repository.APIKeyScopeAnalyticsRead, true},
+		{repository.APIKeyScopeAnalyticsRead, repository.APIKeyScopeFlagsRead, false},
+		{repository.APIKeyScopeAnalyticsRead, repository.APIKeyScopeFlagsWrite, false},
+		{repository.APIKeyScopeFlagsRead, repository.APIKeyScopeAnalyticsRead, false},
+		{repository.APIKeyScopeFlagsWrite, repository.APIKeyScopeAnalyticsRead, false},
+		{repository.APIKeyScopeIngest, repository.APIKeyScopeAnalyticsRead, false},
+		{"something-new", repository.APIKeyScopeAnalyticsRead, false},
 	}
 	for _, c := range cases {
 		if got := scopeAllows(c.have, c.want); got != c.ok {

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -179,12 +179,26 @@ func (s *Server) handleMe(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// handleListProjects lists all projects.
+// handleListProjects lists all projects for a dashboard session, or just the
+// one project an API token is scoped to.
+//
+// The path carries no {id}, so the token middleware cannot check the route
+// against the key's project for us — narrowing here is what keeps one
+// customer's analytics token from enumerating every project on the instance.
 func (s *Server) handleListProjects(w http.ResponseWriter, r *http.Request) {
 	projects, err := s.projects.ListProjects(r.Context())
 	if err != nil {
 		mapServiceError(w, err, "handleListProjects")
 		return
+	}
+	if tokenProject := tokenProjectFromContext(r.Context()); tokenProject != "" {
+		mine := make([]repository.Project, 0, 1)
+		for _, p := range projects {
+			if p.ID == tokenProject {
+				mine = append(mine, p)
+			}
+		}
+		projects = mine
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"projects": projects})
 }

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 
+	"github.com/wiebe-xyz/funnelbarn/internal/repository"
+	"github.com/wiebe-xyz/funnelbarn/internal/timerange"
 	"github.com/wiebe-xyz/funnelbarn/internal/tracing"
 )
 
@@ -41,6 +44,72 @@ func (s *Server) handleEventNames(w http.ResponseWriter, r *http.Request) {
 		names = []string{}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"event_names": names})
+}
+
+// handleEventCounts returns per-event-name counts over a date range — the
+// smallest thing a scheduled readout needs to answer "how many signups last
+// week". The dashboard payload carries the same numbers, but only its top ten
+// and wrapped in a dozen other aggregates; this is the one query, on its own,
+// reachable with a read-only analytics:read token.
+func (s *Server) handleEventCounts(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("id")
+	if projectID == "" {
+		jsonError(w, "project id required", http.StatusBadRequest)
+		return
+	}
+
+	rng, err := timerange.ParseStrict(r.URL.Query())
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Unlike the dashboard's fixed top-10, a readout wants the whole catalog by
+	// default; the ceiling only exists to bound the response.
+	limit := 100
+	if v := r.URL.Query().Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 || n > 500 {
+			jsonError(w, "limit must be an integer between 1 and 500", http.StatusBadRequest)
+			return
+		}
+		limit = n
+	}
+
+	env := r.URL.Query().Get("environment")
+
+	ctx, span := tracing.StartSpan(r.Context(), "events.counts",
+		attribute.String("project.id", projectID),
+		attribute.Int("limit", limit),
+		attribute.String("environment", env),
+	)
+	defer span.End()
+
+	counts, err := s.events.TopEventNames(ctx, projectID, rng.From, rng.To, limit, env)
+	if err != nil {
+		tracing.RecordError(span, err)
+		mapServiceError(w, err, "handleEventCounts")
+		return
+	}
+	if counts == nil {
+		counts = []repository.EventNameStat{}
+	}
+
+	var total int64
+	for _, c := range counts {
+		total += c.Count
+	}
+	span.SetAttributes(attribute.Int("event.result_count", len(counts)))
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"project_id":   projectID,
+		"from":         rng.From.Format(time.RFC3339),
+		"to":           rng.To.Format(time.RFC3339),
+		"environment":  env,
+		"limit":        limit,
+		"events":       counts,
+		"total_events": total,
+	})
 }
 
 // handleEventProperties returns distinct JSON property keys for a given event name.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -321,17 +321,21 @@ func (s *Server) registerRoutes() {
 	// itself authenticates the request (public, rate-limited, no CSRF).
 	s.mux.Handle("POST /api/v1/oidc/backchannel-logout", s.limit(s.loginLimiter, http.HandlerFunc(s.handleBackchannelLogout)))
 
-	// Projects
-	s.mux.HandleFunc("GET /api/v1/projects", s.requireSession(s.handleListProjects))
+	// Projects. The list is also reachable with an analytics:read token, which
+	// narrows it to that token's own project — a scripted readout has to be
+	// able to resolve its project without a dashboard session.
+	s.mux.HandleFunc("GET /api/v1/projects", s.requireSessionOrToken(repository.APIKeyScopeAnalyticsRead, s.handleListProjects))
 	s.mux.HandleFunc("POST /api/v1/projects", s.requireSession(s.handleCreateProject))
 	s.mux.HandleFunc("PUT /api/v1/projects/{id}", s.requireSession(s.handleUpdateProject))
 	s.mux.HandleFunc("DELETE /api/v1/projects/{id}", s.requireSession(s.handleDeleteProject))
 
-	// Dashboard & analytics (session required)
-	s.mux.HandleFunc("GET /api/v1/projects/{id}/dashboard", s.requireSession(s.handleDashboard))
+	// Dashboard & analytics. The read-only routes a scripted readout needs also
+	// accept a project-scoped analytics:read token — see internal/api/api_tokens.go.
+	s.mux.HandleFunc("GET /api/v1/projects/{id}/dashboard", s.requireSessionOrToken(repository.APIKeyScopeAnalyticsRead, s.handleDashboard))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/flows", s.requireSession(s.handlePageFlows))
-	s.mux.HandleFunc("GET /api/v1/projects/{id}/events", s.requireSession(s.handleListEvents))
-	s.mux.HandleFunc("GET /api/v1/projects/{id}/event-names", s.requireSession(s.handleEventNames))
+	s.mux.HandleFunc("GET /api/v1/projects/{id}/events", s.requireSessionOrToken(repository.APIKeyScopeAnalyticsRead, s.handleListEvents))
+	s.mux.HandleFunc("GET /api/v1/projects/{id}/event-names", s.requireSessionOrToken(repository.APIKeyScopeAnalyticsRead, s.handleEventNames))
+	s.mux.HandleFunc("GET /api/v1/projects/{id}/event-counts", s.requireSessionOrToken(repository.APIKeyScopeAnalyticsRead, s.handleEventCounts))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/event-properties", s.requireSession(s.handleEventProperties))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/event-property-values", s.requireSession(s.handleEventPropertyValues))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/environments", s.requireSession(s.handleEnvironments))
@@ -359,12 +363,13 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("DELETE /api/v1/overview/funnels/{id}", s.requireSession(s.handleDeleteCanonicalFunnel))
 	s.mux.HandleFunc("GET /api/v1/overview/funnels/{id}/analysis", s.requireSession(s.handleCanonicalFunnelAnalysis))
 
-	// Funnels
-	s.mux.HandleFunc("GET /api/v1/projects/{id}/funnels", s.requireSession(s.handleListFunnels))
+	// Funnels. Listing and step conversion also accept an analytics:read token;
+	// creating, editing and deleting a funnel stay session-only.
+	s.mux.HandleFunc("GET /api/v1/projects/{id}/funnels", s.requireSessionOrToken(repository.APIKeyScopeAnalyticsRead, s.handleListFunnels))
 	s.mux.HandleFunc("POST /api/v1/projects/{id}/funnels", s.requireSession(s.handleCreateFunnel))
 	s.mux.HandleFunc("PUT /api/v1/projects/{id}/funnels/{fid}", s.requireSession(s.handleUpdateFunnel))
 	s.mux.HandleFunc("DELETE /api/v1/projects/{id}/funnels/{fid}", s.requireSession(s.handleDeleteFunnel))
-	s.mux.HandleFunc("GET /api/v1/projects/{id}/funnels/{fid}/analysis", s.requireSession(s.handleFunnelAnalysis))
+	s.mux.HandleFunc("GET /api/v1/projects/{id}/funnels/{fid}/analysis", s.requireSessionOrToken(repository.APIKeyScopeAnalyticsRead, s.handleFunnelAnalysis))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/funnels/{fid}/segments", s.requireSession(s.handleFunnelSegments))
 
 	// Feature Flags. Reads and updates also accept a project-scoped API token
@@ -373,12 +378,12 @@ func (s *Server) registerRoutes() {
 	// Creation and deletion stay session-only: auto-registration already covers
 	// creation, and a token that can turn an outbound-email gate off should not
 	// also be able to delete the gate.
-	s.mux.HandleFunc("GET /api/v1/projects/{id}/flags", s.requireSessionOrFlagToken(repository.APIKeyScopeFlagsRead, s.handleListFlags))
+	s.mux.HandleFunc("GET /api/v1/projects/{id}/flags", s.requireSessionOrToken(repository.APIKeyScopeFlagsRead, s.handleListFlags))
 	s.mux.HandleFunc("POST /api/v1/projects/{id}/flags", s.requireSession(s.handleCreateFlag))
-	s.mux.HandleFunc("GET /api/v1/projects/{id}/flags/{fid}", s.requireSessionOrFlagToken(repository.APIKeyScopeFlagsRead, s.handleGetFlag))
-	s.mux.HandleFunc("PUT /api/v1/projects/{id}/flags/{fid}", s.requireSessionOrFlagToken(repository.APIKeyScopeFlagsWrite, s.handleUpdateFlag))
+	s.mux.HandleFunc("GET /api/v1/projects/{id}/flags/{fid}", s.requireSessionOrToken(repository.APIKeyScopeFlagsRead, s.handleGetFlag))
+	s.mux.HandleFunc("PUT /api/v1/projects/{id}/flags/{fid}", s.requireSessionOrToken(repository.APIKeyScopeFlagsWrite, s.handleUpdateFlag))
 	s.mux.HandleFunc("DELETE /api/v1/projects/{id}/flags/{fid}", s.requireSession(s.handleDeleteFlag))
-	s.mux.HandleFunc("GET /api/v1/projects/{id}/flags/{fid}/analysis", s.requireSessionOrFlagToken(repository.APIKeyScopeFlagsRead, s.handleFlagAnalysis))
+	s.mux.HandleFunc("GET /api/v1/projects/{id}/flags/{fid}/analysis", s.requireSessionOrToken(repository.APIKeyScopeFlagsRead, s.handleFlagAnalysis))
 	s.mux.HandleFunc("GET /api/v1/projects/{id}/flags/context-keys", s.requireSession(s.handleFlagContextKeys))
 	// Dogfooding playground — same flag-eval logic as the customer endpoint
 	// but session-authed so the dashboard can call it without an API key in the browser.

--- a/internal/repository/projects.go
+++ b/internal/repository/projects.go
@@ -30,6 +30,13 @@ const APIKeyScopeIngest = "ingest"
 // answers when the question is whether mail is about to go out.
 const APIKeyScopeFlagsRead = "flags:read"
 
+// APIKeyScopeAnalyticsRead allows reading a project's analytics — event
+// counts, the event catalog, funnels and funnel-step conversion — without a
+// dashboard session, so a scheduled job can publish a weekly readout instead
+// of asking someone to open the dashboard and copy numbers out of it. It is
+// read-only by construction: no route that mutates anything accepts it.
+const APIKeyScopeAnalyticsRead = "analytics:read"
+
 // APIKeyScopeFlagsWrite additionally allows updating an existing flag
 // (enable / disable / change its value). It deliberately does not allow
 // creating or deleting flags: auto-registration already covers creation, and a

--- a/internal/service/apikeys.go
+++ b/internal/service/apikeys.go
@@ -29,7 +29,7 @@ func (svc *APIKeyService) CreateAPIKey(ctx context.Context, name, projectID, key
 	if !validAPIKeyScope(scope) {
 		return repository.APIKey{}, &domain.ValidationError{
 			Field:   "scope",
-			Message: `must be one of "full", "ingest", "flags:read", "flags:write"`,
+			Message: `must be one of "full", "ingest", "analytics:read", "flags:read", "flags:write"`,
 		}
 	}
 	return svc.store.CreateAPIKey(ctx, name, projectID, keySHA256, scope)
@@ -41,6 +41,7 @@ func validAPIKeyScope(scope string) bool {
 	switch scope {
 	case repository.APIKeyScopeFull,
 		repository.APIKeyScopeIngest,
+		repository.APIKeyScopeAnalyticsRead,
 		repository.APIKeyScopeFlagsRead,
 		repository.APIKeyScopeFlagsWrite:
 		return true

--- a/internal/timerange/timerange.go
+++ b/internal/timerange/timerange.go
@@ -4,6 +4,7 @@
 package timerange
 
 import (
+	"errors"
 	"net/url"
 	"time"
 )
@@ -48,4 +49,47 @@ func Parse(q url.Values) Range {
 	}
 
 	return Range{From: from, To: to}
+}
+
+// ParseStrict resolves the same range as Parse but rejects input it cannot
+// understand instead of silently falling back to the default window.
+//
+// Parse's lenience is right for the dashboard, where the query string comes
+// from our own UI and a stale value should still render something. It is wrong
+// for a programmatic read API: a scheduled readout that asked for last week and
+// quietly got last month reports the wrong number with no way to notice.
+func ParseStrict(q url.Values) (Range, error) {
+	to := time.Now().UTC()
+	from := to.AddDate(0, 0, -30)
+
+	switch v := q.Get("range"); v {
+	case "":
+	case "24h":
+		from = to.Add(-24 * time.Hour)
+	case "7d":
+		from = to.AddDate(0, 0, -7)
+	case "30d":
+		from = to.AddDate(0, 0, -30)
+	default:
+		return Range{}, errors.New("range must be one of 24h, 7d, 30d")
+	}
+
+	if v := q.Get("from"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			return Range{}, errors.New("from must be an RFC3339 timestamp")
+		}
+		from = t.UTC()
+	}
+	if v := q.Get("to"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			return Range{}, errors.New("to must be an RFC3339 timestamp")
+		}
+		to = t.UTC()
+	}
+	if !to.After(from) {
+		return Range{}, errors.New("to must be after from")
+	}
+	return Range{From: from, To: to}, nil
 }

--- a/internal/timerange/timerange_test.go
+++ b/internal/timerange/timerange_test.go
@@ -89,3 +89,48 @@ func TestParse_InvalidDateIgnored(t *testing.T) {
 		t.Errorf("invalid date not ignored: From = %v", r.From)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// ParseStrict
+// ---------------------------------------------------------------------------
+
+func TestParseStrict_AcceptsWhatParseAccepts(t *testing.T) {
+	cases := []url.Values{
+		{},
+		{"range": []string{"24h"}},
+		{"range": []string{"7d"}},
+		{"range": []string{"30d"}},
+		{"from": []string{"2026-01-01T00:00:00Z"}, "to": []string{"2026-01-08T00:00:00Z"}},
+	}
+	for _, q := range cases {
+		r, err := timerange.ParseStrict(q)
+		if err != nil {
+			t.Fatalf("ParseStrict(%v): %v", q, err)
+		}
+		if !r.To.After(r.From) {
+			t.Errorf("ParseStrict(%v): To (%v) must be after From (%v)", q, r.To, r.From)
+		}
+	}
+}
+
+// The difference from Parse: garbage is refused rather than silently answered
+// with the default 30-day window.
+func TestParseStrict_RejectsGarbage(t *testing.T) {
+	cases := []url.Values{
+		{"range": []string{"90d"}},
+		{"from": []string{"last-tuesday"}},
+		{"to": []string{"nope"}},
+		{"from": []string{"2026-01-02T00:00:00Z"}, "to": []string{"2026-01-01T00:00:00Z"}},
+		{"from": []string{"2026-01-01T00:00:00Z"}, "to": []string{"2026-01-01T00:00:00Z"}},
+	}
+	for _, q := range cases {
+		if _, err := timerange.ParseStrict(q); err == nil {
+			t.Errorf("ParseStrict(%v): want an error, got none", q)
+		}
+	}
+
+	// Parse, by contrast, keeps its lenience for the dashboard.
+	if r := timerange.Parse(url.Values{"from": []string{"last-tuesday"}}); !r.To.After(r.From) {
+		t.Error("Parse should still fall back to a usable window")
+	}
+}

--- a/site/src/content/docs/http-api.md
+++ b/site/src/content/docs/http-api.md
@@ -6,7 +6,7 @@ order: 7
 
 # HTTP API Reference
 
-All API endpoints are prefixed with `/api/v1`. Dashboard endpoints require an active session cookie (obtained via `POST /api/v1/login`). The ingest endpoint requires an API key header.
+All API endpoints are prefixed with `/api/v1`. Dashboard endpoints require an active session cookie (obtained via `POST /api/v1/login`). The ingest endpoint requires an API key header. A subset of read-only endpoints also accepts a project-scoped API key, so a script or scheduled job can read a project's numbers without a browser session — see [Reading analytics with an API key](#reading-analytics-with-an-api-key).
 
 ## Authentication
 
@@ -29,6 +29,62 @@ All ingest requests require the `x-funnelbarn-api-key` header:
 
 ```
 x-funnelbarn-api-key: your-api-key
+```
+
+### API key scopes
+
+Keys are issued per project from **Settings → API Keys**. The scope decides what the key may do:
+
+| Scope | Grants |
+|---|---|
+| `ingest` | Send events. Cannot read or change anything. |
+| `analytics:read` | Read this project's events, event counts, funnels and funnel-step conversion. Read-only. |
+| `flags:read` | Read this project's feature flags. |
+| `flags:write` | Read and update (not create or delete) this project's feature flags. |
+| `full` | Everything, for this project. |
+
+Scopes do not imply each other across features. `flags:write` implies `flags:read`, but an `analytics:read` key gets `403` on the flag routes and a `flags:*` key gets `403` on the analytics routes — a token that toggles an outbound-email gate has no business reading the event stream.
+
+Two things are refused by design:
+
+- **The instance-wide `FUNNELBARN_API_KEY`** resolves to no project, which would make it a master key for every project on the instance. Scoped routes answer `401` for it; use a project key from the settings page.
+- **A key aimed at another project** answers `403`, even for a route the scope otherwise allows.
+
+### Reading analytics with an API key
+
+These endpoints accept either a session cookie or an `analytics:read` (or `full`) key in `x-funnelbarn-api-key`:
+
+| Method | Path | Returns |
+|---|---|---|
+| `GET` | `/api/v1/projects` | Just the project the key is scoped to |
+| `GET` | `/api/v1/projects/:id/dashboard` | Aggregate stats over a range |
+| `GET` | `/api/v1/projects/:id/events` | Paginated raw events |
+| `GET` | `/api/v1/projects/:id/event-names` | Distinct event names |
+| `GET` | `/api/v1/projects/:id/event-counts` | Per-event counts over a range |
+| `GET` | `/api/v1/projects/:id/funnels` | The project's funnels |
+| `GET` | `/api/v1/projects/:id/funnels/:fid/analysis` | Per-step conversion |
+
+A weekly readout, end to end:
+
+```bash
+KEY=your-analytics-read-key
+BASE=https://funnelbarn.example.com
+
+# Resolve the project the key belongs to — the list is narrowed to it.
+PROJECT=$(curl -s -H "x-funnelbarn-api-key: $KEY" "$BASE/api/v1/projects" \
+  | jq -r '.projects[0].id')
+
+# Per-event counts for the last 7 days.
+curl -s -H "x-funnelbarn-api-key: $KEY" \
+  "$BASE/api/v1/projects/$PROJECT/event-counts?range=7d" | jq '.events'
+
+# Step conversion for a funnel. Note this endpoint takes from/to only —
+# the `range` shorthand is an event-counts and dashboard convenience.
+FUNNEL=$(curl -s -H "x-funnelbarn-api-key: $KEY" \
+  "$BASE/api/v1/projects/$PROJECT/funnels" | jq -r '.funnels[0].id')
+FROM=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)   # BSD date: -v-7d
+curl -s -H "x-funnelbarn-api-key: $KEY" \
+  "$BASE/api/v1/projects/$PROJECT/funnels/$FUNNEL/analysis?from=$FROM"
 ```
 
 ---
@@ -107,7 +163,7 @@ curl -X POST http://localhost:8080/api/v1/events \
 
 ### `GET /api/v1/projects/:id/dashboard`
 
-Returns aggregate analytics for a project.
+Returns aggregate analytics for a project. Accepts a session or an `analytics:read` key.
 
 **Query parameters:**
 
@@ -145,13 +201,45 @@ Returns a paginated list of raw events.
 | `limit` | `50` | Max events to return (1–500) |
 | `offset` | `0` | Pagination offset |
 
+### `GET /api/v1/projects/:id/event-counts`
+
+Returns a count per event name over a date range — the whole catalog, not the dashboard's top ten, and without the dozen other aggregates wrapped around it. Accepts an `analytics:read` key.
+
+**Query parameters:**
+
+| Parameter | Default | Description |
+|---|---|---|
+| `range` | `30d` | Preset time range: `24h`, `7d`, `30d` |
+| `from` | 30 days ago | RFC3339 start time (overrides `range`) |
+| `to` | now | RFC3339 end time (overrides `range`) |
+| `limit` | `100` | Max distinct event names to return (1–500) |
+| `environment` | all | Restrict to one environment |
+
+Unlike the dashboard endpoint, unparseable input is rejected with `400` rather than silently answered with the default window — a readout that asked for last week and quietly got last month reports the wrong number with no way to notice.
+
+```json
+{
+  "project_id": "proj-123",
+  "from": "2026-08-29T09:00:00Z",
+  "to": "2026-09-05T09:00:00Z",
+  "environment": "",
+  "limit": 100,
+  "total_events": 1284,
+  "events": [
+    {"name": "page_view", "count": 941},
+    {"name": "first_run_started", "count": 287},
+    {"name": "first_run_completed", "count": 56}
+  ]
+}
+```
+
 ---
 
 ## Projects
 
 ### `GET /api/v1/projects`
 
-List all projects.
+List all projects. With an `analytics:read` key instead of a session, the list is narrowed to the one project that key is scoped to.
 
 ### `POST /api/v1/projects`
 
@@ -179,7 +267,7 @@ Approve a pending project (admin action after self-service setup).
 
 ### `GET /api/v1/projects/:id/funnels`
 
-List all funnels for a project.
+List all funnels for a project. Accepts a session or an `analytics:read` key.
 
 ### `POST /api/v1/projects/:id/funnels`
 
@@ -207,7 +295,7 @@ Delete a funnel.
 
 ### `GET /api/v1/projects/:id/funnels/:fid/analysis`
 
-Run funnel analysis. Returns conversion rates for each step.
+Run funnel analysis. Returns conversion rates for each step. Accepts a session or an `analytics:read` key.
 
 **Query parameters:**
 
@@ -282,7 +370,9 @@ Create an API key.
 {"name": "Browser SDK key", "scope": "ingest", "project_id": "proj-123"}
 ```
 
-Scopes: `ingest` (events only) or `full` (events + dashboard API).
+Scopes: `ingest`, `analytics:read`, `flags:read`, `flags:write` or `full` — see [API key scopes](#api-key-scopes). Anything else is refused rather than stored and silently treated as no access.
+
+The plaintext key is returned once, in the create response, and never again.
 
 ### `DELETE /api/v1/apikeys/:kid`
 

--- a/web/src/components/settings/ApiKeySettings.test.ts
+++ b/web/src/components/settings/ApiKeySettings.test.ts
@@ -10,6 +10,7 @@ describe('scopeTone', () => {
   it('marks send-only and read-only scopes', () => {
     expect(scopeTone('ingest')).toBe('read')
     expect(scopeTone('flags:read')).toBe('read')
+    expect(scopeTone('analytics:read')).toBe('read')
   })
 
   it('treats an unrecognised scope as read rather than implying power it lacks', () => {
@@ -20,6 +21,7 @@ describe('scopeTone', () => {
 describe('scopeHint', () => {
   it('says what each scope may do', () => {
     expect(scopeHint('ingest')).toMatch(/Send events/)
+    expect(scopeHint('analytics:read')).toMatch(/Cannot change anything/)
     expect(scopeHint('flags:read')).toMatch(/Cannot change/)
     expect(scopeHint('flags:write')).toMatch(/Cannot create or delete/)
     expect(scopeHint('full')).toMatch(/Full API access/)

--- a/web/src/components/settings/ApiKeySettings.tsx
+++ b/web/src/components/settings/ApiKeySettings.tsx
@@ -27,6 +27,7 @@ export function scopeTone(scope: string): 'read' | 'write' {
 export function scopeHint(scope: string): string {
   switch (scope) {
     case 'ingest': return 'Send events. Cannot read or change anything.'
+    case 'analytics:read': return "Read this project's events, funnels and conversion numbers. Cannot change anything."
     case 'flags:read': return "Read this project's flags. Cannot change them."
     case 'flags:write': return "Read and update this project's flags. Cannot create or delete them."
     case 'full': return 'Full API access to this project.'
@@ -134,8 +135,8 @@ export function ApiKeySettings({
         <div>
           <div style={{ fontWeight: 700, fontSize: 15 }}>API Keys</div>
           <div style={{ fontSize: 13, color: C.muted, marginTop: 2 }}>
-            Keys for sending events, reading or toggling this project&apos;s
-            feature flags, or full management access.
+            Keys for sending events, reading this project&apos;s analytics,
+            reading or toggling its feature flags, or full management access.
           </div>
         </div>
       </div>
@@ -423,6 +424,7 @@ export function ApiKeySettings({
             }}
           >
             <option value="ingest">ingest — send events</option>
+            <option value="analytics:read">analytics:read — read events, funnels and conversion</option>
             <option value="flags:read">flags:read — read this project&apos;s flags</option>
             <option value="flags:write">flags:write — read and toggle flags</option>
             <option value="full">full — everything</option>


### PR DESCRIPTION
## Summary

Reading a project's numbers required a browser session. Settings → API Keys only offered `flags:read`/`flags:write`, so a scheduled job had no way to publish a funnel readout — every read route answered `401` for any key held, including the project's own ingest key.

This adds the `analytics:read` scope and points it at the read-only routes a scripted readout actually needs, plus one new endpoint for per-event counts over a date range.

## Changes

**New scope `analytics:read`**, issuable from Settings → API Keys, accepted on:

| Method | Path | Returns |
|---|---|---|
| `GET` | `/api/v1/projects` | just the project the key is scoped to |
| `GET` | `/api/v1/projects/:id/dashboard` | aggregate stats over a range |
| `GET` | `/api/v1/projects/:id/events` | paginated raw events |
| `GET` | `/api/v1/projects/:id/event-names` | distinct event names |
| `GET` | `/api/v1/projects/:id/event-counts` | **new** — per-event counts over a range |
| `GET` | `/api/v1/projects/:id/funnels` | the project's funnels |
| `GET` | `/api/v1/projects/:id/funnels/:fid/analysis` | per-step conversion |

**`GET /projects/{id}/event-counts`** — a count per event name over `range`/`from`/`to`, with `limit` (default 100, max 500) and `environment`. The dashboard payload carries the same numbers, but only its top ten and wrapped in a dozen other aggregates.

**The scope is read-only and is not a skeleton key.** It is its own axis in `scopeAllows`: an analytics token gets `403` on the flag routes, and a `flags:*` token gets `403` on the analytics routes — a token that toggles an outbound-email gate has no business reading the event stream. A token aimed at another project is `403`. The instance-wide `FUNNELBARN_API_KEY`, which resolves to no project, stays `401`.

`GET /api/v1/projects` carries no `{id}` for the middleware to check the key against, so the handler narrows the list to the token's own project itself — otherwise one customer's readout token enumerates every project on the instance.

**Strict range parsing.** `event-counts` rejects unparseable input with `400` via a new `timerange.ParseStrict`, rather than silently answering with the default 30-day window the way the dashboard does: a readout that asked for last week and quietly got last month reports the wrong number with no way to notice. `timerange.Parse` keeps its lenience for the dashboard UI.

`internal/api/flag_tokens.go` → `api_tokens.go`, since it now gates more than flags.

Docs: scope table + a worked "weekly readout" bash example in `site/src/content/docs/http-api.md`, and the endpoint/scope tables in `README.md`.

## Testing

- `go test -race -count=1 ./...` — all green
- `npm test` in `web/` — 43 files, 392 tests green
- `gofmt`, `go vet`, `tsc --noEmit`, `eslint` — clean

New tests (`internal/api/analytics_tokens_test.go`, 10 cases) cover: every in-scope route reachable with a token and no session; the project list narrowed to the token (and still complete for a session); `403` on flags, on another project, and for an ingest key; `401` for the global key; per-name counts over a range; empty window returning `[]` not `null`; `400` on bad `range`/`from`/`to`/`limit`; and issuance of the new scope. `scopeAllows` and `timerange.ParseStrict` have their own table tests.

Manually verified end-to-end against a locally-run binary with real ingested events: token-only project resolution → event counts → funnel step conversion, plus every negative case above returning the expected status.

Closes #235