### PR TITLE
Closes #236: publish brew tarballs to R2 instead of the retired MinIO

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -3,8 +3,23 @@ name: Binary Release
 # Builds and publishes funnelbarn binaries on every push to main.
 # Publishes to:
 #   - APT repository:      https://webwiebe.nl/apt/ (via rapid-root centralized workflow)
-#   - Homebrew tap (MinIO): https://webwiebe.nl/brew/funnelbarn-darwin-*.tar.gz
+#   - Homebrew tap (Cloudflare R2): https://webwiebe.nl/brew/funnelbarn-darwin-*.tar.gz
 #   - GitHub Releases:     attached .deb and .tar.gz files
+#
+# Brew tarballs are uploaded directly to R2 (bucket:
+# webwiebe-apt-repository-production, under the brew/ prefix). That prefix is
+# SHARED with every other publisher (bugbarn, bb, spanbarn, dynamic-dns...), so
+# uploads and prunes here are always scoped to funnelbarn's own name+arch
+# prefixes — never a bucket-wide sync or LIST, and never `--delete`. After
+# uploading, only the newest 2 versions of each tarball are kept, matching the
+# bucket's 5GB retention policy (rapid-root's infra/docs/apt-repository.md,
+# added in wiebe-xyz/rapid-root#2839).
+#
+# Required GitHub secrets for the brew publish:
+#   R2_ACCESS_KEY  — Cloudflare R2 S3 access key
+#   R2_SECRET_KEY  — Cloudflare R2 S3 secret key
+#   R2_ENDPOINT    — R2 account S3 endpoint
+#   R2_BUCKET      — webwiebe-apt-repository-production
 
 on:
   push:
@@ -324,7 +339,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   update-brew-repo:
-    name: Update Homebrew Tap (MinIO)
+    name: Update Homebrew Tap (R2)
     runs-on: ubuntu-latest
     needs: [tag, build-darwin-tarballs]
     steps:
@@ -372,21 +387,70 @@ jobs:
           end
           EOF
 
