### PR TITLE
Closes #226: session IDs stopped rotating because the server's fallback fingerprint never changed

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -38,6 +38,16 @@ var (
 		Help: "Total events rejected at the ingest edge, labeled by reason.",
 	}, []string{"reason"})
 
+	// SessionsFingerprinted counts events that arrived without a usable session
+	// ID and were assigned a server-derived fingerprint instead, labeled by
+	// "reason" ("missing" or "invalid"). A client that stops sending session IDs
+	// is otherwise invisible: the events keep landing and only the session
+	// counts go wrong, which took three months to notice once.
+	SessionsFingerprinted = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "funnelbarn_sessions_fingerprinted_total",
+		Help: "Events assigned a server-derived session fingerprint, labeled by reason.",
+	}, []string{"reason"})
+
 	// Worker pipeline
 	EventsProcessed = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "funnelbarn_events_processed_total",

--- a/internal/session/fingerprint.go
+++ b/internal/session/fingerprint.go
@@ -2,25 +2,60 @@ package session
 
 import (
 	"crypto/sha256"
-	"fmt"
+	"encoding/hex"
 	"net"
+	"strconv"
 	"strings"
+	"time"
 )
 
-// Fingerprint generates an anonymous session ID from the remote address,
-// user-agent, and environment. No cookie is required. The fingerprint is
-// SHA256(ip + "|" + ua + "|" + env) truncated to 32 hex characters.
+// FingerprintWindow bounds how long one fallback session ID stays in use.
 //
