### PR TITLE
Drop the last MinIO references now that nothing uses it

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -395,10 +395,10 @@ jobs:
           AWS_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT }}
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
         run: |
-          # Fail loudly rather than publishing nowhere. Before this job moved to
-          # R2 it uploaded to MinIO, which the read path had already stopped
-          # serving — so the tap advertised tarballs that 404'd and nobody
-          # noticed. A missing secret must break the build, not go quiet again.
+          # Fail loudly rather than publishing nowhere. This job once uploaded
+          # to storage the read path had already stopped serving, so the tap
+          # advertised tarballs that 404'd and nobody noticed for four
+          # releases. A missing secret must break the build, not go quiet.
           for var in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_ENDPOINT_URL R2_BUCKET; do
             if [ -z "${!var}" ]; then
               echo "ERROR: ${var} is empty — the R2_* secrets must be configured on this repo."

--- a/deploy/RUNBOOK.md
+++ b/deploy/RUNBOOK.md
@@ -13,7 +13,6 @@ Namespaces:
 
 Litestream replicates the SQLite database continuously to Cloudflare R2, bucket `barn-backups`
 (endpoint `https://354b481466ca4280c50f2fb8cf9e3d45.eu.r2.cloudflarestorage.com`, region `auto`).
-This moved off the self-hosted MinIO at `s3.wiebe.xyz` when that was wound down.
 
 Replica paths per environment:
 - Production: `funnelbarn/litestream/production/funnelbarn.db`

--- a/deploy/SECRETS.md
+++ b/deploy/SECRETS.md
@@ -25,15 +25,9 @@ package-repository bucket, under the `brew/` prefix.
 | `R2_ENDPOINT` | R2 account S3 endpoint URL |
 | `R2_BUCKET` | Bucket name (`webwiebe-apt-repository-production`) |
 
-These replace the former `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` /
-`MINIO_ENDPOINT` / `MINIO_BUCKET` secrets. The self-hosted MinIO on layer7
-(`s3.wiebe.xyz`) was wound down in favour of R2 — see
-`wiebe-xyz/rapid-root#2799` for the migration, and note that the `brew/` prefix
-is shared with other publishers, so this repo only ever writes and prunes its
-own `funnelbarn-darwin-*` keys.
-
-The old `MINIO_*` secrets can be deleted from this repository once this
-workflow has published a release to R2 successfully.
+The `brew/` prefix is shared with other publishers, so this repo only ever
+writes and prunes its own `funnelbarn-darwin-*` keys. See
+`wiebe-xyz/rapid-root#2799` for how the shared package repository is set up.
 
 ## Infrastructure SSH
 

--- a/deploy/k8s/production/deployment.yaml
+++ b/deploy/k8s/production/deployment.yaml
@@ -193,8 +193,7 @@ spec:
             # Litestream replicates to R2 (bucket barn-backups) using
             # funnelbarn's own R2 token, the same credential the recordings
             # store uses. One token, referenced twice, so a rotation touches a
-            # single pair of secret keys. The former LITESTREAM_* keys held
-            # MinIO credentials and were dropped when s3.wiebe.xyz was retired.
+            # single pair of secret keys.
             - name: LITESTREAM_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary

Third and final piece of the MinIO wind-down in this repo, after #240 (brew publishing) and #242 (Litestream replica).

Both paths that actually touched MinIO are on R2 now. What remained were historical asides naming the retired storage, plus a line in `deploy/SECRETS.md` telling the reader the old `MINIO_*` secrets could be deleted "once this workflow has published a release to R2 successfully" — which already happened, so the note was stale.

After this, `grep -ri minio` over the repo returns nothing.

## Changes

- `deploy/SECRETS.md` — drop the replacement note and the deletion caveat; keep the part that still matters, that the `brew/` prefix is shared with other publishers.
- `deploy/RUNBOOK.md` — drop the "moved off MinIO" aside from the backup section.
- `deploy/k8s/production/deployment.yaml` — drop the trailing sentence about the old keys; the comment still explains why one token is referenced twice.
- `.github/workflows/binary-release.yml` — the guard comment keeps its reason (a publish going nowhere is how the tap drifted four releases unnoticed) without naming the old storage.

## Testing

- Both YAML files parse.
- `actionlint`: 10 findings, unchanged from baseline; all pre-existing `info`-level SC2086 in untouched steps.
- Comment-and-prose only. No behaviour changes.