-      - name: Deploy to MinIO (brew/ prefix)
+      - name: Deploy to R2 (brew/ prefix — only adds funnelbarn files)
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET_KEY }}
-          AWS_ENDPOINT_URL: ${{ secrets.MINIO_ENDPOINT }}
-          MINIO_BUCKET: ${{ secrets.MINIO_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
+          AWS_DEFAULT_REGION: auto
+          AWS_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
         run: |
+          # Fail loudly rather than publishing nowhere. Before this job moved to
+          # R2 it uploaded to MinIO, which the read path had already stopped
+          # serving — so the tap advertised tarballs that 404'd and nobody
+          # noticed. A missing secret must break the build, not go quiet again.
+          for var in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_ENDPOINT_URL R2_BUCKET; do
+            if [ -z "${!var}" ]; then
+              echo "ERROR: ${var} is empty — the R2_* secrets must be configured on this repo."
+              exit 1
+            fi
+          done
+
           pip install awscli
-          for attempt in 1 2 3; do
-            aws --endpoint-url "$AWS_ENDPOINT_URL" s3 sync \
-              brew-repo/ \
-              s3://${MINIO_BUCKET}/brew/ \
-              --cache-control "public, max-age=3600, must-revalidate" && break
-            echo "Attempt ${attempt} failed, retrying in 10s..."
-            sleep 10
+
+          # Upload per-file with `cp` rather than `s3 sync brew-repo/`: sync
+          # LISTs the whole destination prefix to compute its delta, and brew/
+          # holds every other publisher's tarballs too. `cp` touches only our
+          # own keys.
+          find brew-repo -type f | while read -r f; do
+            key="${f#brew-repo/}"
+            aws --endpoint-url "$AWS_ENDPOINT_URL" s3 cp \
+              "$f" \
+              "s3://${R2_BUCKET}/brew/${key}" \
+              --cache-control "public, max-age=3600, must-revalidate"
+          done
+
+      - name: Prune old brew tarballs from R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
+          AWS_DEFAULT_REGION: auto
+          AWS_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: |
+          # Keep only the newest KEEP versions of each tarball this job
+          # publishes — the bucket's 5GB retention policy (rapid-root#2839 /
+          # infra/docs/apt-repository.md). Scoped to funnelbarn's own name+arch
+          # prefixes: a targeted list per prefix, never a bucket-wide LIST, so
+          # other publishers' tarballs are never considered, let alone removed.
+          KEEP=2
+          for GROUP in funnelbarn-darwin-amd64 funnelbarn-darwin-arm64; do
+            aws --endpoint-url "$AWS_ENDPOINT_URL" s3api list-objects-v2 \
+              --bucket "$R2_BUCKET" --prefix "brew/${GROUP}-" \
+              --query 'Contents[].Key' --output text 2>/dev/null \
+              | tr '\t' '\n' | grep -E '\.tar\.gz$' | sort -V > /tmp/${GROUP}-versions.txt || true
+
+            COUNT=$(wc -l < /tmp/${GROUP}-versions.txt)
+            DROP=$((COUNT - KEEP))
+            if [ "$DROP" -gt 0 ]; then
+              head -n "$DROP" /tmp/${GROUP}-versions.txt | while read -r key; do
+                echo "Pruning old brew tarball: $key"
+                aws --endpoint-url "$AWS_ENDPOINT_URL" s3 rm "s3://${R2_BUCKET}/${key}"
+                aws --endpoint-url "$AWS_ENDPOINT_URL" s3 rm "s3://${R2_BUCKET}/${key}.sha256" || true
+              done
+            else
+              echo "${GROUP}: ${COUNT} tarball(s) in R2, nothing to prune."
+            fi
           done
 
   update-homebrew-tap:

--- a/deploy/SECRETS.md
+++ b/deploy/SECRETS.md
@@ -13,16 +13,27 @@ Used to decrypt Kubernetes secret manifests per environment.
 | `SOPS_AGE_KEY_STAGING` | build-and-test.yml (`deploy-staging` job) | Age private key for decrypting `deploy/k8s/staging/secret.yaml` |
 | `SOPS_AGE_KEY_PRODUCTION` | deploy-production.yml | Age private key for decrypting `deploy/k8s/production/secret.yaml` |
 
-## MinIO / S3 Storage
+## Cloudflare R2 (package repository)
 
-Used to publish Homebrew tarballs and APT packages to the shared MinIO bucket.
+Used by `binary-release.yml` to publish Homebrew tarballs into the shared
+package-repository bucket, under the `brew/` prefix.
 
 | Secret | Description |
 |--------|-------------|
-| `MINIO_ACCESS_KEY` | MinIO user access key (webwiebe-apt) |
-| `MINIO_SECRET_KEY` | MinIO user secret key |
-| `MINIO_ENDPOINT` | MinIO endpoint URL (e.g. https://s3.wiebe.xyz) |
-| `MINIO_BUCKET` | MinIO bucket name (e.g. webwiebe-apt-repository) |
+| `R2_ACCESS_KEY` | Cloudflare R2 S3 access key |
+| `R2_SECRET_KEY` | Cloudflare R2 S3 secret key |
+| `R2_ENDPOINT` | R2 account S3 endpoint URL |
+| `R2_BUCKET` | Bucket name (`webwiebe-apt-repository-production`) |
+
+These replace the former `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` /
+`MINIO_ENDPOINT` / `MINIO_BUCKET` secrets. The self-hosted MinIO on layer7
+(`s3.wiebe.xyz`) was wound down in favour of R2 — see
+`wiebe-xyz/rapid-root#2799` for the migration, and note that the `brew/` prefix
+is shared with other publishers, so this repo only ever writes and prunes its
+own `funnelbarn-darwin-*` keys.
+
+The old `MINIO_*` secrets can be deleted from this repository once this
+workflow has published a release to R2 successfully.
 
 ## Infrastructure SSH
 


### PR DESCRIPTION
## Summary

Moves this repo's Homebrew publishing from the wound-down MinIO to Cloudflare R2, and adds the retention policy the shared bucket now enforces.

**This is a live breakage, not a preventative change.** While picking the issue up I checked the read path:

- `webwiebe/homebrew-funnelbarn`'s formula points at `funnelbarn-darwin-{amd64,arm64}-0.6.20.tar.gz`
- Both **404** on `webwiebe.nl/brew`. So do `0.6.16`, `0.6.18`, `0.6.19`
- The copy of `Formula/funnelbarn.rb` served from the bucket still says **0.6.16** — four releases behind the `v0.6.20` tag

`brew install webwiebe/funnelbarn/funnelbarn` is broken right now. The read path moved to R2 when `wiebe-xyz/rapid-root#2799` completed; this repo kept writing to MinIO, so releases have been publishing into a bucket nobody reads.

## Changes

- **Deploy step → R2**: `R2_ACCESS_KEY` / `R2_SECRET_KEY` / `R2_ENDPOINT` / `R2_BUCKET`, plus the explicit `AWS_DEFAULT_REGION: auto` that R2's signing requires.
- **Per-file `cp` instead of `s3 sync brew-repo/`**: the `brew/` prefix is shared with bugbarn, bb, spanbarn and dynamic-dns. `sync` LISTs the whole destination prefix to compute its delta; `cp` touches only our own keys. (Also drops the 3-attempt retry loop, which existed to work around MinIO's LIST timeouts.)
- **Retention step**: keeps the newest 2 versions of each tarball per architecture, per the 5GB policy from `wiebe-xyz/rapid-root#2839`. Scoped to `funnelbarn-darwin-{amd64,arm64}` prefixes — a targeted list per prefix, never a bucket-wide LIST, and never `--delete` — so other publishers' tarballs are never considered, let alone removed.
- **Hard-fails on a missing R2 secret.** A publish that silently goes nowhere is precisely how this drifted unnoticed for four releases.
- `deploy/SECRETS.md` updated; notes the `MINIO_*` secrets can be deleted once a release publishes to R2 successfully.

## ⚠️ Blocked on secrets — do not merge yet

`gh secret list` shows this repo has only `MINIO_*`. **The four `R2_*` secrets must be added before this merges**, or the new guard will fail the brew job on every push to `main`. Same R2 account/bucket as rapid-root#2799 (`webwiebe-apt-repository-production`).

I could not add them myself — I don't have the R2 credentials.

## Testing

- `actionlint`: baseline 11 shellcheck findings → 10 after this change. The new steps introduce none, and the old unquoted `${MINIO_BUCKET}` in the sync went away.
- Workflow YAML parses; job/step structure verified.
- **Prune selection logic tested standalone** against realistic keys, including the version-ordering trap: `0.6.9 < 0.6.10 < 0.6.20 < 0.6.100` sorts correctly under `sort -V`; `.sha256` files are excluded from the count but deleted alongside their tarball; a co-located `bugbarn-darwin-arm64-*` key is untouched; empty and under-threshold listings no-op.
- No Go or TypeScript is touched, so the Go/vitest suites carry no signal for this change (and the build host is at load 44 — I didn't add a pointless full run to it). The PR quality gates cover it.

## Still to do after merge (needs the secrets, can't be done from here)

- [ ] Add the four `R2_*` secrets
- [ ] Let a release publish, then verify with a real `brew install` from a clean machine — not just by checking objects exist
- [ ] Backfill: `0.6.18`–`0.6.20` are missing from R2 entirely, so the currently-advertised formula stays broken until a new release publishes
- [ ] `webwiebe/bugbarn#170` closed unmerged, so **bugbarn's brew publishing is still on MinIO too** — same breakage, not covered by this PR

Closes #236