### PR TITLE
Stop storing bot recordings, and sweep the ones already stored (#228)

### DIFF
--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -615,6 +615,15 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 				} else if n > 0 {
 					slog.Info("purged unplayable recordings", "count", n)
 				}
+				// Bot recordings written before ingest started refusing them.
+				// The rows could be dropped by a migration, but their R2 chunk
+				// objects could not — deriving those keys needs the row.
+				if n, err := recordings.PurgeBotRecordings(purgeCtx); err != nil {
+					tracing.RecordError(purgeSpan, err)
+					slog.Error("purge bot recordings", "err", err)
+				} else if n > 0 {
+					slog.Info("purged bot recordings", "count", n)
+				}
 			}
 			purgeSpan.End()
 		case <-ticker.C:

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -103,6 +103,11 @@ var (
 		Help: "Total geo lookups that resolved a country.",
 	})
 
+	RecordingChunksDropped = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "funnelbarn_recording_chunks_dropped_total",
+		Help: "Recording chunks refused at ingest because the user agent is a bot.",
+	})
+
 	// External call instrumentation (R2 storage, IAMBarn, OIDC).
 	R2Requests = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "funnelbarn_r2_requests_total",

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -174,6 +174,7 @@ type RecordingRepo interface {
 	ListRecordings(ctx context.Context, projectID string, opts repository.RecordingListOpts) ([]repository.Recording, error)
 	ListOldRecordings(ctx context.Context, before time.Time) ([]repository.Recording, error)
 	ListBrokenRecordings(ctx context.Context) ([]repository.Recording, error)
+	ListBotRecordings(ctx context.Context) ([]repository.Recording, error)
 	DeleteRecording(ctx context.Context, id string) error
 	FlagEvaluationsForSession(ctx context.Context, sessionID, projectID string) ([]repository.FlagEvaluationEntry, error)
 	InsertTraceLinks(ctx context.Context, projectID, sessionID, recordingID string, links []repository.TraceLink) error

--- a/internal/repository/migrations/00032_drop_bot_recordings.sql
+++ b/internal/repository/migrations/00032_drop_bot_recordings.sql
@@ -1,0 +1,29 @@
+-- +goose Up
+-- Bot recordings (is_bot = 1) are 56% of the production recordings table, 91%
+-- of it our own crawler, every one with a full DOM snapshot. Ingest now refuses
+-- them, but the existing rows still have to go.
+--
+-- The ROWS are not deleted here. Each recording's rrweb chunks live in R2 under
+-- a key derived from (project_id, recording_id, chunk_index) — no SQL statement
+-- can reach them, and deleting the row destroys the only record of what those
+-- keys were, stranding ~6,000 gzipped DOM snapshots in object storage forever.
+-- RecordingService.PurgeBotRecordings does the delete instead: chunks from R2
+-- first, then the row. It runs on the maintenance cycle and is idempotent.
+--
+-- What this migration does is make that sweep cheap and clean up after the
+-- deletes that already happened without one.
+
+-- The sweep's lookup is `WHERE is_bot = 1`, run every maintenance cycle
+-- forever. Partial, so it indexes only the shrinking bot set and costs nothing
+-- once the backlog is drained.
+CREATE INDEX IF NOT EXISTS idx_recordings_bot ON recordings(is_bot) WHERE is_bot = 1;
+
+-- recording_traces has no foreign key to recordings, so every recording deleted
+-- by the retention purge (and by project deletes) left its trace rows behind.
+-- DeleteRecording now removes them; this clears the ones already stranded.
+-- Idempotent: the predicate is "parent row is gone", which a re-run re-checks.
+DELETE FROM recording_traces
+WHERE recording_id NOT IN (SELECT id FROM recordings);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_recordings_bot;

--- a/internal/repository/recording_traces_test.go
+++ b/internal/repository/recording_traces_test.go
@@ -154,3 +154,37 @@ func TestRecordingTraces_InsertEmptyNoop(t *testing.T) {
 
 	require.NoError(t, s.InsertTraceLinks(ctx, p.ID, "sess-x", "rec-x", nil))
 }
+
+// recording_traces has no foreign key to recordings, so nothing cascades when a
+// recording is deleted. DeleteRecording removes the links itself; without that,
+// every retention purge left its trace rows behind forever.
+func TestRecordingTraces_DeletedWithTheirRecording(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	p, err := s.CreateProject(ctx, "TraceCascade", "trace-cascade")
+	require.NoError(t, err)
+
+	start := time.Now().UTC().Truncate(time.Second)
+	for _, id := range []string{"rec-gone", "rec-stays"} {
+		rec := makeRecording(p.ID, "sess-"+id, start)
+		rec.ID = id
+		require.NoError(t, s.UpsertRecording(ctx, rec))
+		require.NoError(t, s.InsertTraceLinks(ctx, p.ID, "sess-"+id, id, []repository.TraceLink{
+			{TraceID: "trace-" + id, SpanID: "span1", URL: "https://example.com", OccurredAt: start},
+		}))
+	}
+
+	require.NoError(t, s.DeleteRecording(ctx, "rec-gone"))
+
+	gone, err := s.TracesForRecording(ctx, "rec-gone")
+	require.NoError(t, err)
+	assert.Empty(t, gone, "trace links outlived their recording")
+	_, found, err := s.LookupTrace(ctx, p.ID, "trace-rec-gone")
+	require.NoError(t, err)
+	assert.False(t, found, "a deleted recording is still reachable by trace_id")
+
+	stays, err := s.TracesForRecording(ctx, "rec-stays")
+	require.NoError(t, err)
+	assert.Len(t, stays, 1, "an unrelated recording's traces were deleted too")
+}

--- a/internal/repository/recordings.go
+++ b/internal/repository/recordings.go
@@ -205,8 +205,39 @@ func (s *Store) ListBrokenRecordings(ctx context.Context) ([]Recording, error) {
 	return out, rows.Err()
 }
 
-// DeleteRecording deletes a recording row by ID.
+// ListBotRecordings returns recordings flagged as bot traffic.
+// last_chunk_index/chunk_count are returned so the caller can delete the
+// matching R2 chunk objects, which no SQL delete can reach.
+func (s *Store) ListBotRecordings(ctx context.Context) ([]Recording, error) {
+	const q = `
+		SELECT id, project_id, last_chunk_index, chunk_count
+		FROM recordings
+		WHERE is_bot = 1
+		LIMIT 500`
+	rows, err := s.db.QueryContext(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Recording
+	for rows.Next() {
+		var r Recording
+		if err := rows.Scan(&r.ID, &r.ProjectID, &r.LastChunkIndex, &r.ChunkCount); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// DeleteRecording deletes a recording row by ID, along with its trace links.
+// recording_traces has no foreign key to recordings (it is written by the
+// ingest path before the recording row is guaranteed to exist), so nothing
+// cascades — every recording deleted before this left its trace rows behind.
 func (s *Store) DeleteRecording(ctx context.Context, id string) error {
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM recording_traces WHERE recording_id = ?`, id); err != nil {
+		return err
+	}
 	_, err := s.db.ExecContext(ctx, `DELETE FROM recordings WHERE id = ?`, id)
 	return err
 }

--- a/internal/service/interfaces.go
+++ b/internal/service/interfaces.go
@@ -169,6 +169,7 @@ type Recordings interface {
 	SessionsForPage(ctx context.Context, projectID, page string, from, to time.Time) ([]string, error)
 	PurgeOldRecordings(ctx context.Context, retentionDays int) error
 	PurgeBrokenRecordings(ctx context.Context) (int, error)
+	PurgeBotRecordings(ctx context.Context) (int, error)
 	PurgeProjectRecordings(ctx context.Context, projectID string) error
 	DeleteRecording(ctx context.Context, projectID, recordingID string) error
 	LookupTrace(ctx context.Context, projectID, traceID string) (repository.TraceLookup, bool, error)

--- a/internal/service/recordings.go
+++ b/internal/service/recordings.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/wiebe-xyz/funnelbarn/internal/metrics"
 	"github.com/wiebe-xyz/funnelbarn/internal/ports"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 )
@@ -56,6 +57,20 @@ func NewRecordingService(store ports.RecordingRepo, funnels ports.FunnelRepo, ev
 // IngestChunk compresses the rrweb event chunk, uploads it to R2, and
 // upserts the recording metadata row in SQLite.
 func (svc *RecordingService) IngestChunk(ctx context.Context, chunk RecordingChunk) error {
+	// Bot traffic is dropped here rather than stored and filtered out of the
+	// list query later. DetectBot already has the answer at the first chunk, and
+	// a crawler's replay has no value at any age — so there is no retention
+	// window: a window would still pay the R2 write and N days of storage for a
+	// recording nobody will ever open. Returning nil (not an error) keeps the
+	// SDK's 202 and stops it retrying a chunk we will never accept.
+	if DetectBot(chunk.UserAgent) {
+		metrics.RecordingChunksDropped.Inc()
+		slog.DebugContext(ctx, "recordings: dropping bot chunk",
+			"recording_id", chunk.RecordingID, "project_id", chunk.ProjectID,
+			"user_agent", chunk.UserAgent)
+		return nil
+	}
+
 	// Compress events.
 	compressed, err := gzipJSON(chunk.Events)
 	if err != nil {
@@ -148,6 +163,38 @@ func (svc *RecordingService) PurgeOldRecordings(ctx context.Context, retentionDa
 		}
 	}
 	return nil
+}
+
+// PurgeBotRecordings deletes recordings flagged as bot traffic from both R2 and
+// SQLite. Ingest refuses new ones, but 56% of the table predates that gate and
+// no SQL migration can reach the chunk objects in R2 — only this sweep knows how
+// to derive their keys, and it must do so before the rows that hold them are
+// gone. Idempotent and safe on every retention cycle; returns rows removed.
+//
+// maxBotPurgeBatches bounds one cycle so a large backlog is drained over
+// several passes rather than blocking the maintenance goroutine on 10k+ R2
+// deletes. 20 batches of 500 clears the known production backlog in one cycle.
+const maxBotPurgeBatches = 20
+
+func (svc *RecordingService) PurgeBotRecordings(ctx context.Context) (int, error) {
+	total := 0
+	for range maxBotPurgeBatches {
+		recs, err := svc.store.ListBotRecordings(ctx)
+		if err != nil {
+			return total, fmt.Errorf("recordings: list bot: %w", err)
+		}
+		if len(recs) == 0 {
+			return total, nil
+		}
+		for _, rec := range recs {
+			svc.deleteChunks(ctx, rec.ProjectID, rec.ID, rec.LastChunkIndex, rec.ChunkCount)
+			if err := svc.store.DeleteRecording(ctx, rec.ID); err != nil {
+				return total, fmt.Errorf("recordings: delete bot row %s: %w", rec.ID, err)
+			}
+			total++
+		}
+	}
+	return total, nil
 }
 
 // PurgeBrokenRecordings deletes recordings that can never play back (no full

--- a/internal/service/recordings_test.go
+++ b/internal/service/recordings_test.go
@@ -118,7 +118,9 @@ func TestRecordingService_IngestChunk(t *testing.T) {
 	assert.Equal(t, int64(10000), rec.DurationMs)
 }
 
-func TestRecordingService_IngestChunk_BotDetection(t *testing.T) {
+// A bot chunk is dropped outright: no R2 object, no metadata row. The caller
+// still gets a nil error so the SDK sees its 202 and does not retry.
+func TestRecordingService_IngestChunk_BotChunksAreDropped(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore(t)
 	storage := newMemStorage()
@@ -129,24 +131,59 @@ func TestRecordingService_IngestChunk_BotDetection(t *testing.T) {
 
 	svc := service.NewRecordingService(store, store, store, storage)
 
-	chunk := service.RecordingChunk{
-		RecordingID: "rec-bot-001",
-		SessionID:   "sess-bot-001",
-		ChunkIndex:  0,
-		Events:      json.RawMessage(`[]`),
-		StartedAt:   time.Now().UTC().Truncate(time.Second),
-		DurationMs:  1000,
-		ProjectSlug: "bot-test",
-		ProjectID:   p.ID,
-		UserAgent:   "Googlebot/2.1",
+	for _, ua := range []string{
+		"Googlebot/2.1",
+		"BrandtraceBot/1.0 (+https://brandtrace.net/bot)",
+		"Mozilla/5.0 (X11; Linux x86_64) HeadlessChrome/124.0.0.0",
+	} {
+		chunk := service.RecordingChunk{
+			RecordingID: "rec-bot-" + ua,
+			SessionID:   "sess-bot-001",
+			ChunkIndex:  0,
+			Events:      json.RawMessage(`[{"type":2,"data":{}}]`),
+			StartedAt:   time.Now().UTC().Truncate(time.Second),
+			DurationMs:  1000,
+			ProjectSlug: "bot-test",
+			ProjectID:   p.ID,
+			UserAgent:   ua,
+		}
+		require.NoError(t, svc.IngestChunk(ctx, chunk), "ua %q", ua)
+
+		_, err := store.GetRecording(ctx, chunk.RecordingID)
+		assert.Error(t, err, "bot recording %q was stored", ua)
 	}
 
-	require.NoError(t, svc.IngestChunk(ctx, chunk))
+	assert.Empty(t, storage.keys(), "bot chunks were uploaded to object storage")
+}
 
-	rec, err := store.GetRecording(ctx, "rec-bot-001")
+// A human chunk with the same shape still lands, so the gate is not swallowing
+// everything.
+func TestRecordingService_IngestChunk_HumanChunkStillStored(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	storage := newMemStorage()
+
+	projSvc := service.NewProjectService(store)
+	p, err := projSvc.CreateProject(ctx, "Human Test", "human-test")
 	require.NoError(t, err)
-	assert.True(t, rec.IsBot)
-	assert.Equal(t, "desktop", rec.DeviceType)
+
+	svc := service.NewRecordingService(store, store, store, storage)
+	require.NoError(t, svc.IngestChunk(ctx, service.RecordingChunk{
+		RecordingID: "rec-human-001",
+		SessionID:   "sess-human-001",
+		ChunkIndex:  0,
+		Events:      json.RawMessage(`[{"type":2,"data":{}}]`),
+		StartedAt:   time.Now().UTC().Truncate(time.Second),
+		DurationMs:  1000,
+		ProjectSlug: "human-test",
+		ProjectID:   p.ID,
+		UserAgent:   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/124.0",
+	}))
+
+	rec, err := store.GetRecording(ctx, "rec-human-001")
+	require.NoError(t, err)
+	assert.False(t, rec.IsBot)
+	assert.Len(t, storage.keys(), 1)
 }
 
 func TestRecordingService_IngestChunk_SnapshotDetection(t *testing.T) {
@@ -478,4 +515,75 @@ func TestDetectBot(t *testing.T) {
 			assert.Equal(t, tc.isBot, service.DetectBot(tc.ua))
 		})
 	}
+}
+
+// The 56% of the production recordings table that predates the ingest gate has
+// to be swept, and the sweep is the only thing that can reach the R2 chunk
+// objects — a SQL delete would strand them.
+func TestRecordingService_PurgeBotRecordings(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	storage := newMemStorage()
+
+	projSvc := service.NewProjectService(store)
+	p, err := projSvc.CreateProject(ctx, "PurgeBot", "purgebot")
+	require.NoError(t, err)
+
+	svc := service.NewRecordingService(store, store, store, storage)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// A human recording, ingested normally — it must survive.
+	require.NoError(t, svc.IngestChunk(ctx, service.RecordingChunk{
+		RecordingID: "rec-human", SessionID: "sess-human", ChunkIndex: 0,
+		Events:    json.RawMessage(`[{"type":2,"data":{}}]`),
+		StartedAt: now, DurationMs: 1000, ProjectSlug: "purgebot", ProjectID: p.ID, UserAgent: "Mozilla/5.0",
+	}))
+
+	// Bot recordings as they exist today: written before the ingest gate, with
+	// their chunks already in object storage. Ingest refuses these now, so they
+	// have to be seeded directly.
+	ended := now.Add(time.Second)
+	for _, id := range []string{"rec-bot-a", "rec-bot-b"} {
+		require.NoError(t, store.UpsertRecording(ctx, repository.Recording{
+			ID: id, ProjectID: p.ID, SessionID: "sess-" + id,
+			FirstChunkIndex: 0, LastChunkIndex: 1, ChunkCount: 2,
+			HasSnapshot: true, DurationMs: 1000,
+			StartedAt: now, EndedAt: &ended,
+			UserAgent: "BrandtraceBot/1.0 (+https://brandtrace.net/bot)",
+			IsBot:     true,
+		}))
+		require.NoError(t, storage.Put(ctx, "recordings/"+p.ID+"/"+id+"/00000.json.gz", []byte("chunk-0")))
+		require.NoError(t, storage.Put(ctx, "recordings/"+p.ID+"/"+id+"/00001.json.gz", []byte("chunk-1")))
+	}
+	require.NoError(t, store.InsertTraceLinks(ctx, p.ID, "sess-rec-bot-a", "rec-bot-a", []repository.TraceLink{
+		{TraceID: "trace-bot-a", SpanID: "span-1", URL: "https://example.com", OccurredAt: now},
+	}))
+
+	n, err := svc.PurgeBotRecordings(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+
+	for _, id := range []string{"rec-bot-a", "rec-bot-b"} {
+		_, err := store.GetRecording(ctx, id)
+		assert.Error(t, err, "bot recording %s should be deleted", id)
+	}
+	_, err = store.GetRecording(ctx, "rec-human")
+	assert.NoError(t, err, "human recording must be preserved")
+
+	// Chunk objects go with the rows, and the human recording's stay.
+	for _, k := range storage.keys() {
+		assert.NotContains(t, k, "rec-bot-", "bot chunks should be purged from object storage")
+	}
+	assert.Len(t, storage.keys(), 1)
+
+	// Trace links follow the recording — recording_traces has no FK, so nothing
+	// cascades and they would otherwise be stranded.
+	links, err := store.TracesForRecording(ctx, "rec-bot-a")
+	require.NoError(t, err)
+	assert.Empty(t, links, "trace links should be deleted with the recording")
+
+	// Idempotent: a second cycle finds nothing.
+	n2, err := svc.PurgeBotRecordings(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n2)
 }


### PR DESCRIPTION
## Summary

`DetectBot` already ran at write time and set `recordings.is_bot` correctly, but the flag was only ever consulted as a filter on the recordings **list** query. Every crawler session was still persisted in full — rrweb DOM snapshot, chunk objects and all. In production that is **5,778 of 10,250 recordings (56%)**, 91% of them our own `BrandtraceBot`, every one with `has_snapshot = 1`.

Part of #234 (Wave A, PR 2). Closes #228.

## Changes

**Ingest refuses bot chunks.** `IngestChunk` now checks `DetectBot(chunk.UserAgent)` before the gzip, before the R2 `Put`, and before `UpsertRecording`, so neither store pays for the chunk. It returns `nil` rather than an error: the SDK keeps its 202 and does not retry a chunk we will never accept. Drops are counted in `funnelbarn_recording_chunks_dropped_total` and logged at debug.

**Existing rows are swept, not migrated away.** `RecordingService.PurgeBotRecordings` runs on the 24h maintenance cycle next to `PurgeBrokenRecordings`, in batches of 500 up to 10k per cycle.

**`DeleteRecording` now removes trace links.** `recording_traces` has no foreign key to `recordings` (it is written by the ingest path before the recording row is guaranteed to exist), so nothing cascaded and every recording ever deleted by the retention purge left its trace rows behind. Found while deleting 5,778 rows through that path.

## Two decisions the issue asked to be stated

**1. Drop outright, no retention window.** A crawler replay has no value at any age, and a window would still pay the R2 write plus N days of storage for a recording nobody will open. `is_bot` is still computed, so anything already written stays identifiable — which is what the sweep keys on. The upstream half of the issue's fix (`BrandtraceBot` and e2e runs not loading the recorder at all, worth ~5,700 of the 5,778) is a change to the crawler and the e2e config, not to this repo.

**2. The migration does not delete the rows.** This is a deliberate departure from the epic's sketch. Each recording's chunks live in R2 under a key derived from `(project_id, recording_id, chunk_index)`. No SQL statement can reach an object store, and deleting the row destroys the only record of what those keys were — a `DELETE FROM recordings WHERE is_bot = 1` would clear 56% of the table and strand ~6,018 gzipped DOM snapshots in R2 permanently, where nothing would ever find them again. The Go sweep is the only thing that can delete both sides, and it has to read the row to do it.

The cost is timing: rows go on the first maintenance tick after rollout rather than at process start. Both are idempotent, so the counts can still be confirmed on staging — just after the cycle rather than immediately.

## Migration `00032_drop_bot_recordings.sql`

Two statements, neither destructive to anything reachable:

```sql
CREATE INDEX IF NOT EXISTS idx_recordings_bot ON recordings(is_bot) WHERE is_bot = 1;

DELETE FROM recording_traces
WHERE recording_id NOT IN (SELECT id FROM recordings);
```

- The partial index serves the sweep's `WHERE is_bot = 1` lookup, which now runs every cycle forever. Partial, so it covers only the shrinking bot set and costs nothing once drained.
- The `DELETE` removes trace rows whose recording is already gone — rows no query can reach, since every read path joins through `recordings`. **Idempotent**: the predicate is "parent row is gone", re-checked on each run. Down drops the index; the orphan delete is not reversed because the rows were already unreachable.

**Row counts to confirm on staging before the production tag:**

```sql
-- swept by PurgeBotRecordings (expected ~5,778, ~6,018 chunks)
SELECT COUNT(*), SUM(chunk_count) FROM recordings WHERE is_bot = 1;
-- cleared by the migration
SELECT COUNT(*) FROM recording_traces WHERE recording_id NOT IN (SELECT id FROM recordings);
```

After a maintenance cycle on staging, the first query should return 0.

## Testing

- [x] `go test -race -count=1 ./...` — all packages pass
- [x] `python3 scripts/coverage-gate.py` — passes; `internal/service` 77.15%, `internal/repository` 78.39%, global 87.56%
- [x] `bash scripts/go-quality-gates.sh` — within pinned thresholds
- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] Rewrote `TestRecordingService_IngestChunk_BotDetection`, which asserted the old behaviour, into `..._BotChunksAreDropped` (three UAs: Googlebot, BrandtraceBot, HeadlessChrome; asserts no row and no R2 object) plus `..._HumanChunkStillStored` so the gate is not swallowing everything
- [x] `TestRecordingService_PurgeBotRecordings` — seeds bot rows with chunks and a trace link, asserts rows, chunk objects and trace links all go, a human recording survives, and a second run is a no-op
- [x] `TestRecordingTraces_DeletedWithTheirRecording` — covers the missing cascade directly
- [x] Behaviour change worth knowing: a project whose traffic is entirely bots will stop producing recordings. That is the intent (project A produces 4,987 recordings against 493 analytics events), but it will look like recording broke if you are watching that project.

https://claude.ai/code/session_013ombByUEM1omcxHMpZhZzg