### PR TITLE
Fill in geo, device and environment on the events table (#227, #229)

### DIFF
--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -43,6 +43,21 @@ func Normalize(s string) string {
 	return Production
 }
 
+// NormalizeEvent maps an ingested event's environment onto a canonical value,
+// filing an absent one as production. Deployment config (Normalize) keeps ""
+// as "unset" because the API and the fail-closed start-up check both branch on
+// it, but an event has no such third state: the analytics filters compare
+// environment for equality, so an untagged event is invisible under every
+// filter including the "production" one the dashboard defaults to. Tagging it
+// production matches where those events actually came from — SDKs that predate
+// the environment field only ever ran in production.
+func NormalizeEvent(s string) string {
+	if canonical := Normalize(s); canonical != "" {
+		return canonical
+	}
+	return Production
+}
+
 // IsKnown reports whether s is a recognised environment alias. An unrecognised
 // value still normalises to Production rather than being rejected — dropping an
 // event over a typo is worse than mis-filing it — but callers use this to say

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -70,3 +70,28 @@ func TestCanonical(t *testing.T) {
 		}
 	}
 }
+
+func TestNormalizeEvent(t *testing.T) {
+	// An event with no environment is filed as production. Deployment config
+	// keeps "" (see TestNormalize) because the API branches on the unset state;
+	// an event has no such state and a blank one is invisible to every filter.
+	if got := NormalizeEvent(""); got != Production {
+		t.Errorf("NormalizeEvent(%q) = %q, want %q", "", got, Production)
+	}
+	if got := NormalizeEvent("   "); got != Production {
+		t.Errorf("NormalizeEvent(%q) = %q, want %q", "   ", got, Production)
+	}
+	// Everything else behaves exactly as Normalize does.
+	for _, s := range []string{"prod", "STG", "qa", "local", "feat-branch", "staging"} {
+		if got, want := NormalizeEvent(s), Normalize(s); got != want {
+			t.Errorf("NormalizeEvent(%q) = %q, want %q", s, got, want)
+		}
+	}
+	// And it always lands on a canonical value.
+	for _, s := range []string{"", "prod", "acc", "uat", "develop", "nonsense"} {
+		got := NormalizeEvent(s)
+		if Normalize(got) != got {
+			t.Errorf("NormalizeEvent(%q) = %q, which is not canonical", s, got)
+		}
+	}
+}

--- a/internal/ingest/handler.go
+++ b/internal/ingest/handler.go
@@ -257,6 +257,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ContentLength: int64(len(body)),
 		BodyBase64:    base64.StdEncoding.EncodeToString(body),
 		ProjectSlug:   projectSlug,
