### PR TITLE
fix(apikeys): bind new keys to the project you selected

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -286,8 +286,11 @@ func (s *Server) handleListAPIKeys(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleCreateAPIKey creates a new API key for a project.
-// project_id may be sent in the request body or as a query param.
-// When omitted, the first project is used (single-tenant convenience).
+// project_id may be sent in the request body or as a query param, and is
+// required: this used to fall back to the first project on the instance, which
+// meant a caller that forgot to name one got a key silently bound to whichever
+// project happened to sort first — indistinguishable from a working key until
+// it 403s on the project you meant.
 func (s *Server) handleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		ProjectID string `json:"project_id"`
@@ -304,14 +307,9 @@ func (s *Server) handleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 		body.ProjectID = r.URL.Query().Get("project_id")
 	}
 
-	// If still empty, pick the first available project.
 	if body.ProjectID == "" {
-		projects, err := s.projects.ListProjects(r.Context())
-		if err != nil || len(projects) == 0 {
-			jsonError(w, "no projects found — create a project first", http.StatusBadRequest)
-			return
-		}
-		body.ProjectID = projects[0].ID
+		jsonError(w, "project_id is required — an API key is always scoped to one project", http.StatusBadRequest)
+		return
 	}
 
 	if body.Scope == "" {

--- a/internal/api/auth_coverage_test.go
+++ b/internal/api/auth_coverage_test.go
@@ -4,12 +4,13 @@ package api
 // - 404 paths (nonexistent resource IDs)
 // - handleLogin via DB fallback (when env-var auth is disabled)
 // - handleCreateProject slug-from-domain
-// - handleCreateAPIKey without project_id (auto-picks first)
+// - handleCreateAPIKey project_id requirement and binding
 // - handleListAPIKeys with ?project_id= filter
 // - funnel analysis with all segment types (exercises segmentClause + escapeSQLLiteral)
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 
@@ -152,10 +153,13 @@ func TestHandleCreateProject_SlugFromDomain(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// handleCreateAPIKey — auto-picks first available project when no project_id
+// handleCreateAPIKey — project_id is required
 // ---------------------------------------------------------------------------
 
-func TestHandleCreateAPIKey_AutoPicksFirstProject(t *testing.T) {
+// A key with no named project used to be bound to whichever project sorted
+// first, so a caller that forgot one walked away with a credential for the
+// wrong project that looked entirely healthy until it 403'd.
+func TestHandleCreateAPIKey_RequiresProject(t *testing.T) {
 	srv, store := newTestServer(t)
 	ctx := context.Background()
 	_, _ = store.CreateProject(ctx, "AutoPick", "autopick")
@@ -164,8 +168,43 @@ func TestHandleCreateAPIKey_AutoPicksFirstProject(t *testing.T) {
 		"name":  "auto-key",
 		"scope": "ingest",
 	}, nil)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("missing project_id: want 400, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+// The project named in the request is the project the key is bound to — not
+// the first one on the instance. This is the regression the dashboard hit:
+// a key minted while a second project was selected came back scoped to the
+// first.
+func TestHandleCreateAPIKey_BindsToTheNamedProject(t *testing.T) {
+	srv, store := newTestServer(t)
+	ctx := context.Background()
+	_, _ = store.CreateProject(ctx, "First", "first")
+	second, err := store.CreateProject(ctx, "Second", "second")
+	if err != nil {
+		t.Fatalf("create second project: %v", err)
+	}
+
+	w := postJSON(t, srv, "/api/v1/apikeys", map[string]string{
+		"project_id": second.ID,
+		"name":       "second-key",
+		"scope":      "analytics:read",
+	}, nil)
 	if w.Code != http.StatusCreated {
-		t.Errorf("auto-pick project: want 201, got %d (body: %s)", w.Code, w.Body.String())
+		t.Fatalf("create: want 201, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		APIKey struct {
+			ProjectID string `json:"project_id"`
+		} `json:"api_key"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.APIKey.ProjectID != second.ID {
+		t.Errorf("bound project: want %s (Second), got %s", second.ID, resp.APIKey.ProjectID)
 	}
 }
 

--- a/specs/001-analytics-funnel/contracts/ingest-api.yaml
+++ b/specs/001-analytics-funnel/contracts/ingest-api.yaml
@@ -516,15 +516,18 @@ paths:
 
   /api/v1/apikeys:
     get:
-      summary: List API keys for a project
-      description: Returns all API keys for a project (key hashes are not returned).
+      summary: List API keys
+      description: |
+        Returns API key metadata (key hashes and plaintext keys are never
+        returned). Pass `project_id` to list one project's keys; omit it to
+        list every project's keys across the instance.
       operationId: listAPIKeys
       tags: [APIKeys]
       parameters:
         - name: project_id
           in: query
-          required: true
-          description: Project ID to list keys for
+          required: false
+          description: Project ID to list keys for. Omit to list all projects' keys.
           schema:
             type: string
       responses:
@@ -549,6 +552,9 @@ paths:
       description: |
         Creates a new API key for a project. The plaintext key is returned **once** in
         this response and will never be shown again. Store it securely.
+
+        `project_id` is required — every key is scoped to exactly one project,
+        and the server will not guess which one.
       operationId: createAPIKey
       tags: [APIKeys]
       requestBody:
@@ -561,16 +567,17 @@ paths:
               properties:
                 project_id:
                   type: string
-                  description: Project ID the key belongs to
+                  description: |
+                    Project the key is scoped to. May also be given as a
+                    `?project_id=` query parameter. Required either way.
                 name:
                   type: string
                   description: Human label for this key
                   example: frontend-sdk
                 scope:
-                  type: string
-                  enum: [full, ingest]
-                  default: full
-                  description: Key scope (ingest = events only; full = all API access)
+                  allOf:
+                    - $ref: "#/components/schemas/APIKeyScope"
+                  default: ingest
       responses:
         "201":
           description: API key created — plaintext key shown once
@@ -579,19 +586,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  id:
-                    type: string
-                  name:
-                    type: string
-                  scope:
-                    type: string
+                  api_key:
+                    $ref: "#/components/schemas/APIKeySafe"
                   key:
                     type: string
                     description: Plaintext key — shown once, store securely
                     example: "a1b2c3d4e5f6...64hexchars..."
-                  created_at:
-                    type: string
-                    format: date-time
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -1200,14 +1200,31 @@ components:
       properties:
         id:
           type: string
+        project_id:
+          type: string
+          description: The one project this key can act on
         name:
           type: string
         scope:
-          type: string
-          enum: [full, ingest]
+          $ref: "#/components/schemas/APIKeyScope"
         created_at:
           type: string
           format: date-time
+        last_used_at:
+          type: string
+          format: date-time
+          description: Omitted when the key has never authenticated a request
+
+    APIKeyScope:
+      type: string
+      description: |
+        What a key may do, always within its own project:
+          * `ingest` — send events; cannot read or change anything
+          * `analytics:read` — read events, funnels and conversion numbers
+          * `flags:read` — read feature flags
+          * `flags:write` — read and toggle feature flags
+          * `full` — all API access for the project
+      enum: [ingest, analytics:read, flags:read, flags:write, full]
 
     AttributionReport:
       type: object

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -14,6 +14,12 @@ vi.mock('./lib/auth', () => ({
 const mockUseProjects = vi.fn()
 vi.mock('./lib/projects', () => ({
   useProjects: () => mockUseProjects(),
+  // Delegates to the real resolver so this file exercises the actual
+  // last-visited > default > first precedence rather than a copy of it.
+  useEffectiveProjectId: (urlProjectId?: string) => {
+    const { projects, defaultProjectId } = mockUseProjects()
+    return resolveProjectId(projects, urlProjectId, readLastProjectId(), defaultProjectId)
+  },
   ProjectProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
 
@@ -59,7 +65,7 @@ import React from 'react'
 // Pull DefaultProjectRoute out by re-rendering App at the /dashboard path.
 // Because all providers and pages are mocked, only the routing logic is exercised.
 import App from './App'
-import { LAST_PROJECT_ID_KEY } from './components/ui/ProjectPicker'
+import { LAST_PROJECT_ID_KEY, readLastProjectId, resolveProjectId } from './lib/selectedProject'
 
 function renderAt(path: string) {
   // Patch window.location to the desired path before rendering

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom'
 import { ReactNode, useEffect, useState } from 'react'
 import { AuthProvider, useAuth } from './lib/auth'
-import { ProjectProvider, useProjects } from './lib/projects'
+import { ProjectProvider, useProjects, useEffectiveProjectId } from './lib/projects'
 import Landing from './pages/Landing'
 import Login from './pages/Login'
 import Dashboard from './pages/Dashboard'
@@ -20,7 +20,6 @@ import OverviewFunnels from './pages/OverviewFunnels'
 import EventMapping from './pages/EventMapping'
 import FirstRunWizard from './components/wizards/FirstRunWizard'
 import { ErrorBoundary } from './components/ui/ErrorBoundary'
-import { LAST_PROJECT_ID_KEY } from './components/ui/ProjectPicker'
 import { trackPageView } from './lib/analytics'
 
 function ProtectedRoute({ children }: { children: ReactNode }) {
@@ -128,7 +127,11 @@ function AuthedHome() {
 }
 
 function DefaultProjectRoute({ base }: { base: string }) {
-  const { projects, isLoading, defaultProjectId } = useProjects()
+  const { projects, isLoading } = useProjects()
+  // Priority: last-visited > explicit default > first project. Shared with
+  // every project-aware page so the landing redirect and those pages can never
+  // disagree about which project "current" means.
+  const target = useEffectiveProjectId()
 
   if (isLoading) {
     return (
@@ -156,19 +159,6 @@ function DefaultProjectRoute({ base }: { base: string }) {
     // No projects yet — render Dashboard which handles the empty/create-project state
     return <Dashboard />
   }
-
-  // Priority: last-visited > explicit default > first project.
-  // LAST_PROJECT_ID_KEY is written by Shell on every project-scoped page, so it
-  // always reflects where the user just was. defaultProjectId is the persistent
-  // preference from Settings — used as a fallback when there is no recent history
-  // (e.g. fresh session or first login).
-  let lastId: string | null = null
-  try { lastId = localStorage.getItem(LAST_PROJECT_ID_KEY) } catch { /* quota / private mode */ }
-
-  const target =
-    (lastId && projects.some((p) => p.id === lastId)) ? lastId :
-    (defaultProjectId && projects.some((p) => p.id === defaultProjectId)) ? defaultProjectId :
-    projects[0].id
 
   return <Navigate to={`${base}/${target}`} replace />
 }

--- a/web/src/components/settings/ApiKeySettings.tsx
+++ b/web/src/components/settings/ApiKeySettings.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Trash2, Plus } from 'lucide-react'
 import { api, ApiKey, Project } from '../../lib/api'
 import { CopyButton } from '../ui/CopyButton'
 import { trackEvent } from '../../lib/analytics'
+import { writeLastProjectId } from '../../lib/selectedProject'
 
 const C = {
   bg: '#0f1117',
@@ -66,6 +67,8 @@ interface ApiKeySettingsProps {
   setApiKeys: React.Dispatch<React.SetStateAction<ApiKey[]>>
   loading: boolean
   projects: Project[]
+  /** The project this section is showing keys for — the one the header names. */
+  projectId?: string
   onError: (msg: string) => void
 }
 
@@ -74,26 +77,43 @@ export function ApiKeySettings({
   setApiKeys,
   loading,
   projects,
+  projectId,
   onError,
 }: ApiKeySettingsProps) {
   const [newKeyName, setNewKeyName] = useState('')
   const [newKeyScope, setNewKeyScope] = useState('ingest')
+  // Which project the key is minted for. Defaults to the project on screen, but
+  // is shown and changeable, because a key silently bound to a project you
+  // never chose is indistinguishable from a working one until it 403s.
+  const [newKeyProjectId, setNewKeyProjectId] = useState(projectId ?? '')
   const [creating, setCreating] = useState(false)
   const [newKeyValue, setNewKeyValue] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null)
 
+  // Follow the header when the user switches project.
+  useEffect(() => { if (projectId) setNewKeyProjectId(projectId) }, [projectId])
+
+  const currentProject = projects.find((p) => p.id === projectId)
+
   const handleCreate = async () => {
     if (!newKeyName.trim()) { setError('Name is required'); return }
+    if (!newKeyProjectId) { setError('Select a project for this key'); return }
     setCreating(true)
     setError(null)
     try {
-      const projectId = projects[0]?.id
-      const res = await api.createApiKey(newKeyName, newKeyScope, projectId)
+      const res = await api.createApiKey(newKeyName, newKeyScope, newKeyProjectId)
       trackEvent('api_key_created', { scope: newKeyScope })
-      setApiKeys((prev) => [...prev, res.api_key])
       setNewKeyValue(res.key)
       setNewKeyName('')
+      if (newKeyProjectId === projectId) {
+        setApiKeys((prev) => [...prev, res.api_key])
+      } else {
+        // The list below only holds the project on screen. Rather than show a
+        // key it can never contain, follow the key: switching the selection
+        // re-fetches the list and updates the header picker with it.
+        writeLastProjectId(newKeyProjectId)
+      }
     } catch (e) {
       setError(String(e))
       onError(String(e))
@@ -135,8 +155,13 @@ export function ApiKeySettings({
         <div>
           <div style={{ fontWeight: 700, fontSize: 15 }}>API Keys</div>
           <div style={{ fontSize: 13, color: C.muted, marginTop: 2 }}>
-            Keys for sending events, reading this project&apos;s analytics,
-            reading or toggling its feature flags, or full management access.
+            Keys for{' '}
+            {currentProject
+              ? <strong style={{ color: C.text, fontWeight: 600 }}>{currentProject.name}</strong>
+              : 'this project'}
+            {' '}— sending events, reading its analytics, reading or toggling
+            its feature flags, or full management access. Every key works on one
+            project only.
           </div>
         </div>
       </div>
@@ -410,8 +435,29 @@ export function ApiKeySettings({
             onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
           />
           <select
+            value={newKeyProjectId}
+            onChange={(e) => setNewKeyProjectId(e.target.value)}
+            aria-label="Project for the new API key"
+            style={{
+              background: C.surface,
+              border: `1px solid ${C.border}`,
+              borderRadius: 7,
+              padding: '0.55rem 0.875rem',
+              color: C.text,
+              fontSize: 14,
+              cursor: 'pointer',
+              outline: 'none',
+            }}
+          >
+            {!newKeyProjectId && <option value="">Select a project…</option>}
+            {projects.map((p) => (
+              <option key={p.id} value={p.id}>{p.name}</option>
+            ))}
+          </select>
+          <select
             value={newKeyScope}
             onChange={(e) => setNewKeyScope(e.target.value)}
+            aria-label="Scope for the new API key"
             style={{
               background: C.surface,
               border: `1px solid ${C.border}`,

--- a/web/src/components/shell/Shell.tsx
+++ b/web/src/components/shell/Shell.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom'
 import { BarChart2, Layers, Radio, Settings, Flag, Lightbulb, GitBranch, Video, PlugZap, Globe } from 'lucide-react'
 import { useAuth } from '../../lib/auth'
 import { useProjects } from '../../lib/projects'
-import { LAST_PROJECT_ID_KEY } from '../ui/ProjectPicker'
+import { writeLastProjectId } from '../../lib/selectedProject'
 import { api, type Project } from '../../lib/api'
 import { useIambarnWidget, type IambarnConfig } from '../../lib/iambarn-widget'
 import { C } from '../../lib/theme'
@@ -34,11 +34,7 @@ export default function Shell({ children, projectId, projectName, projects: proj
   // last choice instead of defaulting to the alphabetical first.
   useEffect(() => {
     if (!projectId) return
-    try {
-      window.localStorage.setItem(LAST_PROJECT_ID_KEY, projectId)
-    } catch {
-      /* ignore — quota / disabled storage */
-    }
+    writeLastProjectId(projectId)
   }, [projectId])
 
   useEffect(() => {

--- a/web/src/components/ui/ProjectPicker.test.tsx
+++ b/web/src/components/ui/ProjectPicker.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
-import { ProjectPicker, LAST_PROJECT_ID_KEY } from './ProjectPicker'
+import { ProjectPicker } from './ProjectPicker'
+import { LAST_PROJECT_ID_KEY } from '../../lib/selectedProject'
 import type { Project } from '../../lib/api'
 
 // ---------------------------------------------------------------------------
@@ -174,8 +175,19 @@ describe('ProjectPicker — non-project-scoped routes', () => {
     expect(screen.getByText('Gamma')).toBeInTheDocument()
   })
 
-  it('navigates to /dashboard/<id> when picker is on a non-project-scoped route', () => {
+  // /settings has no /:projectId but does act on the selected project, so it
+  // re-reads the selection itself. Bouncing the user to the dashboard here
+  // used to make switching project mid-task impossible without navigating back.
+  it('stays on /settings and only records the selection', () => {
     renderSettings()
+    fireEvent.click(screen.getByRole('button', { name: /switch project/i }))
+    fireEvent.click(screen.getByText('Beta'))
+    expect(mockNavigate).not.toHaveBeenCalled()
+    expect(window.localStorage.getItem(LAST_PROJECT_ID_KEY)).toBe('p2')
+  })
+
+  it('navigates to /dashboard/<id> from a route that is neither scoped nor project-aware', () => {
+    renderSettings('overview')
     fireEvent.click(screen.getByRole('button', { name: /switch project/i }))
     fireEvent.click(screen.getByText('Beta'))
     expect(mockNavigate).toHaveBeenCalledWith('/dashboard/p2')

--- a/web/src/components/ui/ProjectPicker.tsx
+++ b/web/src/components/ui/ProjectPicker.tsx
@@ -2,6 +2,7 @@ import { useRef, useState, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { ChevronDown, Check, FolderOpen } from 'lucide-react'
 import type { Project } from '../../lib/api'
+import { readLastProjectId, writeLastProjectId } from '../../lib/selectedProject'
 
 const C = {
   bg: '#0f1117',
@@ -12,33 +13,19 @@ const C = {
   muted: '#94a3b8',
 }
 
-/** localStorage key used to remember the user's last-selected project across pages. */
-export const LAST_PROJECT_ID_KEY = 'funnelbarn:lastProjectId'
-
 /**
- * Routes that take a `/:projectId` segment. When the picker fires on any other
- * route (e.g. `/settings`), selecting a project lands the user on
- * `/dashboard/<id>` — the canonical project-landing page.
+ * Routes that take a `/:projectId` segment. Selecting a project there swaps the
+ * id inline.
  */
 const PROJECT_SCOPED_BASES = new Set(['dashboard', 'funnels', 'flags', 'insights', 'live', 'flows'])
 
-function readLastProjectId(): string | undefined {
-  if (typeof window === 'undefined') return undefined
-  try {
-    return window.localStorage.getItem(LAST_PROJECT_ID_KEY) ?? undefined
-  } catch {
-    return undefined
-  }
-}
-
-function writeLastProjectId(id: string) {
-  if (typeof window === 'undefined') return
-  try {
-    window.localStorage.setItem(LAST_PROJECT_ID_KEY, id)
-  } catch {
-    /* ignore — quota / disabled storage */
-  }
-}
+/**
+ * Routes that have no `/:projectId` segment but still act on the selected
+ * project. Switching project there must stay on the page — sending someone to
+ * the dashboard mid-task is how you end up changing project settings for a
+ * project you are no longer looking at.
+ */
+const PROJECT_AWARE_BASES = new Set(['settings'])
 
 interface ProjectPickerProps {
   projects: Project[]
@@ -84,9 +71,11 @@ export function ProjectPicker({ projects, base, projectId, onSelect, variant = '
     setOpen(false)
     onSelect?.()
     writeLastProjectId(project.id)
-    // On project-scoped routes, swap the id inline. Anywhere else (e.g.
-    // /settings) take the user to the project's dashboard, which is the
-    // canonical landing page for a project context.
+    // On project-scoped routes, swap the id inline. On a project-aware route
+    // with no id in the URL (/settings) the page re-reads the selection itself,
+    // so stay put. Anywhere else, take the user to the project's dashboard —
+    // the canonical landing page for a project context.
+    if (PROJECT_AWARE_BASES.has(base)) return
     const target = PROJECT_SCOPED_BASES.has(base) ? base : 'dashboard'
     navigate(`/${target}/${project.id}`)
   }

--- a/web/src/components/wizards/FirstRunWizard.test.tsx
+++ b/web/src/components/wizards/FirstRunWizard.test.tsx
@@ -47,7 +47,7 @@ describe('FirstRunWizard', () => {
       status: 'active',
     })
     vi.mocked(api.createApiKey).mockResolvedValue({
-      api_key: { id: 'k1', name: 'My App ingest', scope: 'ingest', created_at: '' },
+      api_key: { id: 'k1', project_id: 'p1', name: 'My App ingest', scope: 'ingest', created_at: '' },
       key: 'fb_testkey',
     })
 
@@ -74,6 +74,9 @@ describe('FirstRunWizard', () => {
     fireEvent.click(screen.getByText('Go to dashboard →'))
 
     expect(onComplete).toHaveBeenCalledTimes(1)
+    // The ingest key must name the project the wizard just created — the
+    // server no longer guesses one when the caller omits it.
+    expect(api.createApiKey).toHaveBeenCalledWith('My App ingest', 'ingest', 'p1')
   })
 
   it('shows error message when API call fails with 422', async () => {

--- a/web/src/components/wizards/FirstRunWizard.tsx
+++ b/web/src/components/wizards/FirstRunWizard.tsx
@@ -66,7 +66,7 @@ export default function FirstRunWizard({ onComplete }: FirstRunWizardProps) {
       setCreatedProject(p)
       // Also create an ingest key automatically
       try {
-        const keyRes = await api.createApiKey(`${projectName} ingest`, 'ingest')
+        const keyRes = await api.createApiKey(`${projectName} ingest`, 'ingest', p.id)
         setIngestKey(keyRes.key)
         setCreatedKey(keyRes.api_key)
       } catch {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -240,10 +240,14 @@ export const api = {
   },
 
   // API Keys
-  listApiKeys: () =>
-    request<{ api_keys: ApiKey[] }>('/api/v1/apikeys'),
+  // Without a projectId this returns every project's keys, which is only ever
+  // what an instance-wide view wants — a project page must pass its own id.
+  listApiKeys: (projectId?: string) =>
+    request<{ api_keys: ApiKey[] }>(
+      projectId ? `/api/v1/apikeys?project_id=${encodeURIComponent(projectId)}` : '/api/v1/apikeys',
+    ),
 
-  createApiKey: (name: string, scope: string, projectId?: string) =>
+  createApiKey: (name: string, scope: string, projectId: string) =>
     request<{ api_key: ApiKey; key: string }>('/api/v1/apikeys', {
       method: 'POST',
       body: JSON.stringify({ name, scope, project_id: projectId }),
@@ -561,8 +565,10 @@ export interface Segment {
 
 export interface ApiKey {
   id: string
+  /** The one project this key can act on. Every key is bound to exactly one. */
+  project_id: string
   name: string
-  /** 'ingest' | 'flags:read' | 'flags:write' | 'full' */
+  /** 'ingest' | 'analytics:read' | 'flags:read' | 'flags:write' | 'full' */
   scope: string
   created_at: string
   /** Absent when the key has never authenticated a request. */

--- a/web/src/lib/projects.test.tsx
+++ b/web/src/lib/projects.test.tsx
@@ -64,6 +64,7 @@ const projectB: Project = { id: 'proj-b', name: 'Beta', slug: 'beta', status: 'a
 describe('useEffectiveProjectId', () => {
   beforeEach(() => {
     delete store['funnelbarn_default_project']
+    delete store['funnelbarn:lastProjectId']
     vi.clearAllMocks()
   })
 
@@ -94,6 +95,28 @@ describe('useEffectiveProjectId', () => {
     renderWithProjects([])
     await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('undefined'))
   })
+
+  // The header picker writes funnelbarn:lastProjectId. A page with no
+  // /:projectId in its URL (i.e. /settings) has to resolve to the same project
+  // the picker is displaying, or it acts on one the user never chose.
+  it('prefers the project last chosen in the header picker', async () => {
+    store['funnelbarn:lastProjectId'] = 'proj-b'
+    renderWithProjects([projectA, projectB])
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('proj-b'))
+  })
+
+  it('lets an explicit urlProjectId outrank the picker selection', async () => {
+    store['funnelbarn:lastProjectId'] = 'proj-b'
+    renderWithProjects([projectA, projectB], 'proj-a')
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('proj-a'))
+  })
+
+  it('falls through to the default project when the picker selection is gone', async () => {
+    store['funnelbarn:lastProjectId'] = 'proj-deleted'
+    store['funnelbarn_default_project'] = 'proj-b'
+    renderWithProjects([projectA, projectB])
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('proj-b'))
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -109,6 +132,7 @@ function DefaultIdConsumer({ onReady }: { onReady?: (fn: (id: string) => void) =
 describe('setDefaultProjectId', () => {
   beforeEach(() => {
     delete store['funnelbarn_default_project']
+    delete store['funnelbarn:lastProjectId']
     vi.clearAllMocks()
   })
 

--- a/web/src/lib/projects.tsx
+++ b/web/src/lib/projects.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useState, ReactNode, useCallback } from 'react'
 import { api, Project } from './api'
 import { reportError } from './bugbarn'
+import { readLastProjectId, resolveProjectId, subscribeLastProjectId, writeLastProjectId } from './selectedProject'
 
 const STORAGE_KEY = 'funnelbarn_default_project'
 const ENV_STORAGE_KEY = 'funnelbarn_environment'
@@ -11,6 +12,9 @@ interface ProjectContextValue {
   refetch: () => void
   defaultProjectId: string | null
   setDefaultProjectId: (id: string) => void
+  /** The project last chosen in the header picker — see lib/selectedProject.ts. */
+  selectedProjectId: string | null
+  setSelectedProjectId: (id: string) => void
   selectedEnvironment: string
   setSelectedEnvironment: (env: string) => void
 }
@@ -23,6 +27,9 @@ export function ProjectProvider({ children }: { children: ReactNode }) {
   const [defaultProjectId, setDefaultProjectIdState] = useState<string | null>(
     () => localStorage.getItem(STORAGE_KEY)
   )
+  const [selectedProjectId, setSelectedProjectIdState] = useState<string | null>(
+    () => readLastProjectId() ?? null
+  )
   const [selectedEnvironment, setSelectedEnvironmentState] = useState<string>(
     () => localStorage.getItem(ENV_STORAGE_KEY) ?? ''
   )
@@ -30,6 +37,11 @@ export function ProjectProvider({ children }: { children: ReactNode }) {
   const setDefaultProjectId = useCallback((id: string) => {
     setDefaultProjectIdState(id)
     localStorage.setItem(STORAGE_KEY, id)
+  }, [])
+
+  const setSelectedProjectId = useCallback((id: string) => {
+    setSelectedProjectIdState(id)
+    writeLastProjectId(id)
   }, [])
 
   const setSelectedEnvironment = useCallback((env: string) => {
@@ -55,8 +67,13 @@ export function ProjectProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => { refetch() }, [refetch])
 
+  // The header picker writes the selection directly, so mirror it back into
+  // state — otherwise a page reading selectedProjectId would keep acting on the
+  // project the user just switched away from.
+  useEffect(() => subscribeLastProjectId(setSelectedProjectIdState), [])
+
   return (
-    <ProjectContext.Provider value={{ projects, isLoading, refetch, defaultProjectId, setDefaultProjectId, selectedEnvironment, setSelectedEnvironment }}>
+    <ProjectContext.Provider value={{ projects, isLoading, refetch, defaultProjectId, setDefaultProjectId, selectedProjectId, setSelectedProjectId, selectedEnvironment, setSelectedEnvironment }}>
       {children}
     </ProjectContext.Provider>
   )
@@ -68,10 +85,8 @@ export function useProjects(): ProjectContextValue {
   return ctx
 }
 
+/** The project a page should act on — see resolveProjectId for the order. */
 export function useEffectiveProjectId(urlProjectId?: string): string | undefined {
-  const { projects, defaultProjectId } = useProjects()
-  if (urlProjectId) return urlProjectId
-  const defaultExists = defaultProjectId && projects.some((p) => p.id === defaultProjectId)
-  if (defaultExists) return defaultProjectId!
-  return projects[0]?.id
+  const { projects, defaultProjectId, selectedProjectId } = useProjects()
+  return resolveProjectId(projects, urlProjectId, selectedProjectId, defaultProjectId)
 }

--- a/web/src/lib/selectedProject.ts
+++ b/web/src/lib/selectedProject.ts
@@ -1,0 +1,66 @@
+/**
+ * The project the user last switched to in the header picker.
+ *
+ * This lives on its own so that the picker (which writes it) and
+ * ProjectProvider (which reads it back for pages that carry no `/:projectId`
+ * in their URL, e.g. /settings) agree on one value. They used to disagree: the
+ * picker remembered its own id while the provider only knew about the "default
+ * project" chip, so /settings could show one project in the header and mint an
+ * API key for another.
+ */
+export const LAST_PROJECT_ID_KEY = 'funnelbarn:lastProjectId'
+
+export function readLastProjectId(): string | undefined {
+  if (typeof window === 'undefined') return undefined
+  try {
+    return window.localStorage.getItem(LAST_PROJECT_ID_KEY) ?? undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * The one definition of which project is "current": the URL's own id, then the
+ * project last chosen in the header picker, then the "default project"
+ * preference, then the first project.
+ *
+ * Every candidate is checked against the loaded projects, so a remembered id
+ * for a project that has since been deleted falls through instead of
+ * addressing nothing. Kept as a plain function so the landing redirect and
+ * every project-aware page resolve identically and cannot drift apart.
+ */
+export function resolveProjectId(
+  projects: { id: string }[],
+  urlProjectId?: string,
+  selectedProjectId?: string | null,
+  defaultProjectId?: string | null,
+): string | undefined {
+  if (urlProjectId) return urlProjectId
+  const known = (id?: string | null) => !!id && projects.some((p) => p.id === id)
+  if (known(selectedProjectId)) return selectedProjectId!
+  if (known(defaultProjectId)) return defaultProjectId!
+  return projects[0]?.id
+}
+
+/**
+ * Subscribers notified when the selection changes. localStorage alone is not
+ * enough: a write from the picker has to re-render the page underneath it in
+ * the same tab, and the `storage` event only fires in *other* tabs.
+ */
+const listeners = new Set<(id: string) => void>()
+
+export function subscribeLastProjectId(fn: (id: string) => void): () => void {
+  listeners.add(fn)
+  return () => { listeners.delete(fn) }
+}
+
+export function writeLastProjectId(id: string) {
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.setItem(LAST_PROJECT_ID_KEY, id)
+    } catch {
+      /* ignore — quota / disabled storage */
+    }
+  }
+  listeners.forEach((fn) => fn(id))
+}

--- a/web/src/pages/Funnels.tsx
+++ b/web/src/pages/Funnels.tsx
@@ -314,14 +314,17 @@ export default function Funnels() {
   const [deleting, setDeleting] = useState(false)
   const [pendingTemplate, setPendingTemplate] = useState<FunnelTemplate | undefined>(undefined)
 
+  // Scoped to this route's project: an unfiltered list would happily hand the
+  // snippet another project's ingest key.
   useEffect(() => {
-    api.listApiKeys()
+    if (!projectId) return
+    api.listApiKeys(projectId)
       .then((d) => {
         const key = (d.api_keys || []).find((k) => k.scope === 'ingest')
-        if (key) setIngestKey(key.id)
+        setIngestKey(key?.id)
       })
       .catch(() => {})
-  }, [])
+  }, [projectId])
 
   useEffect(() => {
     if (!projectId) return

--- a/web/src/pages/Settings.test.tsx
+++ b/web/src/pages/Settings.test.tsx
@@ -8,13 +8,30 @@ import type { ApiKey, Project } from '../lib/api'
 // Mocks
 // ---------------------------------------------------------------------------
 
+// Two projects, with the selected one deliberately NOT first: the create form
+// used to hand the server `projects[0]`, which on a multi-project instance
+// minted the key against a project the user never chose.
 const mockProjects: Project[] = [
   { id: 'p1', name: 'My Site', slug: 'my-site', status: 'active' },
+  { id: 'p2', name: 'Other Site', slug: 'other-site', status: 'active' },
 ]
+const SELECTED_PROJECT_ID = 'p2'
 const mockRefetch = vi.fn()
+const mockSetSelectedProjectId = vi.fn()
 
 vi.mock('../lib/projects', () => ({
-  useProjects: () => ({ projects: mockProjects, isLoading: false, refetch: mockRefetch }),
+  useProjects: () => ({
+    projects: mockProjects,
+    isLoading: false,
+    refetch: mockRefetch,
+    defaultProjectId: null,
+    setDefaultProjectId: vi.fn(),
+    selectedProjectId: SELECTED_PROJECT_ID,
+    setSelectedProjectId: mockSetSelectedProjectId,
+    selectedEnvironment: '',
+    setSelectedEnvironment: vi.fn(),
+  }),
+  useEffectiveProjectId: () => SELECTED_PROJECT_ID,
 }))
 
 vi.mock('../lib/auth', () => ({
@@ -27,7 +44,7 @@ vi.mock('react-router-dom', async (importOriginal) => {
 })
 
 const mockApiKeys: ApiKey[] = [
-  { id: 'k1', name: 'prod-key', scope: 'ingest', created_at: '2024-01-01T00:00:00Z' },
+  { id: 'k1', project_id: SELECTED_PROJECT_ID, name: 'prod-key', scope: 'ingest', created_at: '2024-01-01T00:00:00Z' },
 ]
 
 const mockApi = vi.hoisted(() => ({
@@ -48,6 +65,7 @@ const mockApi = vi.hoisted(() => ({
     updated_at: '2024-01-01T00:00:00Z',
   }),
   resetProjectHealth: vi.fn().mockResolvedValue(undefined),
+  getEnvironments: vi.fn().mockResolvedValue({ environments: [] }),
   getClientConfig: vi.fn().mockResolvedValue({
     bugbarn_endpoint: '',
     bugbarn_ingest_key: '',
@@ -117,7 +135,7 @@ describe('Settings', () => {
 
   it('creates an API key and shows it revealed', async () => {
     mockApi.createApiKey.mockResolvedValue({
-      api_key: { id: 'k2', name: 'new-key', scope: 'ingest', created_at: '2024-06-01T00:00:00Z' },
+      api_key: { id: 'k2', project_id: SELECTED_PROJECT_ID, name: 'new-key', scope: 'ingest', created_at: '2024-06-01T00:00:00Z' },
       key: 'plaintext-value-here',
     })
     renderSettings()
@@ -130,7 +148,42 @@ describe('Settings', () => {
     await waitFor(() =>
       expect(screen.getByText('plaintext-value-here')).toBeInTheDocument(),
     )
-    expect(mockApi.createApiKey).toHaveBeenCalledWith('new-key', 'ingest', 'p1')
+    expect(mockApi.createApiKey).toHaveBeenCalledWith('new-key', 'ingest', SELECTED_PROJECT_ID)
+  })
+
+  it('lists only the selected project’s keys', async () => {
+    renderSettings()
+    await waitFor(() =>
+      expect(mockApi.listApiKeys).toHaveBeenCalledWith(SELECTED_PROJECT_ID),
+    )
+  })
+
+  it('names the selected project in the API Keys section', async () => {
+    renderSettings()
+    // The name appears in several places on this page; only the API Keys
+    // subtitle emphasises it, which is the one that has to say "Other Site".
+    await waitFor(() =>
+      expect(
+        screen.getAllByText('Other Site').some((el) => el.tagName === 'STRONG'),
+      ).toBe(true),
+    )
+  })
+
+  it('mints against the project chosen in the form, not the first one', async () => {
+    mockApi.createApiKey.mockResolvedValue({
+      api_key: { id: 'k3', project_id: 'p1', name: 'other-key', scope: 'ingest', created_at: '2024-06-01T00:00:00Z' },
+      key: 'plaintext-for-p1',
+    })
+    renderSettings()
+    await waitFor(() => screen.getByText('API Keys'))
+
+    fireEvent.change(screen.getByPlaceholderText(/key name/i), { target: { value: 'other-key' } })
+    fireEvent.change(screen.getByLabelText(/project for the new api key/i), { target: { value: 'p1' } })
+    fireEvent.click(screen.getByRole('button', { name: /create/i }))
+
+    await waitFor(() =>
+      expect(mockApi.createApiKey).toHaveBeenCalledWith('other-key', 'ingest', 'p1'),
+    )
   })
 
   it('first delete click sets confirm state; second click deletes', async () => {

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { Globe, ShieldOff, Video } from 'lucide-react'
 import Shell from '../components/shell/Shell'
 import { api, ApiKey } from '../lib/api'
-import { useProjects } from '../lib/projects'
+import { useProjects, useEffectiveProjectId } from '../lib/projects'
 import { CopyButton } from '../components/ui/CopyButton'
 import { reportError } from '../lib/bugbarn'
 import { ProjectSettings } from '../components/settings/ProjectSettings'
@@ -20,7 +20,11 @@ const C = {
 }
 
 export default function Settings() {
-  const { projects, refetch: refetchProjects, defaultProjectId, setDefaultProjectId } = useProjects()
+  const { projects, isLoading: projectsLoading, refetch: refetchProjects, defaultProjectId, setDefaultProjectId } = useProjects()
+  // /settings carries no /:projectId, so resolve the same project the header
+  // picker displays — otherwise this page acts on a project the user never
+  // chose.
+  const activeProjectId = useEffectiveProjectId()
   const [apiKeys, setApiKeys] = useState<ApiKey[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -40,11 +44,24 @@ export default function Settings() {
   const [anonymizeError, setAnonymizeError] = useState<string | null>(null)
 
   useEffect(() => {
-    api.listApiKeys()
-      .then((d) => setApiKeys(d.api_keys || []))
-      .catch((e) => { reportError(e, { source: 'Settings.listApiKeys' }); setApiKeys([]) })
-      .finally(() => setLoading(false))
-  }, [])
+    if (!activeProjectId) {
+      // No project to scope to: stop waiting once we know why (none exist),
+      // rather than leaving the section on "Loading…" forever.
+      if (!projectsLoading) { setApiKeys([]); setLoading(false) }
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    api.listApiKeys(activeProjectId)
+      .then((d) => { if (!cancelled) setApiKeys(d.api_keys || []) })
+      .catch((e) => {
+        if (cancelled) return
+        reportError(e, { source: 'Settings.listApiKeys' })
+        setApiKeys([])
+      })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [activeProjectId, projectsLoading])
 
   useEffect(() => {
     api.getInstanceSettings()
@@ -116,7 +133,7 @@ export default function Settings() {
   const snippet = `<script src="${publicURL}/sdk.js"\n        data-api-key="${snippetKey}"></script>`
 
   return (
-    <Shell>
+    <Shell projectId={activeProjectId}>
       <style>{`
         @media (max-width: 640px) {
           .api-keys-table { display: none !important; }
@@ -208,6 +225,7 @@ export default function Settings() {
         setApiKeys={setApiKeys}
         loading={loading}
         projects={projects}
+        projectId={activeProjectId}
         onError={setError}
       />
 


### PR DESCRIPTION
## The bug

Creating an API key from the settings dashboard while `profotograaf` was the project shown in the header minted a key bound to **BrandTrace.net**. Confirmed live — the new key's `GET /api/v1/projects` returned only BrandTrace.net, which is the proof of binding since an `analytics:read` token narrows that response to its own project.

## Causes

1. **`ApiKeySettings.tsx` sent `projects[0]?.id`** — the first project in server order, never the one the header names. Invisible on a single-project instance (which is why the existing test passed), silently wrong with several.
2. **`/settings` had no project context.** `ProjectPicker` remembered `funnelbarn:lastProjectId` while `ProjectProvider` only knew the "default project" chip, and `useEffectiveProjectId` never read the picker's key. `Settings` rendered `<Shell>` with no `projectId`, so the header displayed one project while the page acted on another. The key list was fetched unfiltered, showing every project's keys with no project column.
3. **The server filled in `ListProjects()[0]`** when `project_id` was absent, so nothing caught a caller that forgot it.

## Scope decision

Keys stay bound to exactly one project — no "all projects" key. `api_keys.project_id` is `NOT NULL` with an FK, and `serveScopedToken` deliberately rejects a key resolving to an empty project so nothing becomes a master key. That stance is kept.

## Changes

- **One definition of "current project"**: `resolveProjectId` in the new `web/src/lib/selectedProject.ts`, over the key the picker already writes. Used by the landing redirect (`App.tsx`), the header picker and every project-aware page, so they cannot drift. The provider subscribes to writes, so switching project re-renders the page underneath.
- **Switching project from `/settings` stays on `/settings`** instead of bouncing to the dashboard mid-task.
- **`Settings`** scopes its key list to the selected project, re-fetches on switch, and names that project in the section header. The create form gained a **project select**, defaulting to the project on screen; minting for a different one follows the key rather than showing it above a list that cannot contain it.
- **`Funnels`** scoped its ingest-key lookup to its own route's project — the snippet could otherwise embed another project's key.
- **`POST /api/v1/apikeys` returns 400 without `project_id`**; `FirstRunWizard` passes the project it just created.
- **OpenAPI** brought back in line: five-scope enum, `ingest` default, the real nested `201` shape, `project_id`/`last_used_at` on `APIKeySafe`, `project_id` optional on the list endpoint.

## Tests

`Settings.test.tsx` now uses two projects with the selected one deliberately **not** first — the fixture the old bug could hide behind — and asserts both the list call and the create call use the selected id. Plus: precedence coverage for `useEffectiveProjectId` (including a deleted project falling through), picker behaviour on `/settings`, the wizard's project binding, and backend tests for the 400 and for binding to a named non-first project.

`go test -race ./internal/api` ✅ · `go vet` ✅ · `gofmt` clean · 399 web tests ✅ · `tsc --noEmit` ✅ · eslint 0 errors · coverage + duplication gates ✅

## Verifying after deploy

1. Switch the header picker to a project that is not first in `GET /api/v1/projects` order; you stay on `/settings`.
2. The API Keys table lists only that project's keys.
3. Create an `analytics:read` key; the form names that project.
4. `curl -s https://<host>/api/v1/projects -H "x-funnelbarn-api-key: <new key>"` returns exactly the project that was selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NMhdBf7b5pxuFMx5ft4qu