### PR TITLE
test(geoip): cover LookupContext's address parsing and ratchet the floor

### DIFF
--- a/internal/geoip/geoip_test.go
+++ b/internal/geoip/geoip_test.go
@@ -1,6 +1,9 @@
 package geoip
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestOpen_NonexistentCityDBReturnsError(t *testing.T) {
 	l, err := Open("/no/such/geolite2-city.mmdb", "")
@@ -51,5 +54,35 @@ func TestClassifyASN(t *testing.T) {
 		if got := classifyASN(tc.org); got != tc.want {
 			t.Errorf("classifyASN(%q) = %q, want %q", tc.org, got, tc.want)
 		}
+	}
+}
+
+// LookupContext must reject an address it cannot parse before it dereferences
+// cityDB. Until this test existed the only Lookup calls were on a nil receiver,
+// so every statement past the nil check was untested and the ordering of the
+// two guards was load-bearing but unverified.
+func TestLookupContext_UnparseableAddressReturnsNilWithoutTouchingDB(t *testing.T) {
+	// No databases opened: reaching one would panic, which is the point.
+	l := &Lookup{}
+
+	for _, addr := range []string{
+		"",
+		"not-an-ip",
+		"example.com",
+		"example.com:443", // host:port splits, but the host is still not an IP
+		"1.2.3.4:80:90",   // SplitHostPort fails; the whole string is not an IP
+	} {
+		t.Run(addr, func(t *testing.T) {
+			if got := l.LookupContext(context.Background(), addr); got != nil {
+				t.Errorf("LookupContext(%q) = %v, want nil", addr, got)
+			}
+		})
+	}
+}
+
+func TestLookup_DelegatesToLookupContext(t *testing.T) {
+	l := &Lookup{}
+	if got := l.Lookup("not-an-ip"); got != nil {
+		t.Errorf("Lookup on an unparseable address = %v, want nil", got)
 	}
 }

--- a/scripts/coverage-baseline.txt
+++ b/scripts/coverage-baseline.txt
@@ -11,7 +11,7 @@ internal/config	77
 internal/domain	100
 internal/enrich	91
 internal/environment	100
-internal/geoip	34
+internal/geoip	50
 internal/ingest	72
 internal/middleware	100
 internal/repository	74


### PR DESCRIPTION
## Summary

Follow-up to a caveat I raised on #244: `scripts/coverage-gate.py` fails locally on `internal/geoip`. I originally wrote that off as "the CI runner must have a GeoIP database this machine doesn't." That was wrong, and the real reading is worse.

CI reports `internal/geoip` at **32.00% against a committed floor of 34%**, and the gate marks it **ok** — because the ratchet allows a `TOLERANCE_PP = 2.0` noise band. So the package has been sitting a single percentage point from failing the build for as long as that floor has been pinned, and it fails outright on a developer machine (27.59%, outside the band). The gate was absorbing a genuine coverage hole rather than reporting it.

## Why it was under-covered

Every `Lookup` call in the existing tests used a **nil receiver**:

```go
var l *Lookup
l.Lookup("1.2.3.4")   // returns at `if l == nil` — nothing below ever runs
```

So `LookupContext` measured 6.1%, and its entire body was untested. The half of that function that parses the address needs no MaxMind database at all.

## Changes

One test over `LookupContext` with a real (empty) `Lookup`, asserting that an address which is not an IP returns `nil` **before** `cityDB` is dereferenced. That ordering is load-bearing and was unverified: get it wrong and any malformed address is a nil-pointer panic in the ingest path. Cases cover an empty string, plain garbage, a bare hostname, `host:port` with a non-IP host, and a string `SplitHostPort` rejects outright.

Plus a one-liner that `Lookup` delegates to `LookupContext`.

`internal/geoip` 27.59% → **50.00%** locally. Floor ratcheted 34 → 50 in the same PR, per the convention in the gate's own header comment.

## What this does not do

`Open`'s success path, `Close`, and the body of `LookupContext` past the parse all need a real `.mmdb` fixture — either a vendored MaxMind test database or `mmdbwriter` as a test dependency. That is a bigger call about pulling binary fixtures into the repo, so I left it. The remaining 50% is that.

## Testing

- [x] `go test -race -count=1 ./...`
- [x] `python3 scripts/coverage-gate.py` — **passes locally for the first time**
- [x] `go vet ./...`, `gofmt -l` on tracked files
- [x] `scripts/go-quality-gates.sh`

I've pinned the floor at the local number (50). If CI measures higher, I'll bump it to match before merge.

https://claude.ai/code/session_012DF8mc7sCh1UyaLEzUiDwK