+		UserAgent:     r.Header.Get("User-Agent"),
 	}
 
 	select {

--- a/internal/ingest/handler_test.go
+++ b/internal/ingest/handler_test.go
@@ -306,3 +306,63 @@ func TestLogUnattributed_ThrottlesEscalation(t *testing.T) {
 		t.Error("expected a fresh escalation after the re-alert window elapsed")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// ServeHTTP — User-Agent capture
+// ---------------------------------------------------------------------------
+
+// A browser SDK posts over XHR and cannot put user_agent in the payload, so the
+// header is the only source of browser/os/device_type. Carry it on the spool
+// record for the worker to fall back to.
+func TestServeHTTP_RecordsUserAgentHeader(t *testing.T) {
+	sp := newTestSpool(t)
+	h := NewHandler(auth.New("mykey"), sp, 0)
+
+	const ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/124.0"
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(`{"name":"pageview"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(auth.HeaderAPIKey, "mykey")
+	req.Header.Set("x-funnelbarn-project", "my-site")
+	req.Header.Set("User-Agent", ua)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	select {
+	case rec := <-h.queue:
+		if rec.UserAgent != ua {
+			t.Errorf("record UserAgent: want %q, got %q", ua, rec.UserAgent)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no record enqueued")
+	}
+}
+
+// No User-Agent header leaves the field empty rather than inventing one.
+func TestServeHTTP_NoUserAgentHeaderLeavesFieldEmpty(t *testing.T) {
+	sp := newTestSpool(t)
+	h := NewHandler(auth.New("mykey"), sp, 0)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(`{"name":"pageview"}`))
+	req.Header.Set(auth.HeaderAPIKey, "mykey")
+	req.Header.Set("x-funnelbarn-project", "my-site")
+	req.Header.Del("User-Agent")
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	select {
+	case rec := <-h.queue:
+		if rec.UserAgent != "" {
+			t.Errorf("record UserAgent: want empty, got %q", rec.UserAgent)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no record enqueued")
+	}
+}

--- a/internal/repository/migration_backfill_test.go
+++ b/internal/repository/migration_backfill_test.go
@@ -1,0 +1,104 @@
+package repository
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/pressly/goose/v3"
+	_ "modernc.org/sqlite"
+)
+
+// openAtVersion opens a fresh SQLite database migrated up to (and including)
+// the given goose version, so a migration can be tested against rows that
+// existed before it ran.
+func openAtVersion(t *testing.T, version int64) *sql.DB {
+	t.Helper()
+	dsn := filepath.Join(t.TempDir(), "test.db") + "?_pragma=foreign_keys(1)&_pragma=busy_timeout(5000)"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	db.SetMaxOpenConns(1)
+
+	goose.SetBaseFS(migrations)
+	if err := goose.SetDialect("sqlite3"); err != nil {
+		t.Fatalf("goose dialect: %v", err)
+	}
+	goose.SetLogger(goose.NopLogger())
+	if err := goose.UpTo(db, "migrations", version); err != nil {
+		t.Fatalf("goose up to %d: %v", version, err)
+	}
+	return db
+}
+
+func mustExec(t *testing.T, db *sql.DB, query string, args ...any) {
+	t.Helper()
+	if _, err := db.Exec(query, args...); err != nil {
+		t.Fatalf("exec %q: %v", query, err)
+	}
+}
+
+func countRows(t *testing.T, db *sql.DB, query string, args ...any) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(query, args...).Scan(&n); err != nil {
+		t.Fatalf("query %q: %v", query, err)
+	}
+	return n
+}
+
+// 00031 files untagged events and sessions as production. Rows that already
+// carry an environment must be left exactly as they are.
+func TestMigration00031_BackfillsUntaggedEnvironment(t *testing.T) {
+	db := openAtVersion(t, 30)
+
+	mustExec(t, db, `INSERT INTO projects (id, name, slug) VALUES ('p1', 'P1', 'p1')`)
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at, environment)
+		VALUES ('e-blank', 'p1', 's-blank', 'pageview', 'i-blank', CURRENT_TIMESTAMP, '')`)
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at, environment)
+		VALUES ('e-staging', 'p1', 's-staging', 'pageview', 'i-staging', CURRENT_TIMESTAMP, 'staging')`)
+	mustExec(t, db, `INSERT INTO sessions (id, project_id, first_seen_at, last_seen_at, environment)
+		VALUES ('s-blank', 'p1', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '')`)
+	mustExec(t, db, `INSERT INTO sessions (id, project_id, first_seen_at, last_seen_at, environment)
+		VALUES ('s-staging', 'p1', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'staging')`)
+
+	if err := goose.UpTo(db, "migrations", 31); err != nil {
+		t.Fatalf("goose up to 31: %v", err)
+	}
+
+	if got := countRows(t, db, `SELECT COUNT(*) FROM events WHERE environment = ''`); got != 0 {
+		t.Errorf("untagged events after backfill: want 0, got %d", got)
+	}
+	if got := countRows(t, db, `SELECT COUNT(*) FROM sessions WHERE environment = ''`); got != 0 {
+		t.Errorf("untagged sessions after backfill: want 0, got %d", got)
+	}
+	if got := countRows(t, db, `SELECT COUNT(*) FROM events WHERE id = 'e-blank' AND environment = 'production'`); got != 1 {
+		t.Errorf("e-blank not filed as production")
+	}
+	if got := countRows(t, db, `SELECT COUNT(*) FROM events WHERE id = 'e-staging' AND environment = 'staging'`); got != 1 {
+		t.Errorf("e-staging environment was overwritten")
+	}
+	if got := countRows(t, db, `SELECT COUNT(*) FROM sessions WHERE id = 's-staging' AND environment = 'staging'`); got != 1 {
+		t.Errorf("s-staging environment was overwritten")
+	}
+}
+
+// The migration ships in the image and runs at every process start, so a
+// second application must be a no-op rather than re-tagging fresh rows.
+func TestMigration00031_IsIdempotent(t *testing.T) {
+	db := openAtVersion(t, 31)
+
+	mustExec(t, db, `INSERT INTO projects (id, name, slug) VALUES ('p1', 'P1', 'p1')`)
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at, environment)
+		VALUES ('e-dev', 'p1', 's-dev', 'pageview', 'i-dev', CURRENT_TIMESTAMP, 'development')`)
+
+	// Re-running the migration's Up body must not touch a tagged row.
+	mustExec(t, db, `UPDATE events   SET environment = 'production' WHERE environment = ''`)
+	mustExec(t, db, `UPDATE sessions SET environment = 'production' WHERE environment = ''`)
+
+	if got := countRows(t, db, `SELECT COUNT(*) FROM events WHERE id = 'e-dev' AND environment = 'development'`); got != 1 {
+		t.Errorf("re-running the backfill changed an already-tagged row")
+	}
+}

