### PR TITLE
Delete unreachable rows, de-duplicate funnels, guard empty project ids (#232)

### DIFF
--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -596,6 +596,24 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 					slog.Info("purged stale auto flags", "count", nf, "before", cutoff.Format(time.DateOnly))
 				}
 			}
+			// Unreachable rows are invisible to the product by construction —
+			// every read is project-scoped — so nothing surfaces them except a
+			// count. The 344 events that prompted this check went unnoticed for
+			// two months. Error level so it reaches BugBarn as an issue: with
+			// foreign keys enforced and the project_id triggers in place, a
+			// non-zero count means a guard was bypassed.
+			if orphans, err := store.CountOrphanedRows(purgeCtx); err != nil {
+				tracing.RecordError(purgeSpan, err)
+				slog.Error("count orphaned rows", "err", err)
+			} else if orphans.Total() > 0 {
+				slog.Error("rows exist under a project_id that matches no project; they are unreachable by every query",
+					"err", errors.New("orphaned rows present"), "handled", false,
+					"events", orphans.Events,
+					"sessions", orphans.Sessions,
+					"funnels", orphans.Funnels,
+				)
+			}
+
 			if recordings != nil {
 				retentionDays := 90 // default
 				if v, ok, _ := store.GetInstanceSetting(purgeCtx, "recording_retention_days"); ok {

--- a/internal/repository/events.go
+++ b/internal/repository/events.go
@@ -41,6 +41,35 @@ type Event struct {
 	SessionSignalsRaw map[string]any `json:"-"`
 }
 
+// OrphanCounts reports rows whose project_id matches no project. Every read
+// path is project-scoped, so such rows are unreachable: stored, indexed and
+// backed up, but invisible to the product. 372 of them accumulated over three
+// weeks in June 2026 and went unnoticed until an audit two months later.
+type OrphanCounts struct {
+	Events   int64
+	Sessions int64
+	Funnels  int64
+}
+
+// Total returns the number of orphaned rows across all tables.
+func (o OrphanCounts) Total() int64 { return o.Events + o.Sessions + o.Funnels }
+
+// CountOrphanedRows counts rows whose project_id matches no row in projects.
+// Foreign keys and a BEFORE-INSERT trigger both refuse these now, so a non-zero
+// result means a guard has been bypassed and is worth an alert, not a metric.
+func (s *Store) CountOrphanedRows(ctx context.Context) (OrphanCounts, error) {
+	const q = `
+		SELECT
+			(SELECT COUNT(*) FROM events   e WHERE NOT EXISTS (SELECT 1 FROM projects p WHERE p.id = e.project_id)),
+			(SELECT COUNT(*) FROM sessions s WHERE NOT EXISTS (SELECT 1 FROM projects p WHERE p.id = s.project_id)),
+			(SELECT COUNT(*) FROM funnels  f WHERE NOT EXISTS (SELECT 1 FROM projects p WHERE p.id = f.project_id))`
+	var out OrphanCounts
+	if err := s.db.QueryRowContext(ctx, q).Scan(&out.Events, &out.Sessions, &out.Funnels); err != nil {
+		return OrphanCounts{}, err
+	}
+	return out, nil
+}
+
 // InsertEvent writes a new event to the database.
 func (s *Store) InsertEvent(ctx context.Context, e Event) error {
 	const q = `

--- a/internal/repository/migration_backfill_test.go
+++ b/internal/repository/migration_backfill_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"database/sql"
 	"path/filepath"
 	"testing"
@@ -100,5 +101,209 @@ func TestMigration00031_IsIdempotent(t *testing.T) {
 
 	if got := countRows(t, db, `SELECT COUNT(*) FROM events WHERE id = 'e-dev' AND environment = 'development'`); got != 1 {
 		t.Errorf("re-running the backfill changed an already-tagged row")
+	}
+}
+
+// 00033 deletes rows whose project_id matches no project. Those rows are
+// unreachable by every query (all reads are project-scoped) but still indexed
+// and backed up.
+func TestMigration00033_DeletesOrphanedRows(t *testing.T) {
+	db := openAtVersion(t, 32)
+
+	mustExec(t, db, `INSERT INTO projects (id, name, slug) VALUES ('p1', 'P1', 'p1')`)
+	// Real rows, which must survive.
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at)
+		VALUES ('e-ok', 'p1', 's-ok', 'pageview', 'i-ok', CURRENT_TIMESTAMP)`)
+	mustExec(t, db, `INSERT INTO sessions (id, project_id, first_seen_at, last_seen_at)
+		VALUES ('s-ok', 'p1', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`)
+	mustExec(t, db, `INSERT INTO funnels (id, project_id, name) VALUES ('f-ok', 'p1', 'Checkout')`)
+	mustExec(t, db, `INSERT INTO funnel_steps (id, funnel_id, step_order, event_name)
+		VALUES ('fs-ok', 'f-ok', 0, 'pageview')`)
+
+	// Orphans, written in the window before foreign keys were enforced. Foreign
+	// keys are on now, so they have to be inserted with enforcement off — which
+	// is exactly how they got there.
+	mustExec(t, db, `PRAGMA foreign_keys = OFF`)
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at)
+		VALUES ('e-orphan', '', 's-orphan', 'pageview', 'i-orphan', CURRENT_TIMESTAMP)`)
+	mustExec(t, db, `INSERT INTO sessions (id, project_id, first_seen_at, last_seen_at)
+		VALUES ('s-orphan', '', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`)
+	mustExec(t, db, `INSERT INTO funnels (id, project_id, name) VALUES ('f-orphan', '', 'Ghost')`)
+	mustExec(t, db, `INSERT INTO funnel_steps (id, funnel_id, step_order, event_name)
+		VALUES ('fs-orphan', 'f-orphan', 0, 'pageview')`)
+	mustExec(t, db, `PRAGMA foreign_keys = ON`)
+
+	if err := goose.UpTo(db, "migrations", 33); err != nil {
+		t.Fatalf("goose up to 33: %v", err)
+	}
+
+	for _, c := range []struct {
+		name  string
+		query string
+		want  int
+	}{
+		{"orphaned events", `SELECT COUNT(*) FROM events WHERE project_id = ''`, 0},
+		{"orphaned sessions", `SELECT COUNT(*) FROM sessions WHERE project_id = ''`, 0},
+		{"orphaned funnels", `SELECT COUNT(*) FROM funnels WHERE project_id = ''`, 0},
+		{"orphaned funnel steps", `SELECT COUNT(*) FROM funnel_steps WHERE funnel_id = 'f-orphan'`, 0},
+		{"real event", `SELECT COUNT(*) FROM events WHERE id = 'e-ok'`, 1},
+		{"real session", `SELECT COUNT(*) FROM sessions WHERE id = 's-ok'`, 1},
+		{"real funnel", `SELECT COUNT(*) FROM funnels WHERE id = 'f-ok'`, 1},
+		{"real funnel step", `SELECT COUNT(*) FROM funnel_steps WHERE id = 'fs-ok'`, 1},
+	} {
+		if got := countRows(t, db, c.query); got != c.want {
+			t.Errorf("%s: want %d, got %d", c.name, c.want, got)
+		}
+	}
+}
+
+// De-duplication is scoped to funnels that are identical in every respect. Two
+// funnels that merely share a name are different funnels and must survive —
+// production has exactly such a pair ("Funnel Analysis Engagement", 4 steps and
+// 3 steps).
+func TestMigration00033_DeduplicatesOnlyIdenticalFunnels(t *testing.T) {
+	db := openAtVersion(t, 32)
+
+	mustExec(t, db, `INSERT INTO projects (id, name, slug) VALUES ('p1', 'P1', 'p1')`)
+	mustExec(t, db, `INSERT INTO projects (id, name, slug) VALUES ('p2', 'P2', 'p2')`)
+
+	addFunnel := func(id, project, name, created string, steps ...string) {
+		t.Helper()
+		mustExec(t, db, `INSERT INTO funnels (id, project_id, name, created_at) VALUES (?, ?, ?, ?)`,
+			id, project, name, created)
+		for i, ev := range steps {
+			mustExec(t, db, `INSERT INTO funnel_steps (id, funnel_id, step_order, event_name) VALUES (?, ?, ?, ?)`,
+				id+"-s"+ev, id, i, ev)
+		}
+	}
+
+	// Identical pair — the older one survives.
+	addFunnel("f-dup-old", "p1", "Login to Dashboard", "2026-06-01 10:00:00", "login", "dashboard_view")
+	addFunnel("f-dup-new", "p1", "Login to Dashboard", "2026-07-01 10:00:00", "login", "dashboard_view")
+	// Same name, different steps — both survive.
+	addFunnel("f-diff-a", "p1", "Funnel Analysis Engagement", "2026-06-01 10:00:00", "a", "b", "c", "d")
+	addFunnel("f-diff-b", "p1", "Funnel Analysis Engagement", "2026-07-01 10:00:00", "a", "b", "c")
+	// Same name and steps but a different project — both survive.
+	addFunnel("f-p1", "p1", "Registration", "2026-06-01 10:00:00", "sign_up")
+	addFunnel("f-p2", "p2", "Registration", "2026-06-01 10:00:00", "sign_up")
+
+	if err := goose.UpTo(db, "migrations", 33); err != nil {
+		t.Fatalf("goose up to 33: %v", err)
+	}
+
+	for _, c := range []struct {
+		id   string
+		want int
+	}{
+		{"f-dup-old", 1}, {"f-dup-new", 0},
+		{"f-diff-a", 1}, {"f-diff-b", 1},
+		{"f-p1", 1}, {"f-p2", 1},
+	} {
+		if got := countRows(t, db, `SELECT COUNT(*) FROM funnels WHERE id = ?`, c.id); got != c.want {
+			t.Errorf("funnel %s: want %d row(s), got %d", c.id, c.want, got)
+		}
+	}
+	// The losing funnel's steps go with it.
+	if got := countRows(t, db, `SELECT COUNT(*) FROM funnel_steps WHERE funnel_id = 'f-dup-new'`); got != 0 {
+		t.Errorf("steps of the de-duplicated funnel survived: %d", got)
+	}
+}
+
+// The migration ships in the image and runs at every process start.
+func TestMigration00033_IsIdempotent(t *testing.T) {
+	db := openAtVersion(t, 33)
+
+	mustExec(t, db, `INSERT INTO projects (id, name, slug) VALUES ('p1', 'P1', 'p1')`)
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at)
+		VALUES ('e-ok', 'p1', 's-ok', 'pageview', 'i-ok', CURRENT_TIMESTAMP)`)
+	mustExec(t, db, `INSERT INTO funnels (id, project_id, name) VALUES ('f-ok', 'p1', 'Checkout')`)
+
+	mustExec(t, db, `DELETE FROM events WHERE NOT EXISTS (SELECT 1 FROM projects p WHERE p.id = events.project_id)`)
+	mustExec(t, db, `DELETE FROM funnels WHERE NOT EXISTS (SELECT 1 FROM projects p WHERE p.id = funnels.project_id)`)
+
+	if got := countRows(t, db, `SELECT COUNT(*) FROM events WHERE id = 'e-ok'`); got != 1 {
+		t.Error("re-running the orphan delete removed a valid event")
+	}
+	if got := countRows(t, db, `SELECT COUNT(*) FROM funnels WHERE id = 'f-ok'`); got != 1 {
+		t.Error("re-running the orphan delete removed a valid funnel")
+	}
+}
+
+// The triggers are the storage-layer guard NOT NULL never provided: NOT NULL
+// accepts the empty string, and the foreign key was not enforced when these
+// rows were written.
+func TestMigration00033_RejectsEmptyProjectID(t *testing.T) {
+	db := openAtVersion(t, 33)
+	mustExec(t, db, `INSERT INTO projects (id, name, slug) VALUES ('p1', 'P1', 'p1')`)
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at)
+		VALUES ('e-ok', 'p1', 's-ok', 'pageview', 'i-ok', CURRENT_TIMESTAMP)`)
+	mustExec(t, db, `INSERT INTO sessions (id, project_id, first_seen_at, last_seen_at)
+		VALUES ('s-ok', 'p1', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`)
+
+	// Even with foreign keys off — the state that let the 344 rows in — the
+	// empty string is refused.
+	mustExec(t, db, `PRAGMA foreign_keys = OFF`)
+	for _, c := range []struct {
+		name  string
+		query string
+	}{
+		{"insert event", `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at)
+			VALUES ('e-bad', '', 's', 'pageview', 'i-bad', CURRENT_TIMESTAMP)`},
+		{"update event", `UPDATE events SET project_id = '' WHERE id = 'e-ok'`},
+		{"insert session", `INSERT INTO sessions (id, project_id, first_seen_at, last_seen_at)
+			VALUES ('s-bad', '', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`},
+		{"update session", `UPDATE sessions SET project_id = '' WHERE id = 's-ok'`},
+	} {
+		if _, err := db.Exec(c.query); err == nil {
+			t.Errorf("%s with an empty project_id was accepted", c.name)
+		}
+	}
+	mustExec(t, db, `PRAGMA foreign_keys = ON`)
+
+	// A real project_id is unaffected.
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at)
+		VALUES ('e-good', 'p1', 's-ok', 'pageview', 'i-good', CURRENT_TIMESTAMP)`)
+	if got := countRows(t, db, `SELECT COUNT(*) FROM events WHERE id = 'e-good'`); got != 1 {
+		t.Error("the trigger rejected a valid insert")
+	}
+}
+
+// CountOrphanedRows is what would have surfaced the 344 unreachable events in
+// June rather than in an audit two months later. It runs on the maintenance
+// cycle and logs at error level, so a non-zero count reaches BugBarn.
+func TestStore_CountOrphanedRows(t *testing.T) {
+	ctx := context.Background()
+	s, err := Open(filepath.Join(t.TempDir(), "orphans.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	if _, err := s.CreateProject(ctx, "Orphans", "orphans"); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	counts, err := s.CountOrphanedRows(ctx)
+	if err != nil {
+		t.Fatalf("count orphaned rows: %v", err)
+	}
+	if counts.Total() != 0 {
+		t.Fatalf("fresh database reports %d orphans", counts.Total())
+	}
+
+	// Getting an orphan in takes both guards off — which is what the June 2026
+	// window effectively was: no foreign-key enforcement and no trigger.
+	mustExec(t, s.db, `PRAGMA foreign_keys = OFF`)
+	mustExec(t, s.db, `DROP TRIGGER IF EXISTS events_project_id_not_empty_insert`)
+	mustExec(t, s.db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at)
+		VALUES ('e-orphan', '', 's-orphan', 'pageview', 'i-orphan', CURRENT_TIMESTAMP)`)
+	mustExec(t, s.db, `INSERT INTO sessions (id, project_id, first_seen_at, last_seen_at)
+		VALUES ('s-orphan', 'no-such-project', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`)
+
+	counts, err = s.CountOrphanedRows(ctx)
+	if err != nil {
+		t.Fatalf("count orphaned rows: %v", err)
+	}
+	if counts.Events != 1 || counts.Sessions != 1 || counts.Funnels != 0 || counts.Total() != 2 {
+		t.Errorf("counts = %+v (total %d), want 1 event, 1 session, 0 funnels", counts, counts.Total())
 	}
 }

--- a/internal/repository/migrations/00033_repair_orphans_and_funnels.sql
+++ b/internal/repository/migrations/00033_repair_orphans_and_funnels.sql
@@ -1,0 +1,104 @@
+-- +goose Up
+-- Production data repair, plus the storage-layer guard that stops it recurring.
+--
+-- Orphaned rows (#232): 344 events, 27 sessions and 1 funnel carry
+-- project_id = '', which matches no row in projects. Every read path is
+-- project-scoped, so these rows are stored, indexed and backed up while being
+-- permanently unreachable. They were written between 2026-06-03 and 2026-06-25,
+-- a window that predates both foreign-key enforcement (#195, 2026-07-09) and
+-- the ErrNoProject guard in PersistEvent (#214, 2026-08-23).
+--
+-- They are deleted, not re-attributed. The obvious rescue — read the project
+-- from the event's session — does not work here: those events' sessions are
+-- themselves in the orphaned set, so the join resolves to '' again. Chasing it
+-- further would mean attributing events by session_id alone, and session IDs
+-- are currently shared across projects (#225 — 28 of them, covering 54% of the
+-- events table), so a "rescue" could file one customer's events under another's
+-- project. 344 unreachable rows are not worth that risk.
+--
+-- Idempotent throughout: every predicate is the condition that selected the
+-- rows, so a second run matches nothing.
+
+-- Funnels first: funnel_steps cascades from funnels, and deleting the parent
+-- takes its steps with it.
+DELETE FROM funnels  WHERE NOT EXISTS (SELECT 1 FROM projects p WHERE p.id = funnels.project_id);
+DELETE FROM sessions WHERE NOT EXISTS (SELECT 1 FROM projects p WHERE p.id = sessions.project_id);
+DELETE FROM events   WHERE NOT EXISTS (SELECT 1 FROM projects p WHERE p.id = events.project_id);
+
+-- Exact-duplicate funnels (#230). A pair only counts as duplicate when the
+-- project, name, description, scope AND the full ordered step list all match —
+-- so two funnels that merely share a name are left alone, and so is the
+-- "Funnel Analysis Engagement" pair, whose members have 4 and 3 steps and are
+-- therefore different funnels that happen to be named the same. The earliest
+-- row of each identical group survives (ties broken by id, so the choice is
+-- deterministic rather than dependent on scan order).
+DELETE FROM funnels
+WHERE EXISTS (
+    SELECT 1 FROM funnels g
+    WHERE g.id <> funnels.id
+      AND g.project_id = funnels.project_id
+      AND g.name = funnels.name
+      AND COALESCE(g.description, '') = COALESCE(funnels.description, '')
+      AND g.scope = funnels.scope
+      AND (g.created_at < funnels.created_at
+           OR (g.created_at = funnels.created_at AND g.id < funnels.id))
+      AND (SELECT group_concat(step_order || ':' || event_name, '|')
+             FROM (SELECT step_order, event_name FROM funnel_steps
+                    WHERE funnel_id = g.id ORDER BY step_order, event_name))
+        = (SELECT group_concat(step_order || ':' || event_name, '|')
+             FROM (SELECT step_order, event_name FROM funnel_steps
+                    WHERE funnel_id = funnels.id ORDER BY step_order, event_name))
+);
+
+-- Defence in depth (#232 item 3). SQLite cannot add a CHECK constraint to an
+-- existing table — that needs a full table rebuild, and rebuilding the events
+-- table (24 columns, 3 indexes, ~85k rows) inside a migration that runs
+-- unattended at process start is a much larger risk than the one being guarded
+-- against. BEFORE triggers give the same guarantee at the same layer: an empty
+-- project_id is refused by the database whatever the caller does, and NOT NULL
+-- (which accepts '') no longer stands alone.
+--
+-- This is not expected to change ingest behaviour. Two guards already stand in
+-- front of it: the handler rejects a request that resolves no project slug with
+-- a 400, and PersistEvent refuses ErrNoProject before InsertEvent. The trigger
+-- is the backstop for a path that does not exist today.
+
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS events_project_id_not_empty_insert
+BEFORE INSERT ON events FOR EACH ROW WHEN NEW.project_id = ''
+BEGIN
+    SELECT RAISE(ABORT, 'events.project_id must not be empty');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS events_project_id_not_empty_update
+BEFORE UPDATE OF project_id ON events FOR EACH ROW WHEN NEW.project_id = ''
+BEGIN
+    SELECT RAISE(ABORT, 'events.project_id must not be empty');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS sessions_project_id_not_empty_insert
+BEFORE INSERT ON sessions FOR EACH ROW WHEN NEW.project_id = ''
+BEGIN
+    SELECT RAISE(ABORT, 'sessions.project_id must not be empty');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS sessions_project_id_not_empty_update
+BEFORE UPDATE OF project_id ON sessions FOR EACH ROW WHEN NEW.project_id = ''
+BEGIN
+    SELECT RAISE(ABORT, 'sessions.project_id must not be empty');
+END;
+-- +goose StatementEnd
+
+-- +goose Down
+DROP TRIGGER IF EXISTS sessions_project_id_not_empty_update;
+DROP TRIGGER IF EXISTS sessions_project_id_not_empty_insert;
+DROP TRIGGER IF EXISTS events_project_id_not_empty_update;
+DROP TRIGGER IF EXISTS events_project_id_not_empty_insert;
+-- The deleted rows are not restored: they were unreachable by every query
+-- before deletion, so there is nothing to restore them for.


### PR DESCRIPTION
> **Stacked on #246.** Base is `issue-234/pr1-ingest-enrichment`, which contributes the `openAtVersion` migration-test helper this PR's tests use. It retargets to `main` automatically when #246 merges — review the [three commits since the base](https://github.com/webwiebe/funnelbarn/compare/issue-234/pr1-ingest-enrichment...issue-234/pr3-orphans-and-funnels).

## Summary

Production holds **344 events, 27 sessions and 1 funnel** whose `project_id` is the empty string, matching no row in `projects`. Every read path is project-scoped, so these rows are stored, indexed and backed up while being permanently invisible to the product.

Part of #234 (Wave A, PR 3). Closes #232. Partially addresses #230 — see below.

## How the 344 rows got past `ErrNoProject`

The epic asked for this specifically, since a new constraint over a still-reachable path turns a silent bad write into a hard ingest failure. **The path is closed, and the rows predate every guard:**

| | Date |
|---|---|
| Orphaned rows written | 2026-06-03 → 2026-06-25 |
| Foreign-key enforcement landed (#195) | 2026-07-09 |
| `ErrNoProject` guard landed (#214) | 2026-08-23 |

`NOT NULL` accepts the empty string, and with FK enforcement off nothing checked the reference either. The window closed on its own a fortnight before the first fix. Today an event that resolves no project is refused with a 400 in `ingest/handler.go` before it is ever spooled, and `PersistEvent` refuses it again before `InsertEvent`. **The triggers add no new failure mode** — they are a third backstop for a path that does not exist.

## Migration `00033_repair_orphans_and_funnels.sql`

**1. Delete the orphaned rows.** `NOT EXISTS` rather than `NOT IN`, so a NULL id in `projects` cannot silently make the predicate match nothing. Funnels are deleted first so `funnel_steps` cascades from the parent.

They are deleted, **not re-attributed**. The issue asks whether their `session_id`s can be matched to sessions that do have a project — they cannot: those sessions are themselves in the orphaned set, so the join resolves to `''` again. Going further would mean attributing events by `session_id` alone, and session IDs are currently shared across projects (#225 — 28 of them, covering 54% of the events table), so a "rescue" could file one customer's events under another's project. 344 unreachable rows are not worth that.

**2. De-duplicate funnels.** Only funnels identical in project, name, description, scope *and* full ordered step list. The earliest survives, ties broken by id so the choice does not depend on scan order. The production pair named `Funnel Analysis Engagement` has **4 and 3 steps** — same name, different funnels — and is deliberately left alone. Covered by `TestMigration00033_DeduplicatesOnlyIdenticalFunnels`.

**3. Guard the empty string.** `BEFORE INSERT` and `BEFORE UPDATE OF project_id` triggers on `events` and `sessions`.

**Triggers rather than `CHECK`:** SQLite cannot add a `CHECK` constraint to an existing table. It needs a create-copy-drop-rename rebuild, and rebuilding the `events` table (24 columns, 3 indexes, ~85k rows) inside a migration that runs unattended at process start on every rollout is a far larger risk than the one being guarded against — a mistake in the copy is silent and total. The triggers give the same guarantee at the same layer: the database refuses an empty `project_id` whatever the caller does, verified in `TestMigration00033_RejectsEmptyProjectID` with foreign keys explicitly **off**.

All three parts are idempotent — each predicate is the condition that selected the rows. Down drops the triggers; the deleted rows are not restored, as they were unreachable before deletion.

**Row counts to confirm on staging:**

```sql
SELECT (SELECT COUNT(*) FROM events   e WHERE NOT EXISTS (SELECT 1 FROM projects p WHERE p.id = e.project_id)),
       (SELECT COUNT(*) FROM sessions s WHERE NOT EXISTS (SELECT 1 FROM projects p WHERE p.id = s.project_id)),
       (SELECT COUNT(*) FROM funnels  f WHERE NOT EXISTS (SELECT 1 FROM projects p WHERE p.id = f.project_id));
-- expected 344 | 27 | 1 before, 0 | 0 | 0 after
```

## Also: an integrity check, so this is never found by audit again

`CountOrphanedRows` runs on the maintenance cycle and logs at **error** level when non-zero, so it reaches BugBarn as an issue. Unreachable data is invisible by construction — nothing surfaced these rows for two months. This is #232's fourth item.

## What is NOT here: the 20 zero-match template funnels (#230)

The epic asks for them to be deleted in this migration. **I have not done that, and I think deleting them would be a mistake.**

A funnel matching zero events is not evidence of misconfiguration on its own — a funnel created yesterday matches zero events until traffic arrives. A predicate that deletes zero-match funnels either eats legitimately-new ones or needs a hard-coded date to avoid it. Worse, #231 (in this same epic) reports that event names have drifted three ways, and calls out exactly this interaction: *"a funnel built on `page_view` currently looks broken for a project that emits `page.view`, and normalisation would fix some of these without deleting them."* The zero-match set is dominated by `Registration` ×4, `Newsletter Signup` ×4, `Login (Returning User)` ×4 — the shape most likely to be a naming mismatch rather than junk.

Deleting hand-authored funnel definitions from a migration that runs unattended on production, when a sibling issue says some of them are recoverable, is the one irreversible mistake available in this PR. I also checked: **nothing in this repository seeds template funnels on project creation**, so the epic's "stop seeding them" half has no target here — they came in through the API.

#230's own third fix is the durable one: surface a funnel step that references an event name the project has never emitted, so an unconfigured funnel reads as unconfigured instead of as 0% conversion. That is an API field plus a UI state, not a migration, and it belongs in its own PR. **#230 stays open** with the duplicate half done.

## Testing

- [x] `go test -race -count=1 ./...` — all packages pass
- [x] `python3 scripts/coverage-gate.py` — passes, global 87.62%
- [x] `bash scripts/go-quality-gates.sh` — within pinned thresholds
- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `TestMigration00033_DeletesOrphanedRows` — orphans in all three tables plus a cascaded `funnel_steps` row go; valid rows in each survive
- [x] `TestMigration00033_DeduplicatesOnlyIdenticalFunnels` — identical pair de-duplicated oldest-wins; same-name-different-steps pair survives; same-name-same-steps in a *different project* survives
- [x] `TestMigration00033_IsIdempotent` — re-running the deletes touches nothing
- [x] `TestMigration00033_RejectsEmptyProjectID` — insert and update, events and sessions, with foreign keys off; a valid insert still succeeds
- [x] `TestStore_CountOrphanedRows` — 0 on a clean database, correct per-table counts with an orphan present

https://claude.ai/code/session_013ombByUEM1omcxHMpZhZzg