### PR TITLE
Record every flag evaluation, not just auto flags returning DISABLED (#233)

### DIFF
--- a/internal/repository/flags.go
+++ b/internal/repository/flags.go
@@ -159,8 +159,11 @@ func (s *Store) CountAutoFlags(ctx context.Context, projectID string) (int, erro
 	return n, nil
 }
 
-// TouchFlagEvaluated records that an auto flag was just evaluated, so the
-// retention sweep can tell live unconfigured flags from abandoned ones.
+// TouchFlagEvaluated records that a flag was just evaluated, so the retention
+// sweep can tell live flags from abandoned ones and the dashboard can show when
+// a flag was last in service. Called for every origin: it used to be reached
+// only for origin='auto', which left the busiest flags reading as
+// never-evaluated.
 func (s *Store) TouchFlagEvaluated(ctx context.Context, flagID string) error {
 	_, err := s.db.ExecContext(ctx, `UPDATE feature_flags SET last_evaluated_at = CURRENT_TIMESTAMP WHERE id = ?`, flagID)
 	return err

--- a/internal/service/flags.go
+++ b/internal/service/flags.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -101,10 +102,18 @@ const DefaultConfigCacheTTL = 60 * time.Second
 type FlagService struct {
 	store          ports.FlagRepo
 	configCacheTTL time.Duration
+
+	// touchedMu guards the last_evaluated_at write throttle.
+	touchedMu sync.Mutex
+	touchedAt map[string]time.Time
 }
 
 func NewFlagService(store ports.FlagRepo) *FlagService {
-	return &FlagService{store: store, configCacheTTL: DefaultConfigCacheTTL}
+	return &FlagService{
+		store:          store,
+		configCacheTTL: DefaultConfigCacheTTL,
+		touchedAt:      make(map[string]time.Time),
+	}
 }
 
 // WithConfigCacheTTL overrides the cache hint returned for config flags.
@@ -358,12 +367,13 @@ func buildAutoFlag(projectID, flagKey string, defaultValue any, kind string) rep
 func (svc *FlagService) EvaluateOrRegisterFlag(ctx context.Context, projectID, flagKey string, evalContext map[string]any, defaultValue any, maxAuto int, kind string) (FlagEvalResult, error) {
 	res, err := svc.EvaluateFlag(ctx, projectID, flagKey, evalContext)
 	if err == nil {
-		// Keep auto, still-unconfigured flags alive in the retention sweep while
-		// they're actively evaluated. DISABLED covers inactive (auto) and paused
-		// (manual, never pruned) flags; touchIfAuto filters to origin='auto'.
-		if res.Reason == "DISABLED" {
-			svc.touchIfAuto(projectID, flagKey)
-		}
+		// Record that the flag was evaluated. This used to fire only for
+		// origin='auto' flags returning DISABLED, which is the intersection of
+		// two gates that between them excluded every flag actually in service:
+		// a live manual flag returns a real reason, not DISABLED, and would be
+		// filtered on origin anyway. last_evaluated_at therefore marked the
+		// flags nobody used and left the busy ones reading as never-evaluated.
+		svc.touchEvaluated(projectID, flagKey)
 		return res, nil
 	}
 	if !errors.Is(err, sql.ErrNoRows) {
@@ -381,17 +391,59 @@ func (svc *FlagService) EvaluateOrRegisterFlag(ctx context.Context, projectID, f
 		// Still hand the caller its default so the SDK is unaffected.
 		return FlagEvalResult{Value: defaultValue, Variant: "default", Reason: "DISABLED", FlagKey: flagKey}, nil
 	}
-	// Re-evaluate now that the inert flag exists (returns default, reason DISABLED).
-	return svc.EvaluateFlag(ctx, projectID, flagKey, evalContext)
+	// Re-evaluate now that the inert flag exists (returns default, reason
+	// DISABLED). Record this evaluation too: the flag is brand new, so the
+	// sweep's COALESCE would fall back to created_at either way, but leaving it
+	// null here means a flag auto-registered and then evaluated once a day
+	// keeps reading as never-evaluated.
+	res, err = svc.EvaluateFlag(ctx, projectID, flagKey, evalContext)
+	if err == nil {
+		svc.touchEvaluated(projectID, flagKey)
+	}
+	return res, err
 }
 
-// touchIfAuto best-effort bumps last_evaluated_at for an auto flag, off the
-// request path so it never adds latency or fails the evaluation.
-func (svc *FlagService) touchIfAuto(projectID, flagKey string) {
+// touchInterval throttles the last_evaluated_at write to at most one per flag
+// per minute. The gate it replaces was an origin filter, which limited write
+// amplification by excluding the flags that generate the most evaluations —
+// exactly the ones the column needs to be right about. A time throttle applies
+// the same concern uniformly: staleness is measured in days, so a minute's
+// resolution costs nothing and a flag served a thousand times a second still
+// produces one write per minute.
+const touchInterval = time.Minute
+
+// maxTrackedTouches bounds the throttle map. Flags per instance are few (tens),
+// but auto-registration can mint them, so the map is dropped rather than grown
+// without limit; the only cost of losing it is one extra write per flag.
+const maxTrackedTouches = 4096
+
+// shouldTouch reports whether this flag's last_evaluated_at is due for a write,
+// recording the decision so the next evaluation within touchInterval skips it.
+func (svc *FlagService) shouldTouch(projectID, flagKey string, now time.Time) bool {
+	key := projectID + "\x00" + flagKey
+	svc.touchedMu.Lock()
+	defer svc.touchedMu.Unlock()
+	if last, ok := svc.touchedAt[key]; ok && now.Sub(last) < touchInterval {
+		return false
+	}
+	if len(svc.touchedAt) >= maxTrackedTouches {
+		svc.touchedAt = make(map[string]time.Time, maxTrackedTouches)
+	}
+	svc.touchedAt[key] = now
+	return true
+}
+
+// touchEvaluated best-effort bumps last_evaluated_at for any flag, whatever its
+// origin or evaluation reason, off the request path so it never adds latency or
+// fails the evaluation.
+func (svc *FlagService) touchEvaluated(projectID, flagKey string) {
+	if !svc.shouldTouch(projectID, flagKey, time.Now()) {
+		return
+	}
 	go func() {
 		ctx := context.Background()
 		f, err := svc.store.FlagByKey(ctx, projectID, flagKey)
-		if err != nil || f.Origin != "auto" {
+		if err != nil {
 			return
 		}
 		if err := svc.store.TouchFlagEvaluated(ctx, f.ID); err != nil {

--- a/internal/service/flags_test.go
+++ b/internal/service/flags_test.go
@@ -640,3 +640,89 @@ func TestEvaluateOrRegisterFlag_HonoursDeclaredKind(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, repository.FlagKindExperiment, other.Kind)
 }
+
+// The two flags responsible for every evaluation in production are manual and
+// active, so they returned a real reason (not DISABLED) from an origin the
+// touch filtered out — and read as never-evaluated forever.
+func TestEvaluateOrRegisterFlag_TouchesLiveManualFlag(t *testing.T) {
+	store := mock.New()
+	svc := service.NewFlagService(store)
+	ctx := context.Background()
+
+	f := createTestFlag(t, svc, "proj-1", "iambarn-enabled",
+		map[string]any{"on": true, "off": false},
+		map[string]int{"on": 100}, "off")
+	require.Equal(t, "manual", f.Origin)
+	require.Nil(t, f.LastEvaluatedAt)
+
+	res, err := svc.EvaluateOrRegisterFlag(ctx, "proj-1", "iambarn-enabled",
+		map[string]any{"targeting_key": "device-1"}, false, 100, "")
+	require.NoError(t, err)
+	require.NotEqual(t, "DISABLED", res.Reason, "an active flag returns a real reason")
+
+	// The touch is deliberately off the request path, so wait for it.
+	require.Eventually(t, func() bool {
+		got, err := store.FlagByID(ctx, f.ID)
+		return err == nil && got.LastEvaluatedAt != nil
+	}, 2*time.Second, 5*time.Millisecond, "last_evaluated_at was never set for a live manual flag")
+}
+
+// Auto flags still get their touch — the retention sweep depends on it.
+func TestEvaluateOrRegisterFlag_StillTouchesAutoFlag(t *testing.T) {
+	store := mock.New()
+	svc := service.NewFlagService(store)
+	ctx := context.Background()
+
+	_, err := svc.EvaluateOrRegisterFlag(ctx, "proj-1", "anon_qr_limit",
+		map[string]any{"targeting_key": "device-1"}, float64(3), 100, "")
+	require.NoError(t, err)
+
+	flags, err := svc.ListFlags(ctx, "proj-1")
+	require.NoError(t, err)
+	require.Len(t, flags, 1)
+	require.Equal(t, "auto", flags[0].Origin)
+
+	require.Eventually(t, func() bool {
+		got, err := store.FlagByID(ctx, flags[0].ID)
+		return err == nil && got.LastEvaluatedAt != nil
+	}, 2*time.Second, 5*time.Millisecond, "last_evaluated_at was never set for an auto flag")
+}
+
+// A flag evaluated repeatedly inside the throttle window produces one write,
+// not one per evaluation.
+func TestEvaluateOrRegisterFlag_TouchIsThrottled(t *testing.T) {
+	store := mock.New()
+	svc := service.NewFlagService(store)
+	ctx := context.Background()
+
+	f := createTestFlag(t, svc, "proj-1", "busy-flag",
+		map[string]any{"on": true, "off": false},
+		map[string]int{"on": 100}, "off")
+
+	_, err := svc.EvaluateOrRegisterFlag(ctx, "proj-1", "busy-flag",
+		map[string]any{"targeting_key": "device-1"}, false, 100, "")
+	require.NoError(t, err)
+
+	var first time.Time
+	require.Eventually(t, func() bool {
+		got, err := store.FlagByID(ctx, f.ID)
+		if err != nil || got.LastEvaluatedAt == nil {
+			return false
+		}
+		first = *got.LastEvaluatedAt
+		return true
+	}, 2*time.Second, 5*time.Millisecond)
+
+	// Every further evaluation in this window must be skipped before the
+	// goroutine is even started, so the stored timestamp cannot move.
+	for range 50 {
+		_, err := svc.EvaluateOrRegisterFlag(ctx, "proj-1", "busy-flag",
+			map[string]any{"targeting_key": "device-1"}, false, 100, "")
+		require.NoError(t, err)
+	}
+	got, err := store.FlagByID(ctx, f.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.LastEvaluatedAt)
+	require.True(t, got.LastEvaluatedAt.Equal(first),
+		"throttled evaluations still wrote: %v != %v", *got.LastEvaluatedAt, first)
+}

--- a/internal/service/flags_touch_internal_test.go
+++ b/internal/service/flags_touch_internal_test.go
@@ -1,0 +1,55 @@
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+// The throttle replaces an origin filter as the defence against write
+// amplification, so it has to hold on its own: one write per flag per minute,
+// independently per flag, and never a permanent lockout.
+func TestShouldTouch_ThrottlesPerFlagPerInterval(t *testing.T) {
+	svc := NewFlagService(nil)
+	base := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+
+	if !svc.shouldTouch("proj-1", "flag-a", base) {
+		t.Fatal("first evaluation should write")
+	}
+	if svc.shouldTouch("proj-1", "flag-a", base.Add(time.Second)) {
+		t.Error("second evaluation inside the interval should be skipped")
+	}
+	if svc.shouldTouch("proj-1", "flag-a", base.Add(touchInterval-time.Nanosecond)) {
+		t.Error("an evaluation just under the interval should be skipped")
+	}
+	if !svc.shouldTouch("proj-1", "flag-a", base.Add(touchInterval)) {
+		t.Error("an evaluation at the interval should write again")
+	}
+
+	// A different flag has its own budget.
+	if !svc.shouldTouch("proj-1", "flag-b", base.Add(time.Second)) {
+		t.Error("a different flag key should not be throttled by flag-a")
+	}
+	// So does the same key in a different project — the throttle must not let
+	// one project suppress another's writes.
+	if !svc.shouldTouch("proj-2", "flag-a", base.Add(time.Second)) {
+		t.Error("a different project should not be throttled by proj-1")
+	}
+}
+
+// The throttle map is bounded, and dropping it costs at most one extra write.
+func TestShouldTouch_BoundsTheThrottleMap(t *testing.T) {
+	svc := NewFlagService(nil)
+	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+
+	for i := range maxTrackedTouches + 10 {
+		if !svc.shouldTouch("proj-1", "flag-"+string(rune('a'+i%26))+string(rune(i)), now) {
+			t.Fatalf("distinct flag %d should write", i)
+		}
+	}
+	svc.touchedMu.Lock()
+	size := len(svc.touchedAt)
+	svc.touchedMu.Unlock()
+	if size > maxTrackedTouches {
+		t.Errorf("throttle map grew to %d, past the %d cap", size, maxTrackedTouches)
+	}
+}


### PR DESCRIPTION
## Summary

`feature_flags.last_evaluated_at` marked the flags nobody used and ignored the ones in service. `iambarn-enabled` and `anon-free-generations` account for **all 1,166 flag evaluations in the production database**, and both read as never-evaluated.

Part of #234 (Wave A, PR 4). Closes #233.

## The gate was two gates, not one

The issue names the origin filter. There is a second one in front of it, and either alone was enough to exclude every flag in service:

```go
if res.Reason == "DISABLED" {     // an ACTIVE flag returns a real reason
    svc.touchIfAuto(projectID, flagKey)   // and this filters to origin == "auto"
}
```

A live manual flag fails both tests. `iambarn-enabled` is `manual` and `active`, so it never got past the first line, and would have been filtered on origin if it had. Removing only the origin gate would have left the bug in place, which is why this PR removes both.

## Changes

- Every successful evaluation records the flag, whatever its origin or reason. `touchIfAuto` becomes `touchEvaluated`.
- The evaluation that follows an auto-registration is recorded too. Previously that path returned `EvaluateFlag` directly and skipped the touch; `created_at` covered for it via the sweep's `COALESCE`, but a flag auto-registered and then evaluated once a day still read as never-evaluated.
- Write amplification, which was the origin gate's job, is now handled uniformly: at most one write per flag per minute, decided in memory before the goroutine is started. Staleness is measured in days, so a minute's resolution costs nothing, and a flag served a thousand times a second produces one write per minute rather than a thousand. The throttle map is bounded at 4096 entries and dropped wholesale when full — the only cost of losing it is one extra write per flag.

## On the blast radius

The issue says "depending on what that sweep does, a live flag could be flagged for cleanup or removal". It could not: `PurgeStaleAutoFlags` deletes only `origin = 'auto' AND status = 'inactive'`, so a manual flag was never a deletion candidate. The damage is narrower but still real — the column cannot answer "is this flag still in use" for any flag that is, which is the only question it exists to answer.

## Not included

The issue's two adjacent observations — no flag has a `conversion_event` set, and `ab_tests` has 0 rows — are a product question about whether `flag_kind` should default to `experiment` at all. That is a different change from this one-line gate and does not belong in the same diff.

## Testing

- [x] `go test -race -count=1 ./...` — all packages pass
- [x] `python3 scripts/coverage-gate.py` — passes, global 87.60%
- [x] `bash scripts/go-quality-gates.sh` — within pinned thresholds
- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `TestShouldTouch_ThrottlesPerFlagPerInterval` — deterministic, injected clock: writes at the boundary, skips inside it, and is independent per flag key and per project (so one project cannot suppress another's writes)
- [x] `TestShouldTouch_BoundsTheThrottleMap` — the map never exceeds its cap
- [x] `TestEvaluateOrRegisterFlag_TouchesLiveManualFlag` — reproduces the production case: manual + active, real reason, previously never touched
- [x] `TestEvaluateOrRegisterFlag_StillTouchesAutoFlag` — the retention sweep's input is not regressed
- [x] `TestEvaluateOrRegisterFlag_TouchIsThrottled` — 50 evaluations after the first produce no further write
- [x] No breaking changes. Existing rows are unaffected; the column simply starts being correct from the first evaluation after deploy.

https://claude.ai/code/session_013ombByUEM1omcxHMpZhZzg