--- a/internal/repository/migrations/00031_ingest_enrichment_backfill.sql
+++ b/internal/repository/migrations/00031_ingest_enrichment_backfill.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- Events and sessions written before the ingest pipeline defaulted an absent
+-- environment carry environment = ''. Every analytics query filters with
+-- `(? = '' OR environment = ?)`, so those rows are invisible under the
+-- dashboard's default "production" filter and only reappear under "all".
+-- File them as production: the environment field postdates the SDKs that wrote
+-- them, and those SDKs only ever ran against production.
+--
+-- Idempotent: the predicate is the same one that selects the rows, so a re-run
+-- matches nothing. Scoped to environment = '' — no row with a real tag is
+-- touched.
+UPDATE events   SET environment = 'production' WHERE environment = '';
+UPDATE sessions SET environment = 'production' WHERE environment = '';
+
+-- +goose Down
+-- Not reversible: the original rows are indistinguishable from events that
+-- were genuinely tagged 'production' at ingest, so undoing the backfill would
+-- untag both. Left as a no-op rather than losing correct data.
+SELECT 1;

--- a/internal/spool/spool.go
+++ b/internal/spool/spool.go
@@ -29,6 +29,10 @@ type Record struct {
 	ContentLength int64     `json:"contentLength,omitempty"`
 	BodyBase64    string    `json:"bodyBase64"`
 	ProjectSlug   string    `json:"projectSlug,omitempty"`
+	// UserAgent is the request's User-Agent header, kept so the worker can fall
+	// back to it when the JSON payload carries no user_agent of its own. Without
+	// it, browser/os/device_type stay empty for every SDK that omits the field.
+	UserAgent string `json:"userAgent,omitempty"`
 }
 
 // cursor tracks the byte offset of the last successfully processed record.

--- a/internal/worker/persist_test.go
+++ b/internal/worker/persist_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/wiebe-xyz/funnelbarn/internal/geoip"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 )
 