-// The IP is stripped to /24 (IPv4) or /48 (IPv6) before hashing to provide
-// a degree of k-anonymity while still being stable within a session.
-// Including environment prevents sessions from bleeding across environments
-// when the same API key is used for dev, staging, and production.
-func Fingerprint(remoteAddr, userAgent, environment string) string {
-	ip := extractIP(remoteAddr)
-	normalized := normalizeIP(ip)
+// The fingerprint is stateless, so it cannot watch for idle time the way a
+// client-side session cookie does. Instead it changes at fixed boundaries: a
+// visitor whose activity straddles one is counted as two sessions. That is the
+// price of never minting a session that runs for months — before this bound
+// existed, a single fingerprint in production collected 39,893 events from 742
+// visitors over three months, because nothing in its inputs ever changed.
+const FingerprintWindow = 30 * time.Minute
 
-	h := sha256.Sum256([]byte(normalized + "|" + userAgent + "|" + environment))
-	return fmt.Sprintf("%x", h[:16]) // 32 hex chars
+// FingerprintInput carries everything a fallback session ID is derived from.
+type FingerprintInput struct {
+	// ClientIP is the visitor's own address, as "ip" or "ip:port". It must be
+	// the address the request came from originally, not that of a reverse proxy
+	// or CDN edge: every visitor behind one ingress shares the proxy's address,
+	// so keying on it files all of them under a single session.
+	ClientIP string
+	// UserAgent may be empty; on its own it separates very little.
+	UserAgent string
+	// ProjectSlug scopes the session to one project. sessions.id is a global
+	// primary key, so two projects behind the same ingress must not collide.
+	ProjectSlug string
+	// Environment keeps sessions from bleeding across dev, staging, and
+	// production when one API key is shared between them.
+	Environment string
+	// At is when the event occurred. It selects the time window.
+	At time.Time
+}
+
+// Fingerprint derives an anonymous session ID for an event whose client sent no
+// usable session ID of its own. No cookie is required.
+//
+// The IP is stripped to /24 (IPv4) or /48 (IPv6) before hashing, for a degree
+// of k-anonymity while staying stable within a session. The result is
+// SHA256(ip | ua | project | env | window) truncated to 32 hex characters.
+func Fingerprint(in FingerprintInput) string {
+	ip := normalizeIP(extractIP(in.ClientIP))
+	window := in.At.UTC().Unix() / int64(FingerprintWindow/time.Second)
+
+	h := sha256.Sum256([]byte(strings.Join([]string{
+		ip,
+		in.UserAgent,
+		in.ProjectSlug,
+		in.Environment,
+		strconv.FormatInt(window, 10),
+	}, "|")))
+	return hex.EncodeToString(h[:16]) // 32 hex chars
 }
 
 // extractIP strips the port component from a host:port string.
@@ -54,11 +89,9 @@ func normalizeIP(ip string) string {
 	return v6.String()
 }
 
-// SessionExpired returns true when the lastSeen timestamp string indicates
-// that a 30-minute idle window has passed compared to now (string comparison
-// in RFC3339 format works because the format is lexicographically sortable).
-// Callers pass RFC3339 timestamps; this function exists purely as a helper
-// for the JS SDK session rotation logic and is not used server-side.
+// IsValidSessionID reports whether id has the shape this server mints and the
+// SDKs generate: 32 hexadecimal characters. Anything else is replaced by a
+// Fingerprint rather than stored as-is.
 func IsValidSessionID(id string) bool {
 	id = strings.TrimSpace(id)
 	return len(id) == 32 && isHex(id)

--- a/internal/session/fingerprint_test.go
+++ b/internal/session/fingerprint_test.go
@@ -2,35 +2,123 @@ package session
 
 import (
 	"testing"
+	"time"
 )
+
+var fixedTime = time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+
+// fp builds a fingerprint from the common case, letting each test vary only
+// the field it cares about.
+func fp(mutate ...func(*FingerprintInput)) string {
+	in := FingerprintInput{
+		ClientIP:    "192.168.1.42:54321",
+		UserAgent:   "Mozilla/5.0 Chrome/124",
+		ProjectSlug: "my-site",
+		Environment: "production",
+		At:          fixedTime,
+	}
+	for _, m := range mutate {
+		m(&in)
+	}
+	return Fingerprint(in)
+}
+
+func ip(v string) func(*FingerprintInput)    { return func(i *FingerprintInput) { i.ClientIP = v } }
+func ua(v string) func(*FingerprintInput)    { return func(i *FingerprintInput) { i.UserAgent = v } }
+func at(v time.Time) func(*FingerprintInput) { return func(i *FingerprintInput) { i.At = v } }
 
 // ---------------------------------------------------------------------------
 // Fingerprint
 // ---------------------------------------------------------------------------
 
 func TestFingerprint_ReturnsHex32(t *testing.T) {
-	fp := Fingerprint("192.168.1.42:54321", "Mozilla/5.0 Chrome/124", "production")
-	if len(fp) != 32 {
-		t.Errorf("expected 32 hex chars, got %d: %q", len(fp), fp)
+	got := fp()
+	if len(got) != 32 {
+		t.Errorf("expected 32 hex chars, got %d: %q", len(got), got)
 	}
-	if !isHex(fp) {
-		t.Errorf("fingerprint is not hex: %q", fp)
+	if !isHex(got) {
+		t.Errorf("fingerprint is not hex: %q", got)
 	}
 }
 
 func TestFingerprint_Deterministic(t *testing.T) {
-	a := Fingerprint("10.0.0.5:8080", "some-ua", "production")
-	b := Fingerprint("10.0.0.5:8080", "some-ua", "production")
-	if a != b {
+	if a, b := fp(), fp(); a != b {
 		t.Errorf("Fingerprint not deterministic: %q != %q", a, b)
 	}
 }
 
 func TestFingerprint_DifferentInputsDifferentOutput(t *testing.T) {
-	a := Fingerprint("10.0.0.5:8080", "ua-1", "production")
-	b := Fingerprint("10.0.0.5:8080", "ua-2", "production")
-	if a == b {
+	if a, b := fp(ua("ua-1")), fp(ua("ua-2")); a == b {
 		t.Error("different UAs should produce different fingerprints")
+	}
+}
+
+func TestFingerprint_IsValidSessionID(t *testing.T) {
+	if got := fp(ip("203.0.113.10:12345")); !IsValidSessionID(got) {
+		t.Errorf("Fingerprint result %q should be a valid session ID", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Inputs that must keep sessions apart
+// ---------------------------------------------------------------------------
+
+func TestFingerprint_DifferentEnvironmentsDifferentOutput(t *testing.T) {
+	prod := fp()
+	dev := fp(func(i *FingerprintInput) { i.Environment = "development" })
+	if prod == dev {
+		t.Error("different environments should produce different fingerprints")
+	}
+}
+
+func TestFingerprint_DifferentProjectsDifferentOutput(t *testing.T) {
+	// sessions.id is a global primary key, so two projects reached through the
+	// same ingress must not mint the same session ID.
+	a := fp(func(i *FingerprintInput) { i.ProjectSlug = "site-one" })
+	b := fp(func(i *FingerprintInput) { i.ProjectSlug = "site-two" })
+	if a == b {
+		t.Error("different projects should produce different fingerprints")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Time window — a fingerprinted session must not grow without bound (#226)
+// ---------------------------------------------------------------------------
+
+func TestFingerprint_StableWithinWindow(t *testing.T) {
+	// 09:00 and 09:29 fall in the same half-hour window.
+	base := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+	if a, b := fp(at(base)), fp(at(base.Add(29*time.Minute))); a != b {
+		t.Errorf("events inside one window should share a session: %q != %q", a, b)
+	}
+}
+
+func TestFingerprint_RotatesAcrossWindows(t *testing.T) {
+	base := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+	for _, gap := range []time.Duration{FingerprintWindow, time.Hour, 24 * time.Hour, 90 * 24 * time.Hour} {
+		if a, b := fp(at(base)), fp(at(base.Add(gap))); a == b {
+			t.Errorf("events %s apart should not share a session ID", gap)
+		}
+	}
+}
+
+func TestFingerprint_WindowIsAbsoluteNotSliding(t *testing.T) {
+	// Continuous activity must still roll over. Stepping a minute at a time
+	// across three hours has to produce more than one session ID, or a visitor
+	// who never goes idle stays in one session forever.
+	base := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+	seen := map[string]bool{}
+	for i := 0; i <= 180; i++ {
+		seen[fp(at(base.Add(time.Duration(i)*time.Minute)))] = true
+	}
+	if len(seen) < 6 {
+		t.Errorf("3 hours of continuous activity produced %d session IDs, want at least 6", len(seen))
+	}
+}
+
+func TestFingerprint_ZeroTimeDoesNotPanic(t *testing.T) {
+	if got := fp(at(time.Time{})); len(got) != 32 {
+		t.Errorf("zero timestamp: expected 32 chars, got %q", got)
 	}
 }
 
@@ -40,33 +128,27 @@ func TestFingerprint_DifferentInputsDifferentOutput(t *testing.T) {
 
 func TestFingerprint_IPv4AnonymizationSlash24(t *testing.T) {
 	// 192.168.1.5 and 192.168.1.99 share /24 prefix → same fingerprint.
-	fpA := Fingerprint("192.168.1.5:1000", "ua", "production")
-	fpB := Fingerprint("192.168.1.99:2000", "ua", "production")
-	if fpA != fpB {
-		t.Errorf("IPv4 /24: same subnet should fingerprint identically, got %q vs %q", fpA, fpB)
+	if a, b := fp(ip("192.168.1.5:1000")), fp(ip("192.168.1.99:2000")); a != b {
+		t.Errorf("IPv4 /24: same subnet should fingerprint identically, got %q vs %q", a, b)
 	}
 
 	// Different /24 subnet → different fingerprint.
-	fpC := Fingerprint("192.168.2.5:1000", "ua", "production")
-	if fpA == fpC {
-		t.Errorf("IPv4: different /24 subnets should produce different fingerprints")
+	if a, c := fp(ip("192.168.1.5:1000")), fp(ip("192.168.2.5:1000")); a == c {
+		t.Error("IPv4: different /24 subnets should produce different fingerprints")
 	}
 }
 
 func TestFingerprint_IPv4WithoutPort(t *testing.T) {
-	// When remoteAddr has no port, it should still work.
-	fp := Fingerprint("10.0.0.1", "ua", "production")
-	if len(fp) != 32 {
-		t.Errorf("expected 32 chars, got %d: %q", len(fp), fp)
+	// When the address has no port, it should still work.
+	if got := fp(ip("10.0.0.1")); len(got) != 32 {
+		t.Errorf("expected 32 chars, got %d: %q", len(got), got)
 	}
 }
 
 func TestFingerprint_IPv4LastOctetIgnored(t *testing.T) {
-	// Simpler: check a few specific IPs in 172.16.0.x — all map to same /24.
-	base := Fingerprint("172.16.0.1:9000", "ua", "production")
+	base := fp(ip("172.16.0.1:9000"))
 	for _, suffix := range []string{"2", "100", "200", "255"} {
-		fp := Fingerprint("172.16.0."+suffix+":9000", "ua", "production")
-		if fp != base {
+		if got := fp(ip("172.16.0." + suffix + ":9000")); got != base {
 			t.Errorf("172.16.0.%s should match 172.16.0.1 (same /24), got different fingerprint", suffix)
 		}
 	}
@@ -78,24 +160,19 @@ func TestFingerprint_IPv4LastOctetIgnored(t *testing.T) {
 
 func TestFingerprint_IPv6AnonymizationSlash48(t *testing.T) {
 	// 2001:db8:1234::1 and 2001:db8:1234::2 share /48.
-	fpA := Fingerprint("[2001:db8:1234::1]:80", "ua", "production")
-	fpB := Fingerprint("[2001:db8:1234::2]:80", "ua", "production")
-	if fpA != fpB {
-		t.Errorf("IPv6 /48: same prefix should fingerprint identically, got %q vs %q", fpA, fpB)
+	if a, b := fp(ip("[2001:db8:1234::1]:80")), fp(ip("[2001:db8:1234::2]:80")); a != b {
+		t.Errorf("IPv6 /48: same prefix should fingerprint identically, got %q vs %q", a, b)
 	}
 
 	// Different /48 prefix → different fingerprint.
-	fpC := Fingerprint("[2001:db8:5678::1]:80", "ua", "production")
-	if fpA == fpC {
-		t.Errorf("IPv6: different /48 prefixes should produce different fingerprints")
+	if a, c := fp(ip("[2001:db8:1234::1]:80")), fp(ip("[2001:db8:5678::1]:80")); a == c {
+		t.Error("IPv6: different /48 prefixes should produce different fingerprints")
 	}
 }
 
 func TestFingerprint_IPv6NoBrackets(t *testing.T) {
-	// Without brackets+port (raw IPv6 addr as remoteAddr).
-	fp := Fingerprint("::1", "ua", "production")
-	if len(fp) != 32 {
-		t.Errorf("expected 32 chars, got %d: %q", len(fp), fp)
+	if got := fp(ip("::1")); len(got) != 32 {
+		t.Errorf("expected 32 chars, got %d: %q", len(got), got)
 	}
 }
 
@@ -113,8 +190,7 @@ func TestNormalizeIP_IPv4(t *testing.T) {
 		{"8.8.8.8", "8.8.8.0"},
 	}
 	for _, tc := range tests {
-		got := normalizeIP(tc.ip)
-		if got != tc.want {
+		if got := normalizeIP(tc.ip); got != tc.want {
 			t.Errorf("normalizeIP(%q) = %q, want %q", tc.ip, got, tc.want)
 		}
 	}
@@ -132,8 +208,7 @@ func TestNormalizeIP_IPv6(t *testing.T) {
 
 func TestNormalizeIP_Invalid(t *testing.T) {
 	// Invalid IP should be returned as-is.
-	got := normalizeIP("not-an-ip")
-	if got != "not-an-ip" {
+	if got := normalizeIP("not-an-ip"); got != "not-an-ip" {
 		t.Errorf("normalizeIP(invalid) = %q, want %q", got, "not-an-ip")
 	}
 }
@@ -158,29 +233,9 @@ func TestIsValidSessionID(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.id, func(t *testing.T) {
-			got := IsValidSessionID(tc.id)
-			if got != tc.want {
+			if got := IsValidSessionID(tc.id); got != tc.want {
 				t.Errorf("IsValidSessionID(%q) = %v, want %v", tc.id, got, tc.want)
 			}
 		})
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Fingerprint produces a valid session ID
-// ---------------------------------------------------------------------------
-
-func TestFingerprint_IsValidSessionID(t *testing.T) {
-	fp := Fingerprint("203.0.113.10:12345", "Mozilla/5.0", "production")
-	if !IsValidSessionID(fp) {
-		t.Errorf("Fingerprint result %q should be a valid session ID", fp)
-	}
-}
-
-func TestFingerprint_DifferentEnvironmentsDifferentOutput(t *testing.T) {
-	prod := Fingerprint("10.0.0.5:8080", "ua", "production")
-	dev := Fingerprint("10.0.0.5:8080", "ua", "development")
-	if prod == dev {
-		t.Error("different environments should produce different fingerprints")
 	}
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/wiebe-xyz/funnelbarn/internal/enrich"
 	"github.com/wiebe-xyz/funnelbarn/internal/environment"
 	"github.com/wiebe-xyz/funnelbarn/internal/geoip"
+	"github.com/wiebe-xyz/funnelbarn/internal/metrics"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 	"github.com/wiebe-xyz/funnelbarn/internal/session"
 	"github.com/wiebe-xyz/funnelbarn/internal/spool"
@@ -69,10 +70,30 @@ func ProcessRecord(record spool.Record) (repository.Event, error) {
 		warnUnknownEnvironment(payload.Environment, env)
 	}
 
-	// Derive session ID.
+	// The address the visitor actually came from. record.RemoteAddr is the TCP
+	// peer, which behind an ingress or CDN is the proxy, identical for every
+	// visitor; ClientIP is resolved from the forwarding headers at the edge.
+	clientIP := record.ClientIP
+	if clientIP == "" {
+		clientIP = record.RemoteAddr
+	}
+
+	// Derive session ID. A client that sends none of its own — or sends
+	// something that is not one of ours — gets a fingerprint instead.
 	sessionID := payload.SessionID
 	if sessionID == "" || !session.IsValidSessionID(sessionID) {
-		sessionID = session.Fingerprint(record.RemoteAddr, payload.UserAgent, env)
+		reason := "missing"
+		if sessionID != "" {
+			reason = "invalid"
+		}
+		metrics.SessionsFingerprinted.WithLabelValues(reason).Inc()
+		sessionID = session.Fingerprint(session.FingerprintInput{
+			ClientIP:    clientIP,
+			UserAgent:   payload.UserAgent,
+			ProjectSlug: record.ProjectSlug,
+			Environment: env,
+			At:          occurredAt,
+		})
 	}
 
 	// Extract UTM from URL if not provided directly.
@@ -109,11 +130,6 @@ func ProcessRecord(record spool.Record) (repository.Event, error) {
 	eventID, err := generateUUIDLocal()
 	if err != nil {
 		return repository.Event{}, fmt.Errorf("generate uuid: %w", err)
-	}
-
-	clientIP := record.ClientIP
-	if clientIP == "" {
-		clientIP = record.RemoteAddr
 	}
 
 	event := repository.Event{

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -336,3 +336,74 @@ func TestProcessRecord_KnownEnvironmentAliasIsCanonicalised(t *testing.T) {
 		t.Errorf("environment: want %q, got %q", environment.Staging, event.Environment)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// ProcessRecord — the fallback fingerprint must separate visitors (#226)
+// ---------------------------------------------------------------------------
+
+// fingerprintFor processes one clientless event and returns the session ID the
+// worker minted for it.
+func fingerprintFor(t *testing.T, mutate func(*spool.Record)) string {
+	t.Helper()
+	rec := makeRecord(EventPayload{Name: "pageview"})
+	// Behind an ingress every visitor shares the TCP peer address; the real
+	// client address arrives in a header and is carried on ClientIP.
+	rec.RemoteAddr = "10.42.0.9:38000"
+	rec.ClientIP = "203.0.113.5"
+	mutate(&rec)
+
+	event, err := ProcessRecord(rec)
+	if err != nil {
+		t.Fatalf("ProcessRecord: %v", err)
+	}
+	if len(event.SessionID) != 32 {
+		t.Fatalf("fingerprinted session ID should be 32 chars, got %d: %q", len(event.SessionID), event.SessionID)
+	}
+	return event.SessionID
+}
+
+func TestProcessRecord_FingerprintUsesClientIPNotProxyAddress(t *testing.T) {
+	// Two visitors, same ingress, different real addresses.
+	a := fingerprintFor(t, func(r *spool.Record) { r.ClientIP = "203.0.113.5" })
+	b := fingerprintFor(t, func(r *spool.Record) { r.ClientIP = "198.51.100.7" })
+
+	if a == b {
+		t.Fatal("two visitors behind one ingress share a session ID: the fingerprint is keyed on the proxy address, not the client's")
+	}
+}
+
+func TestProcessRecord_FingerprintFallsBackToRemoteAddr(t *testing.T) {
+	// Records spooled before ClientIP existed carry only RemoteAddr.
+	a := fingerprintFor(t, func(r *spool.Record) { r.ClientIP = ""; r.RemoteAddr = "203.0.113.5:1000" })
+	b := fingerprintFor(t, func(r *spool.Record) { r.ClientIP = ""; r.RemoteAddr = "198.51.100.7:1000" })
+
+	if a == b {
+		t.Error("with no ClientIP the fingerprint should still separate visitors by RemoteAddr")
+	}
+}
+
+func TestProcessRecord_FingerprintRotatesOverTime(t *testing.T) {
+	base := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+	at := func(ts time.Time) func(*spool.Record) {
+		return func(r *spool.Record) {
+			body, _ := json.Marshal(EventPayload{Name: "pageview", Timestamp: ts})
+			r.BodyBase64 = base64.StdEncoding.EncodeToString(body)
+		}
+	}
+
+	if a, b := fingerprintFor(t, at(base)), fingerprintFor(t, at(base.Add(time.Minute))); a != b {
+		t.Error("events a minute apart should stay in one session")
+	}
+	if a, b := fingerprintFor(t, at(base)), fingerprintFor(t, at(base.Add(90*24*time.Hour))); a == b {
+		t.Fatal("events three months apart share a session ID: the fingerprint never rotates, so one session grows without bound")
+	}
+}
+
+func TestProcessRecord_FingerprintIsScopedToProject(t *testing.T) {
+	a := fingerprintFor(t, func(r *spool.Record) { r.ProjectSlug = "site-one" })
+	b := fingerprintFor(t, func(r *spool.Record) { r.ProjectSlug = "site-two" })
+
+	if a == b {
+		t.Error("two projects sharing an ingress should not share a session ID (sessions.id is a global primary key)")
+	}
+}

--- a/sdks/js/README.md
+++ b/sdks/js/README.md
@@ -65,6 +65,7 @@ await analytics.flush();
 | `projectName` | `string` | — | Project identifier |
 | `flushInterval` | `number` | `5000` | Flush interval in ms |
 | `sessionTimeout` | `number` | `1800000` | Session idle timeout in ms |
+| `sessionMaxAge` | `number` | `86400000` | Hard cap on session lifetime in ms, regardless of activity |
 
 ### `analytics.page(properties?)`
 

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -30,6 +30,13 @@ export interface FunnelBarnOptions {
   flushInterval?: number;
   /** Session idle timeout in ms (default: 30 minutes) */
   sessionTimeout?: number;
+  /**
+   * Hard cap on how long one session ID may live, regardless of activity
+   * (default: 24 hours). The idle timeout alone never fires for a tab that
+   * stays busy — a kiosk, a dashboard left open, a page with a polling
+   * heartbeat — so without this a single session ID can run for months.
+   */
+  sessionMaxAge?: number;
   /** Enable session recording by default (default: false). Server config can override. */
   recording?: boolean;
   /** Recording chunk flush interval in ms (default: 10000) */
@@ -102,7 +109,9 @@ interface EventPayload {
 
 const SESSION_KEY = "funnelbarn_sid";
 const SESSION_EXPIRY_KEY = "funnelbarn_sid_exp";
+const SESSION_STARTED_KEY = "funnelbarn_sid_start";
 const SESSION_TIMEOUT_DEFAULT = 30 * 60 * 1000; // 30 min
+const SESSION_MAX_AGE_DEFAULT = 24 * 60 * 60 * 1000; // 24 h
 
 // Per-tab recording continuity. Persisted to sessionStorage on unload so a
 // full-page navigation resumes the same recording instead of starting a new
@@ -139,6 +148,7 @@ export class FunnelBarnClient {
   private readonly environment?: string;
   private readonly flushInterval: number;
   private readonly sessionTimeout: number;
+  private readonly sessionMaxAge: number;
 
   private queue: EventPayload[] = [];
   private flushTimer?: ReturnType<typeof setInterval>;
@@ -187,6 +197,7 @@ export class FunnelBarnClient {
     this.environment = options.environment;
     this.flushInterval = options.flushInterval ?? 5000;
     this.sessionTimeout = options.sessionTimeout ?? SESSION_TIMEOUT_DEFAULT;
+    this.sessionMaxAge = options.sessionMaxAge ?? SESSION_MAX_AGE_DEFAULT;
     this.recordingOptions = options;
 
     this.startFlushTimer();
@@ -430,20 +441,31 @@ export class FunnelBarnClient {
       localStorage.getItem(SESSION_EXPIRY_KEY) ?? "0",
       10
     );
+    const startedAt = parseInt(
+      localStorage.getItem(SESSION_STARTED_KEY) ?? "0",
+      10
+    );
 
-    if (now < expiry) {
+    // The idle window slides on every event, so on its own it never expires a
+    // session that keeps seeing activity. Age it out as well.
+    const idle = now >= expiry;
+    const tooOld = startedAt > 0 && now - startedAt >= this.sessionMaxAge;
+    const existing = localStorage.getItem(SESSION_KEY);
+
+    if (!idle && !tooOld && existing) {
       // Extend session expiry on activity.
       localStorage.setItem(
         SESSION_EXPIRY_KEY,
         String(now + this.sessionTimeout)
       );
-      return localStorage.getItem(SESSION_KEY) ?? this.generateSessionID();
+      return existing;
     }
 
     // New session.
     const id = this.generateSessionID();
     localStorage.setItem(SESSION_KEY, id);
     localStorage.setItem(SESSION_EXPIRY_KEY, String(now + this.sessionTimeout));
+    localStorage.setItem(SESSION_STARTED_KEY, String(now));
     return id;
   }
 

--- a/sdks/js/test/sdk.test.mjs
+++ b/sdks/js/test/sdk.test.mjs
@@ -131,6 +131,48 @@ describe('FunnelBarnClient', () => {
     assert.ok(sid1.length > 0);
   });
 
+  it('session ID rotates once the idle window has passed', async () => {
+    const client = new FunnelBarnClient({
+      apiKey: 'k',
+      endpoint: 'http://localhost:8080',
+      sessionTimeout: 20,
+    });
+    client.track('event1');
+    await client.flush();
+    await new Promise((r) => setTimeout(r, 40));
+    client.track('event2');
+    await client.flush();
+
+    const sid1 = JSON.parse(requests[0].options.body).session_id;
+    const sid2 = JSON.parse(requests[1].options.body).session_id;
+    assert.notEqual(sid1, sid2, 'an idle gap should start a new session');
+  });
+
+  it('session ID rotates at the max age even while activity continues', async () => {
+    // The idle window slides on every event, so a tab that never goes quiet
+    // would otherwise hold one session ID forever (#226).
+    const client = new FunnelBarnClient({
+      apiKey: 'k',
+      endpoint: 'http://localhost:8080',
+      sessionTimeout: 60_000,
+      sessionMaxAge: 30,
+    });
+
+    const ids = new Set();
+    for (let i = 0; i < 6; i++) {
+      client.track(`event${i}`);
+      await client.flush();
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    for (const req of requests) {
+      ids.add(JSON.parse(req.options.body).session_id);
+    }
+    assert.ok(
+      ids.size > 1,
+      'continuous activity past the max age must start a new session'
+    );
+  });
+
   it('posts to the correct endpoint URL', async () => {
     const client = new FunnelBarnClient({ apiKey: 'k', endpoint: 'http://example.com' });
     client.track('test');

--- a/site/src/content/docs/sdk-js.md
+++ b/site/src/content/docs/sdk-js.md
@@ -57,6 +57,7 @@ analytics.page();
 | `projectName` | `string` | — | Project identifier sent as `x-funnelbarn-project` header (events only; not used for recording) |
 | `flushInterval` | `number` | `5000` | How often (ms) the event queue is flushed |
 | `sessionTimeout` | `number` | `1800000` | Session idle timeout in ms (default 30 min) |
+| `sessionMaxAge` | `number` | `86400000` | Hard cap on session lifetime in ms, regardless of activity (default 24 h) |
 | `recording` | `boolean` | `false` | Enable session recording immediately on init (server config can also enable it) |
 | `recordingChunkMs` | `number` | `10000` | How often (ms) a recording chunk is flushed to the server |
 | `recordInclude` | `string[]` | — | URL path glob patterns to always record (e.g. `['/checkout/**']`) |
@@ -102,7 +103,9 @@ analytics.identify('');
 
 ## Sessions
 
-The SDK generates a random session ID and stores it in `localStorage` under `funnelbarn_sid`. Sessions expire after the `sessionTimeout` idle period. A new session ID is created when the previous one expires.
+The SDK generates a random session ID and stores it in `localStorage` under `funnelbarn_sid`. A new session ID is created when either bound is reached: the `sessionTimeout` idle period passes with no events, or the session reaches `sessionMaxAge` counted from when it started. The second bound matters for pages that never go quiet — a kiosk, a dashboard left open, anything with a polling heartbeat — because the idle window slides forward on every event and would otherwise never expire.
+
+If a client sends no session ID at all, the server derives an anonymous one from the visitor's IP prefix, user agent, project, and a 30-minute time window. It is a fallback: it cannot tell two visitors behind one NAT apart, and it splits a visit that straddles a window boundary into two sessions. Send your own session ID for accurate session counts.
 
 The session ID is sent with every event so FunnelBarn can group page views and custom events into sessions without requiring cookies.
 


### PR DESCRIPTION
## Summary

The 39,893-event session was not minted by a client. It came from the server.

When an event arrives without a usable `session_id`, `worker.ProcessRecord` derives one with `session.Fingerprint`. That function hashed three things — remote address, user agent, environment — and in production all three were constant, so it returned one session ID per environment, forever.

- **Remote address.** It hashed `record.RemoteAddr`, the TCP peer. Behind the ingress that is the proxy, identical for all 742 visitors. `record.ClientIP` already carried the real client address (resolved from `CF-Connecting-IP` / `X-Real-IP` / `X-Forwarded-For` at the ingest edge) and was sitting unused a few lines further down.
- **User agent.** Empty, per #227.
- **Environment.** Clients send none, and `environment.Normalize("")` returns `""` — which is also why production and test hostnames landed in one session.

So the hash reduced to `SHA256(ingressIP/24 + "||")`. One constant. 742 visitors, one session; the whole project's 41,204 events resolving to 3 sessions; and the August signature of 19,231 events under a single `user_id_hash` is the same collapse with only one logged-in visitor left in the window.

There was also no time component at all, so even with correct inputs a returning visitor would have stayed in one session from June to August.

## Changes

`session.Fingerprint` now takes a struct and hashes `ip | ua | project | env | window`:

- **Client IP, not the proxy.** `ProcessRecord` passes `record.ClientIP`, falling back to `RemoteAddr` for records spooled before that field existed.
- **A 30-minute time window**, so a fallback session is bounded even under continuous traffic. The window is absolute rather than idle-based because the fingerprint is stateless and `ProcessRecord` is deliberately DB-free; a visit that straddles a boundary counts as two sessions, which is the price of never minting one that runs for months. Documented on the constant.
- **Scoped to the project.** `sessions.id` is a global primary key, so two projects behind one ingress could previously collide.
- **`funnelbarn_sessions_fingerprinted_total{reason}`** counts events falling back to a fingerprint. A client that stops sending session IDs is now visible in hours instead of three months.

JS SDK: the idle window slid forward on every event, so a page that never goes quiet (kiosk, dashboard left open, polling heartbeat) held one ID indefinitely. Sessions now also end at `sessionMaxAge`, default 24h, counted from when the session started. Docs updated in the SDK README and `site/`.

## On the server-side guard

The issue suggested rejecting or re-minting a session ID once it exceeds a plausible event count or age. Now that the IDs turn out to have been server-minted, that guard would be treating the symptom: the fingerprint is bounded at the source, and a count-based guard needs a DB read per event in the ingest hot path. Left for epic #234 to decide, rather than added speculatively here.

## Testing

Three new worker tests fail on `main` with the exact production shape and pass here:

```
--- FAIL: TestProcessRecord_FingerprintUsesClientIPNotProxyAddress
    two visitors behind one ingress share a session ID
--- FAIL: TestProcessRecord_FingerprintRotatesOverTime
    events three months apart share a session ID
--- FAIL: TestProcessRecord_FingerprintIsScopedToProject
    two projects sharing an ingress should not share a session ID
```

Plus window boundary coverage in `internal/session` (stable within a window, rotates across one, three hours of continuous minute-by-minute activity yields more than one ID) and two JS SDK tests (idle rotation, and max-age rotation under continuous activity).

Run locally, all passing:

- [x] `go test -race -count=1 ./...`
- [x] `go vet ./...`, `staticcheck ./...`, `gofmt -l` on tracked files
- [x] `scripts/go-quality-gates.sh` (complexity / file length / duplication)
- [x] `cd web && npm test` (392 tests), `npm run lint`, `npm run lint:eslint` (0 errors)
- [x] `cd sdks/js && npm test` (33 tests)
- [x] `internal/session` 100% coverage, `internal/worker` above its floor

One note on `scripts/coverage-gate.py`: it reports `FAIL 27.59% (floor 34%) internal/geoip` on this machine. That is pre-existing and unrelated to this PR — unmodified `main` fails identically in a scratch worktree, and `internal/geoip` is untouched here.

My first explanation for it (that the CI runner has a GeoIP database this machine lacks) was wrong. CI measures `internal/geoip` at 32.00%, also below the 34% floor, and passes only because the ratchet allows a 2pp tolerance band. Fixed separately in #245.

Closes #226

https://claude.ai/code/session_012DF8mc7sCh1UyaLEzUiDwK