@@ -121,5 +122,76 @@ func TestPersistEvent_RejectsEventWithoutProject(t *testing.T) {
 	}
 	if len(store.events) != 0 {
 		t.Errorf("expected no insert attempt, got %d events", len(store.events))
+	}
+}
+
+// The geo lookup used to land only on the session row, leaving
+// events.country_code empty. The country widgets group events, so they read
+// empty on every project until the event carries the code too.
+func TestPersistEvent_CopiesGeoCountryOntoEvent(t *testing.T) {
+	store := &fakeEventStore{}
+	event := repository.Event{
+		ID:         "evt-geo",
+		ProjectID:  "proj-geo",
+		SessionID:  "sess-geo",
+		Name:       "pageview",
+		IngestID:   "ingest-geo",
+		OccurredAt: time.Now().UTC(),
+	}
+
+	err := PersistEvent(context.Background(), store, event, &geoip.GeoResult{CountryCode: "NL", City: "Nijmegen"})
+	if err != nil {
+		t.Fatalf("PersistEvent: %v", err)
+	}
+	if len(store.events) != 1 {
+		t.Fatalf("want 1 event, got %d", len(store.events))
+	}
+	if store.events[0].CountryCode != "NL" {
+		t.Errorf("event country_code: want NL, got %q", store.events[0].CountryCode)
+	}
+	if store.sessions[0].CountryCode != "NL" {
+		t.Errorf("session country_code: want NL, got %q", store.sessions[0].CountryCode)
+	}
+}
+
+// A lookup that resolved nothing must not blank a country the payload already
+// carried.
+func TestPersistEvent_EmptyGeoLookupKeepsExistingCountry(t *testing.T) {
+	store := &fakeEventStore{}
+	event := repository.Event{
+		ID:          "evt-geo-keep",
+		ProjectID:   "proj-geo",
+		SessionID:   "sess-geo-keep",
+		Name:        "pageview",
+		IngestID:    "ingest-geo-keep",
+		CountryCode: "DE",
+		OccurredAt:  time.Now().UTC(),
+	}
+
+	if err := PersistEvent(context.Background(), store, event, &geoip.GeoResult{}); err != nil {
+		t.Fatalf("PersistEvent: %v", err)
+	}
+	if store.events[0].CountryCode != "DE" {
+		t.Errorf("event country_code: want DE, got %q", store.events[0].CountryCode)
+	}
+}
+
+// No geo lookup at all (collection disabled) leaves the event untouched.
+func TestPersistEvent_NilGeoLeavesCountryUnset(t *testing.T) {
+	store := &fakeEventStore{}
+	event := repository.Event{
+		ID:         "evt-geo-nil",
+		ProjectID:  "proj-geo",
+		SessionID:  "sess-geo-nil",
+		Name:       "pageview",
+		IngestID:   "ingest-geo-nil",
+		OccurredAt: time.Now().UTC(),
+	}
+
+	if err := PersistEvent(context.Background(), store, event, nil); err != nil {
+		t.Fatalf("PersistEvent: %v", err)
+	}
+	if store.events[0].CountryCode != "" {
+		t.Errorf("event country_code: want empty, got %q", store.events[0].CountryCode)
 	}
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -64,10 +64,22 @@ func ProcessRecord(record spool.Record) (repository.Event, error) {
 	// Normalize environment to a canonical value. An unrecognised value is
 	// filed as production rather than rejected — dropping an event over a typo
 	// is worse than mis-filing it — but say so once per distinct value, or
-	// "prodution" silently pollutes production reporting forever.
-	env := environment.Normalize(payload.Environment)
+	// "prodution" silently pollutes production reporting forever. An absent
+	// value is filed as production too: the analytics filters compare
+	// environment for equality, so an untagged event is invisible under every
+	// filter including the one the dashboard defaults to.
+	env := environment.NormalizeEvent(payload.Environment)
 	if !environment.IsKnown(payload.Environment) {
 		warnUnknownEnvironment(payload.Environment, env)
+	}
+
+	// The user agent. SDKs that post from a browser leave user_agent out of the
+	// payload (XHR cannot set it), so fall back to the request header the ingest
+	// handler captured. Without this fallback browser/os/device_type are empty
+	// on every such event and the audience widgets have nothing to group by.
+	ua := payload.UserAgent
+	if ua == "" {
+		ua = record.UserAgent
 	}
 
 	// The address the visitor actually came from. record.RemoteAddr is the TCP
@@ -89,7 +101,7 @@ func ProcessRecord(record spool.Record) (repository.Event, error) {
 		metrics.SessionsFingerprinted.WithLabelValues(reason).Inc()
 		sessionID = session.Fingerprint(session.FingerprintInput{
 			ClientIP:    clientIP,
-			UserAgent:   payload.UserAgent,
+			UserAgent:   ua,
 			ProjectSlug: record.ProjectSlug,
 			Environment: env,
 			At:          occurredAt,
@@ -118,7 +130,6 @@ func ProcessRecord(record spool.Record) (repository.Event, error) {
 	referrerDomain := enrich.ExtractReferrerDomain(payload.Referrer)
 
 	// Parse user agent.
-	ua := payload.UserAgent
 	var browser, osName, deviceType string
 	if ua != "" {
 		uaInfo := enrich.ParseUA(ua)
@@ -183,6 +194,15 @@ var ErrNoProject = errors.New("event has no project ID")
 func PersistEvent(ctx context.Context, store EventPersister, event repository.Event, geo *geoip.GeoResult) error {
 	if event.ProjectID == "" {
 		return fmt.Errorf("%w (ingest_id %s, event %q)", ErrNoProject, event.IngestID, event.Name)
+	}
+
+	// Carry the resolved country onto the event itself. The geo lookup was
+	// only ever written to the session row, so events.country_code stayed empty
+	// and the country widgets — which group events, not sessions — returned
+	// nothing. Only overwrite when the lookup produced something, so a payload
+	// that already carried a country keeps it.
+	if geo != nil && geo.CountryCode != "" {
+		event.CountryCode = geo.CountryCode
 	}
 
 	// Check idempotency: skip if already stored.

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -407,3 +407,80 @@ func TestProcessRecord_FingerprintIsScopedToProject(t *testing.T) {
 		t.Error("two projects sharing an ingress should not share a session ID (sessions.id is a global primary key)")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// User-Agent fallback to the request header
+// ---------------------------------------------------------------------------
+
+// A browser SDK posts over XHR and cannot set User-Agent on the payload, so
+// enrichment has to come off the header the ingest handler captured. Without
+// the fallback, browser/os/device_type are empty on every one of those events.
+func TestProcessRecord_UserAgentFallsBackToRequestHeader(t *testing.T) {
+	record := makeRecord(EventPayload{
+		Name:      "pageview",
+		SessionID: "abcdef1234567890abcdef1234567890",
+	})
+	record.UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/124.0"
+
+	event, err := ProcessRecord(record)
+	if err != nil {
+		t.Fatalf("ProcessRecord: %v", err)
+	}
+	if event.UserAgent != record.UserAgent {
+		t.Errorf("UserAgent: want %q, got %q", record.UserAgent, event.UserAgent)
+	}
+	if event.Browser == "" || event.OS == "" || event.DeviceType == "" {
+		t.Errorf("enrichment empty: browser=%q os=%q device=%q", event.Browser, event.OS, event.DeviceType)
+	}
+}
+
+// An explicit payload user_agent still wins — a server-side SDK forwarding a
+// visitor's UA must not be overwritten by its own HTTP client's header.
+func TestProcessRecord_PayloadUserAgentBeatsHeader(t *testing.T) {
+	const payloadUA = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Version/17.0 Mobile/15E148 Safari/604.1"
+	record := makeRecord(EventPayload{
+		Name:      "pageview",
+		SessionID: "abcdef1234567890abcdef1234567890",
+		UserAgent: payloadUA,
+	})
+	record.UserAgent = "funnelbarn-go/1.2.3"
+
+	event, err := ProcessRecord(record)
+	if err != nil {
+		t.Fatalf("ProcessRecord: %v", err)
+	}
+	if event.UserAgent != payloadUA {
+		t.Errorf("UserAgent: want payload UA %q, got %q", payloadUA, event.UserAgent)
+	}
+}
+
+// No UA anywhere leaves the enrichment fields empty rather than guessing.
+func TestProcessRecord_NoUserAgentAnywhere(t *testing.T) {
+	event, err := ProcessRecord(makeRecord(EventPayload{
+		Name:      "pageview",
+		SessionID: "abcdef1234567890abcdef1234567890",
+	}))
+	if err != nil {
+		t.Fatalf("ProcessRecord: %v", err)
+	}
+	if event.UserAgent != "" || event.Browser != "" || event.OS != "" || event.DeviceType != "" {
+		t.Errorf("expected empty enrichment, got ua=%q browser=%q os=%q device=%q",
+			event.UserAgent, event.Browser, event.OS, event.DeviceType)
+	}
+}
+
+// An event that arrives with no environment is filed as production, not left
+// blank: every analytics query compares environment for equality, so a blank
+// one is invisible under the dashboard's default filter.
+func TestProcessRecord_AbsentEnvironmentIsFiledAsProduction(t *testing.T) {
+	event, err := ProcessRecord(makeRecord(EventPayload{
+		Name:      "pageview",
+		SessionID: "abcdef1234567890abcdef1234567890",
+	}))
+	if err != nil {
+		t.Fatalf("ProcessRecord: %v", err)
+	}
+	if event.Environment != environment.Production {
+		t.Errorf("Environment: want %q, got %q", environment.Production, event.Environment)
+	}
+}


### PR DESCRIPTION
## Summary

Five audience widgets — `TopCountries`, `OverviewTopCountries`, `TopBrowsers`, `TopDevices`, `TopOSSystems` — return empty on every project because the event columns they group by are never written. Same bug shape three times: a field that should be set at ingest isn't.

Part of #234 (Wave A, PR 1). Closes #227 and #229.

## Changes

**User agent (#227).** Browser SDKs post over XHR and cannot set `user_agent` in the payload, so `payload.UserAgent` is empty and `enrich.ParseUA` — already wired in `worker.go` — never had an input. The ingest handler now carries the request's `User-Agent` header on the spool record and the worker falls back to it. An explicit payload `user_agent` still wins, so a server-side SDK forwarding a visitor's UA is unaffected. This unblocks `browser`, `os` and `device_type`.

**Country (#227).** The geo lookup only ever landed on the session row, leaving `events.country_code` empty. `PersistEvent` now copies the resolved country onto the event before `InsertEvent`, and leaves an existing value alone when the lookup resolves nothing.

**Environment (#229).** An event arriving with no environment is filed as `production` via a new `environment.NormalizeEvent`. Every analytics query filters with `(? = '' OR environment = ?)`, so untagged rows were invisible under the dashboard's default "production" filter and only reappeared under "all".

**Which of the two options in #229 was taken:** default at ingest, not widen the query filter. Widening the filter would have meant `production` also matching untagged rows, which silently makes "production" mean "production or unknown" for every query forever. Defaulting at write time keeps the filters honest, and the events in question genuinely came from production — the environment field postdates the SDKs that wrote them.

`environment.Normalize` is unchanged: deployment config still maps `""` to unset, because `internal/api/middleware.go` (rate-limit exemption) and `validateFailClosed` in `cmd/funnelbarn/main.go` both branch on that third state. Changing it globally would have made an unset `FUNNELBARN_ENVIRONMENT` refuse to start.

## Migration `00031_ingest_enrichment_backfill.sql`

```sql
UPDATE events   SET environment = 'production' WHERE environment = '';
UPDATE sessions SET environment = 'production' WHERE environment = '';
```

- **Idempotent** — the predicate is the same one that selects the rows, so a second run matches nothing. Covered by `TestMigration00031_IsIdempotent`.
- **Non-destructive outside its predicate** — scoped to `environment = ''`; a row with any real tag is untouched. Covered by `TestMigration00031_BackfillsUntaggedEnvironment`, which asserts a `staging` row survives.
- **Down is a no-op** — backfilled rows are indistinguishable from rows genuinely tagged `production` at ingest, so reversing would untag both.

**Expected row count:** the audit reported ~43,000 untagged events in production. To confirm against staging before the production tag:

```sql
SELECT COUNT(*) FROM events   WHERE environment = '';
SELECT COUNT(*) FROM sessions WHERE environment = '';
```

## Explicitly out of scope

`country_code` is **not** backfilled here. That backfill joins through `sessions`, whose project attribution is unreliable until #225 lands. It is Wave C in #234.

## Testing

- [x] `go test -race -count=1 ./...` — all packages pass
- [x] `python3 scripts/coverage-gate.py` — passes; `internal/ingest` 78.17%, `internal/worker` 78.15%, `internal/environment` 100%, global 87.64%
- [x] `bash scripts/go-quality-gates.sh` — complexity, file length and duplication all within their pinned thresholds
- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] New tests: UA header fallback, payload UA precedence, no-UA-anywhere, absent environment, geo country copied to event, empty geo preserving an existing country, nil geo, and both migration tests
- [x] No breaking changes — the migration only touches rows that were already unreachable

https://claude.ai/code/session_013ombByUEM1omcxHMpZhZzg