### PR TITLE
Key sessions on (project_id, id) and repair the collided rows (#225)

### DIFF
--- a/internal/repository/migration_backfill_test.go
+++ b/internal/repository/migration_backfill_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/pressly/goose/v3"
@@ -306,4 +307,207 @@ func TestStore_CountOrphanedRows(t *testing.T) {
 	if counts.Events != 1 || counts.Sessions != 1 || counts.Funnels != 0 || counts.Total() != 2 {
 		t.Errorf("counts = %+v (total %d), want 1 event, 1 session, 0 funnels", counts, counts.Total())
 	}
+}
+
+// seedForSplit sets up the production shape: one session ID emitted by two
+// projects, with the sessions row owned by whichever wrote last.
+func seedForSplit(t *testing.T, db *sql.DB) {
+	t.Helper()
+	mustExec(t, db, `INSERT INTO projects (id, name, slug) VALUES ('pa', 'A', 'a')`)
+	mustExec(t, db, `INSERT INTO projects (id, name, slug) VALUES ('pc', 'C', 'c')`)
+
+	// Project A: three events for session "shared".
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at, url, referrer, utm_source, device_type, country_code, environment)
+		VALUES ('a1', 'pa', 'shared', 'pageview', 'ia1', '2026-08-01 10:00:00', 'https://a.example/landing', 'https://google.com', 'newsletter', 'desktop', 'NL', 'production')`)
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at, url, environment)
+		VALUES ('a2', 'pa', 'shared', 'pageview', 'ia2', '2026-08-01 10:05:00', 'https://a.example/pricing', 'production')`)
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at, url, environment)
+		VALUES ('a3', 'pa', 'shared', 'signup', 'ia3', '2026-08-01 10:09:00', 'https://a.example/done', 'production')`)
+
+	// Project C: one event for the same session ID.
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at, url, environment)
+		VALUES ('c1', 'pc', 'shared', 'pageview', 'ic1', '2026-08-02 09:00:00', 'https://c.example/home', 'staging')`)
+
+	// The single sessions row, owned by C because C wrote last, carrying C's geo.
+	mustExec(t, db, `INSERT INTO sessions
+		(id, project_id, first_seen_at, last_seen_at, event_count, entry_url, exit_url, device_type, country_code, environment,
+		 ip, city, latitude, longitude, asn_org, geo_anonymized, screen_width, signals_collected)
+		VALUES ('shared', 'pc', '2026-08-01 10:00:00', '2026-08-02 09:00:00', 4, 'https://a.example/landing', 'https://c.example/home', 'desktop', 'NL', 'staging',
+		 '203.0.113.7', 'Nijmegen', 51.84, 5.86, 'Example ISP', 0, 1920, 1)`)
+}
+
+// The repair splits a colliding session into one row per project, with each
+// project's aggregates re-derived from its own events.
+func TestMigration00034_SplitsCollidingSessionsPerProject(t *testing.T) {
+	db := openAtVersion(t, 33)
+	seedForSplit(t, db)
+
+	if err := goose.UpTo(db, "migrations", 34); err != nil {
+		t.Fatalf("goose up to 34: %v", err)
+	}
+
+	if got := countRows(t, db, `SELECT COUNT(*) FROM sessions WHERE id = 'shared'`); got != 2 {
+		t.Fatalf("want 2 rows for the shared session, got %d", got)
+	}
+
+	var count int
+	var first, last, entry, exit, env string
+	err := db.QueryRow(`SELECT event_count, first_seen_at, last_seen_at, entry_url, exit_url, environment
+		FROM sessions WHERE id = 'shared' AND project_id = 'pa'`).
+		Scan(&count, &first, &last, &entry, &exit, &env)
+	if err != nil {
+		t.Fatalf("read project A's row: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("project A event_count: want 3, got %d", count)
+	}
+	if !strings.HasPrefix(first, "2026-08-01T10:00:00") || !strings.HasPrefix(last, "2026-08-01T10:09:00") {
+		t.Errorf("project A window: got %s .. %s", first, last)
+	}
+	if entry != "https://a.example/landing" || exit != "https://a.example/done" {
+		t.Errorf("project A urls: entry %q exit %q", entry, exit)
+	}
+	if env != "production" {
+		t.Errorf("project A environment: want production, got %q", env)
+	}
+
+	// Project C keeps only its own single event — its inflated count is gone.
+	err = db.QueryRow(`SELECT event_count, entry_url, exit_url, environment
+		FROM sessions WHERE id = 'shared' AND project_id = 'pc'`).
+		Scan(&count, &entry, &exit, &env)
+	if err != nil {
+		t.Fatalf("read project C's row: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("project C event_count: want 1, got %d", count)
+	}
+	if entry != "https://c.example/home" || exit != "https://c.example/home" {
+		t.Errorf("project C urls: entry %q exit %q", entry, exit)
+	}
+	if env != "staging" {
+		t.Errorf("project C environment: want staging, got %q", env)
+	}
+}
+
+// Geo and device signals have no per-project source, so they stay with the one
+// project the old row already attributed them to. Copying them to every split
+// row would invent a city and an ASN for a visitor who was never there.
+func TestMigration00034_GeoStaysWithItsOwningProject(t *testing.T) {
+	db := openAtVersion(t, 33)
+	seedForSplit(t, db)
+
+	if err := goose.UpTo(db, "migrations", 34); err != nil {
+		t.Fatalf("goose up to 34: %v", err)
+	}
+
+	var city, asn sql.NullString
+	var width sql.NullInt64
+	var signals int
+	err := db.QueryRow(`SELECT city, asn_org, screen_width, signals_collected
+		FROM sessions WHERE id = 'shared' AND project_id = 'pc'`).Scan(&city, &asn, &width, &signals)
+	if err != nil {
+		t.Fatalf("read project C's row: %v", err)
+	}
+	if city.String != "Nijmegen" || asn.String != "Example ISP" || width.Int64 != 1920 || signals != 1 {
+		t.Errorf("the owning project lost its geo/signals: city=%v asn=%v width=%v signals=%d",
+			city, asn, width, signals)
+	}
+
+	err = db.QueryRow(`SELECT city, asn_org, screen_width, signals_collected
+		FROM sessions WHERE id = 'shared' AND project_id = 'pa'`).Scan(&city, &asn, &width, &signals)
+	if err != nil {
+		t.Fatalf("read project A's row: %v", err)
+	}
+	if city.Valid || asn.Valid || width.Valid {
+		t.Errorf("another project's geo was copied onto project A: city=%v asn=%v width=%v", city, asn, width)
+	}
+	if signals != 0 {
+		t.Errorf("signals_collected: want 0 on a split row, got %d", signals)
+	}
+}
+
+// 29 rows in production sit under a project none of their own events belong to.
+// The rebuild is authoritative for any session ID that has events, so those
+// rows are not carried across.
+func TestMigration00034_DropsMisattributedRows(t *testing.T) {
+	db := openAtVersion(t, 33)
+	mustExec(t, db, `INSERT INTO projects (id, name, slug) VALUES ('pa', 'A', 'a')`)
+	mustExec(t, db, `INSERT INTO projects (id, name, slug) VALUES ('pc', 'C', 'c')`)
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at, environment)
+		VALUES ('a1', 'pa', 'stolen', 'pageview', 'ia1', '2026-08-01 10:00:00', 'production')`)
+	// The row was last written by C, which owns none of this session's events.
+	mustExec(t, db, `INSERT INTO sessions (id, project_id, first_seen_at, last_seen_at, event_count)
+		VALUES ('stolen', 'pc', '2026-08-01 10:00:00', '2026-08-01 10:00:00', 1)`)
+
+	if err := goose.UpTo(db, "migrations", 34); err != nil {
+		t.Fatalf("goose up to 34: %v", err)
+	}
+
+	if got := countRows(t, db, `SELECT COUNT(*) FROM sessions WHERE id = 'stolen' AND project_id = 'pc'`); got != 0 {
+		t.Error("a session row survived under a project that owns none of its events")
+	}
+	if got := countRows(t, db, `SELECT COUNT(*) FROM sessions WHERE id = 'stolen' AND project_id = 'pa'`); got != 1 {
+		t.Error("the session was not rebuilt under the project its events belong to")
+	}
+}
+
+// A session whose events were removed by the retention purge has nothing to
+// re-derive from and must survive the rebuild untouched.
+func TestMigration00034_KeepsEventlessSessions(t *testing.T) {
+	db := openAtVersion(t, 33)
+	mustExec(t, db, `INSERT INTO projects (id, name, slug) VALUES ('pa', 'A', 'a')`)
+	mustExec(t, db, `INSERT INTO sessions (id, project_id, first_seen_at, last_seen_at, event_count, entry_url, city)
+		VALUES ('purged', 'pa', '2026-01-01 10:00:00', '2026-01-01 10:30:00', 12, 'https://a.example/old', 'Nijmegen')`)
+
+	if err := goose.UpTo(db, "migrations", 34); err != nil {
+		t.Fatalf("goose up to 34: %v", err)
+	}
+
+	var count int
+	var entry, city string
+	err := db.QueryRow(`SELECT event_count, entry_url, city FROM sessions WHERE id = 'purged' AND project_id = 'pa'`).
+		Scan(&count, &entry, &city)
+	if err != nil {
+		t.Fatalf("the event-less session was dropped: %v", err)
+	}
+	if count != 12 || entry != "https://a.example/old" || city != "Nijmegen" {
+		t.Errorf("the event-less session was altered: count=%d entry=%q city=%q", count, entry, city)
+	}
+}
+
+// The rebuild ships in the image and runs at process start; re-deriving from
+// the same events must land on the same rows.
+func TestMigration00034_IsIdempotent(t *testing.T) {
+	db := openAtVersion(t, 33)
+	seedForSplit(t, db)
+	if err := goose.UpTo(db, "migrations", 34); err != nil {
+		t.Fatalf("goose up to 34: %v", err)
+	}
+
+	before := dumpSessions(t, db)
+	// Re-apply by hand: goose records the version, so a genuine second run only
+	// happens if the version table is lost, but the SQL still has to be safe.
+	if _, err := db.Exec(`DELETE FROM goose_db_version WHERE version_id = 34`); err != nil {
+		t.Fatalf("reset goose version: %v", err)
+	}
+	if err := goose.UpTo(db, "migrations", 34); err != nil {
+		t.Fatalf("second goose up to 34: %v", err)
+	}
+	if after := dumpSessions(t, db); after != before {
+		t.Errorf("re-running the rebuild changed the result:\nbefore: %s\nafter:  %s", before, after)
+	}
+}
+
+func dumpSessions(t *testing.T, db *sql.DB) string {
+	t.Helper()
+	var out string
+	err := db.QueryRow(`SELECT COALESCE(group_concat(row, ';'), '') FROM (
+		SELECT project_id || '/' || id || '/' || event_count || '/' || first_seen_at ||
+		       '/' || last_seen_at || '/' || COALESCE(entry_url,'-') || '/' || COALESCE(exit_url,'-') ||
+		       '/' || COALESCE(city,'-') AS row
+		FROM sessions ORDER BY project_id, id)`).Scan(&out)
+	if err != nil {
+		t.Fatalf("dump sessions: %v", err)
+	}
+	return out
 }

--- a/internal/repository/migrations/00034_sessions_composite_key.sql
+++ b/internal/repository/migrations/00034_sessions_composite_key.sql
@@ -1,0 +1,178 @@
+-- +goose Up
+-- sessions was keyed on id alone. Two projects that ever emit the same session
+-- ID upserted the SAME row, and its project_id ended up owned by whichever
+-- project wrote last. In production 28 session IDs appear under more than one
+-- project (one spans 10), covering 45,869 of 84,764 events — 54% of the table —
+-- and 29 rows sit under a project none of their own events belong to. Every
+-- per-project session and unique-visitor count is decided by write order rather
+-- than by the data: one project reports 141 sessions against 2 real ones.
+--
+-- The key becomes (project_id, id), which requires a table rebuild — SQLite
+-- cannot alter a primary key in place.
+--
+-- REPAIR RULE: split per project. A colliding session becomes one row per
+-- (project_id, session_id) pair present in events, with first_seen_at,
+-- last_seen_at, event_count and entry/exit URL re-derived from that project's
+-- own events. Most-events-wins was rejected: it keeps one row and silently
+-- drops a real session from every other project's counts, which is the same bug
+-- redistributed. events is the authority here — it has always carried the
+-- correct project_id per row (its own FK enforces it), so the ownership being
+-- re-derived is recorded fact, not a guess.
+--
+-- GEO AND DEVICE SIGNALS carry over only to the row whose project matches the
+-- old row's project_id. Those columns exist only on the session, never on an
+-- event, so a split has no per-project source to rebuild them from — but the
+-- old row's project_id and its geo were written by the same visitor in the same
+-- upsert, so that one pair is internally consistent. The other split rows start
+-- with them empty and refill on their next event. Copying one visitor's city
+-- and ASN onto another project's session would be fabricated data that looks
+-- real.
+--
+-- Sessions whose ID has NO events anywhere are carried across untouched: their
+-- events were removed by the retention purge, and there is nothing to re-derive
+-- from. Sessions whose ID does have events are rebuilt from those events alone,
+-- which is what discards the 29 mis-attributed rows.
+--
+-- Idempotent: the scratch table is dropped first, and re-running re-derives the
+-- same rows from the same events.
+
+DROP TABLE IF EXISTS sessions_rebuild;
+
+CREATE TABLE sessions_rebuild (
+    id            TEXT NOT NULL,
+    project_id    TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    first_seen_at DATETIME NOT NULL,
+    last_seen_at  DATETIME NOT NULL,
+    event_count   INTEGER NOT NULL DEFAULT 0,
+    entry_url     TEXT,
+    exit_url      TEXT,
+    referrer      TEXT,
+    utm_source    TEXT,
+    utm_medium    TEXT,
+    utm_campaign  TEXT,
+    device_type   TEXT,
+    country_code  TEXT,
+    ip               TEXT,
+    city             TEXT,
+    region           TEXT,
+    latitude         REAL,
+    longitude        REAL,
+    timezone         TEXT,
+    asn_org          TEXT,
+    connection_class TEXT,
+    geo_anonymized   INTEGER NOT NULL DEFAULT 0,
+    screen_width      INTEGER,
+    screen_height     INTEGER,
+    pixel_ratio       REAL,
+    touch             INTEGER,
+    dark_mode         INTEGER,
+    reduced_motion    INTEGER,
+    browser_timezone  TEXT,
+    cpu_cores         INTEGER,
+    signals_collected INTEGER NOT NULL DEFAULT 0,
+    environment       TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (project_id, id)
+);
+
+-- One row per (project, session) actually present in events. The non-aggregate
+-- attributes come from that project's FIRST event for the session, which is
+-- what UpsertSession recorded originally (it sets them on INSERT and leaves
+-- them alone on every later event); exit_url comes from the last.
+INSERT INTO sessions_rebuild (
+    id, project_id, first_seen_at, last_seen_at, event_count,
+    entry_url, exit_url, referrer, utm_source, utm_medium, utm_campaign,
+    device_type, country_code, environment,
+    ip, city, region, latitude, longitude, timezone, asn_org, connection_class,
+    geo_anonymized,
+    screen_width, screen_height, pixel_ratio, touch, dark_mode, reduced_motion,
+    browser_timezone, cpu_cores, signals_collected
+)
+WITH ranked AS (
+    SELECT
+        e.project_id, e.session_id, e.url, e.referrer,
+        e.utm_source, e.utm_medium, e.utm_campaign,
+        e.device_type, e.country_code, e.environment,
+        ROW_NUMBER() OVER w_first AS rn_first,
+        ROW_NUMBER() OVER w_last  AS rn_last,
+        COUNT(*)           OVER w_part AS event_count,
+        MIN(e.occurred_at) OVER w_part AS first_seen_at,
+        MAX(e.occurred_at) OVER w_part AS last_seen_at
+    FROM events e
+    WINDOW
+        w_part  AS (PARTITION BY e.project_id, e.session_id),
+        -- id breaks ties so the choice is deterministic rather than dependent
+        -- on scan order when two events share a timestamp.
+        w_first AS (PARTITION BY e.project_id, e.session_id ORDER BY e.occurred_at ASC,  e.id ASC),
+        w_last  AS (PARTITION BY e.project_id, e.session_id ORDER BY e.occurred_at DESC, e.id DESC)
+)
+SELECT
+    f.session_id, f.project_id, f.first_seen_at, f.last_seen_at, f.event_count,
+    f.url, l.url, f.referrer, f.utm_source, f.utm_medium, f.utm_campaign,
+    f.device_type, f.country_code, COALESCE(f.environment, ''),
+    -- The join below matches only the project that already owned the old row,
+    -- so every other split row gets NULL geo and NULL signals. That IS the
+    -- rule; no CASE is needed to express it.
+    s.ip, s.city, s.region, s.latitude, s.longitude, s.timezone, s.asn_org,
+    s.connection_class, COALESCE(s.geo_anonymized, 0),
+    s.screen_width, s.screen_height, s.pixel_ratio, s.touch, s.dark_mode,
+    s.reduced_motion, s.browser_timezone, s.cpu_cores, COALESCE(s.signals_collected, 0)
+FROM ranked f
+JOIN ranked l
+  ON l.project_id = f.project_id AND l.session_id = f.session_id AND l.rn_last = 1
+LEFT JOIN sessions s
+  ON s.id = f.session_id AND s.project_id = f.project_id
+WHERE f.rn_first = 1;
+
+-- Sessions whose ID has no events anywhere: retention removed the events and
+-- left the row. Nothing to re-derive, so carry them across verbatim. A session
+-- whose ID DOES have events is deliberately not matched here — the rebuild
+-- above is authoritative for it, which is how the 29 mis-attributed rows are
+-- dropped rather than preserved.
+INSERT INTO sessions_rebuild (
+    id, project_id, first_seen_at, last_seen_at, event_count,
+    entry_url, exit_url, referrer, utm_source, utm_medium, utm_campaign,
+    device_type, country_code, environment,
+    ip, city, region, latitude, longitude, timezone, asn_org, connection_class,
+    geo_anonymized,
+    screen_width, screen_height, pixel_ratio, touch, dark_mode, reduced_motion,
+    browser_timezone, cpu_cores, signals_collected
+)
+SELECT
+    s.id, s.project_id, s.first_seen_at, s.last_seen_at, s.event_count,
+    s.entry_url, s.exit_url, s.referrer, s.utm_source, s.utm_medium, s.utm_campaign,
+    s.device_type, s.country_code, s.environment,
+    s.ip, s.city, s.region, s.latitude, s.longitude, s.timezone, s.asn_org,
+    s.connection_class, s.geo_anonymized,
+    s.screen_width, s.screen_height, s.pixel_ratio, s.touch, s.dark_mode,
+    s.reduced_motion, s.browser_timezone, s.cpu_cores, s.signals_collected
+FROM sessions s
+WHERE NOT EXISTS (SELECT 1 FROM events e WHERE e.session_id = s.id);
+
+DROP TABLE sessions;
+ALTER TABLE sessions_rebuild RENAME TO sessions;
+
+CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions (project_id, last_seen_at DESC);
+CREATE INDEX IF NOT EXISTS idx_sessions_ip ON sessions (ip) WHERE ip IS NOT NULL;
+
+-- The 00033 triggers were attached to the old table and went with it.
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS sessions_project_id_not_empty_insert
+BEFORE INSERT ON sessions FOR EACH ROW WHEN NEW.project_id = ''
+BEGIN
+    SELECT RAISE(ABORT, 'sessions.project_id must not be empty');
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER IF NOT EXISTS sessions_project_id_not_empty_update
+BEFORE UPDATE OF project_id ON sessions FOR EACH ROW WHEN NEW.project_id = ''
+BEGIN
+    SELECT RAISE(ABORT, 'sessions.project_id must not be empty');
+END;
+-- +goose StatementEnd
+
+-- +goose Down
+-- Not reversible. Going back to a single-column key would have to merge the
+-- split rows again, and the merge has no correct answer — that ambiguity is the
+-- bug this migration removes.
+SELECT 1;

--- a/internal/repository/sessions.go
+++ b/internal/repository/sessions.go
@@ -38,6 +38,10 @@ type Session struct {
 
 // UpsertSession inserts or updates a session record. Geo fields are written
 // on INSERT only; subsequent updates to the same session preserve them.
+//
+// The conflict target is (project_id, id), matching the primary key. Keyed on
+// id alone, two projects that emitted the same session ID upserted the same
+// row and its project_id was decided by whichever wrote last.
 func (s *Store) UpsertSession(ctx context.Context, sess Session) error {
 	const q = `
 		INSERT INTO sessions (
@@ -47,7 +51,7 @@ func (s *Store) UpsertSession(ctx context.Context, sess Session) error {
 			device_type, country_code, environment,
 			ip, city, region, latitude, longitude, timezone, asn_org, connection_class
 		) VALUES (?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT(id) DO UPDATE SET
+		ON CONFLICT(project_id, id) DO UPDATE SET
 			last_seen_at = excluded.last_seen_at,
 			event_count  = event_count + 1,
 			exit_url     = excluded.exit_url`

--- a/internal/repository/store_test.go
+++ b/internal/repository/store_test.go
@@ -657,6 +657,51 @@ func TestStore_UpsertSession_Update(t *testing.T) {
 	assert.Equal(t, 2, got.EventCount)
 }
 
+// The whole point of the composite key: two projects emitting the same session
+// ID get two rows, and each project's counts move independently. Keyed on id
+// alone these upserts landed on one row whose project_id was decided by write
+// order, and 54% of the events table was affected.
+func TestStore_UpsertSession_SameIDInTwoProjects(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	pa, err := s.CreateProject(ctx, "A", "proj-collide-a")
+	require.NoError(t, err)
+	pc, err := s.CreateProject(ctx, "C", "proj-collide-c")
+	require.NoError(t, err)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	base := repository.Session{ID: "shared-id", FirstSeenAt: now, LastSeenAt: now}
+
+	a := base
+	a.ProjectID = pa.ID
+	a.EntryURL = "https://a.example/landing"
+	require.NoError(t, s.UpsertSession(ctx, a))
+
+	c := base
+	c.ProjectID = pc.ID
+	c.EntryURL = "https://c.example/home"
+	require.NoError(t, s.UpsertSession(ctx, c))
+
+	// Two more events for A only.
+	a.LastSeenAt = now.Add(time.Minute)
+	require.NoError(t, s.UpsertSession(ctx, a))
+	require.NoError(t, s.UpsertSession(ctx, a))
+
+	forA, err := s.ListSessions(ctx, pa.ID, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, forA, 1)
+	assert.Equal(t, 3, forA[0].EventCount, "project A should count its own three events")
+	assert.Equal(t, "https://a.example/landing", forA[0].EntryURL)
+
+	forC, err := s.ListSessions(ctx, pc.ID, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, forC, 1, "project C must not have been overwritten by A")
+	assert.Equal(t, 1, forC[0].EventCount, "project C should count only its own event")
+	assert.Equal(t, "https://c.example/home", forC[0].EntryURL,
+		"project C's entry URL was overwritten by project A")
+}
+
 // --------------------------------------------------------------------------
 // Users
 // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`sessions` was keyed on `id` alone, with no project in the key. Two projects that ever emitted the same session ID upserted the **same row**, and its `project_id` ended up owned by whichever wrote last.

In production: **28 session IDs appear under more than one project** (one spans 10), covering **45,869 of 84,764 events — 54% of the table** — and 29 rows sit under a project none of their own events belong to. One project reports **141 sessions against 2 real ones**. Every per-project session count and unique-visitor count is decided by write order rather than by the data.

Part of #234 (Wave B, PR 5a). Refs #225 — 5b closes it.

## The repair rule: split per project

A colliding session becomes **one row per `(project_id, session_id)` pair present in `events`**, with `first_seen_at`, `last_seen_at`, `event_count` and entry/exit URL re-derived from that project's own events, and the remaining attributes taken from that project's *first* event — which is exactly what the original upsert recorded (it sets them on INSERT and leaves them alone afterwards).

```
sessions (before)                  sessions (after)

id=shared  project=C   ─────>      id=shared project=A  ev=3
(one row; C wrote last,            id=shared project=C  ev=1
 so A's 3 events are
 counted under C)
```

`events` is the authority for this. Its own foreign key has always enforced a correct `project_id` per row, so the ownership being re-derived is recorded fact, not a guess.

**Most-events-wins was rejected.** It keeps one row and silently drops a real session from every other project's counts — the same bug, redistributed. **Dropping the colliding rows** was rejected too: it discards history for the sessions behind 54% of the events table when that history is fully recoverable.

## Geo and device signals

`city`, `latitude`, `asn_org`, `screen_width` and friends live only on the session row, never on an event, so a split has no per-project source to rebuild them from.

They carry over **only to the row whose project matches the old row's `project_id`**. That pair is internally consistent — the old row's `project_id` and its geo were written by the same visitor in the same upsert. The other split rows start empty and refill on their next event. Copying one visitor's city and ASN onto another project's session would be fabricated data that looks real, and it would be indistinguishable from real data afterwards.

In the SQL this is just the join condition (`LEFT JOIN sessions s ON s.id = ... AND s.project_id = ...`), so unmatched rows get NULL geo without a special case.

## Sessions with no events

Carried across verbatim. Their events were removed by the retention purge and there is nothing to re-derive from.

The predicate is deliberately "this session **ID** has no events **anywhere**", not "no events for this project". That distinction is what drops the 29 mis-attributed rows: if the ID has events, the rebuild is authoritative for it and the old row's attribution is discarded; if it has none, the old row is all there is.

## Migration `00034_sessions_composite_key.sql`

SQLite cannot alter a primary key in place, so this is a create-copy-drop-rename where the copy *is* the repair. It also recreates the two indexes and the two `project_id <> ''` triggers from 00033, which went with the old table.

- **Idempotent** — the scratch table is dropped first, and re-deriving from the same events lands on the same rows. `TestMigration00034_IsIdempotent` proves it by resetting the goose version and re-running, then diffing the full table.
- **Down is a no-op** — reversing would have to merge the split rows again, and that merge has no correct answer. The ambiguity is the bug being removed.

**Row counts to confirm on staging:**

```sql
-- before: 28 colliding ids, 45,869 events affected
SELECT COUNT(*), SUM(ev) FROM (
  SELECT session_id, COUNT(DISTINCT project_id) p, COUNT(*) ev
  FROM events GROUP BY session_id HAVING p > 1);
-- before: 29 mis-attributed rows; after: 0
SELECT COUNT(*) FROM sessions s
WHERE EXISTS (SELECT 1 FROM events e WHERE e.session_id = s.id AND e.project_id <> s.project_id);
-- per-project counts should now equal the distinct session ids in events
SELECT project_id, COUNT(*) FROM sessions GROUP BY project_id;
SELECT project_id, COUNT(DISTINCT session_id) FROM events GROUP BY project_id;
```

**Before the production deploy carrying this**, confirm the litestream replica for the production database is current — this migration rewrites the whole table and litestream is the only route back.

## Why `UpsertSession` changes here and not in 5b

The migration alone would break ingest. `ON CONFLICT(id)` needs a unique index on `id`, and after the rebuild there is none — the key is `(project_id, id)`. The conflict target has to move in the same commit.

The read paths that still resolve a session by id alone (`SessionByID`, `AnonymizeSessionGeo`, `UpsertSessionSignals`, the `JOIN sessions s ON s.id = e.session_id` in the funnel engines) are **PR 5b**. They are no worse than today — each already returns or writes an arbitrary one of the colliding rows — but they are now expressible correctly, and 5b is a mechanical sweep that reads much better on its own than bolted onto a data migration.

## Testing

- [x] `go test -race -count=1 ./...` — all packages pass
- [x] `python3 scripts/coverage-gate.py` — passes, global 87.59%
- [x] `bash scripts/go-quality-gates.sh` — within pinned thresholds
- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `TestMigration00034_SplitsCollidingSessionsPerProject` — one ID, two projects; asserts per-project `event_count`, time window, entry/exit URL and environment on both rows
- [x] `TestMigration00034_GeoStaysWithItsOwningProject` — the owning project keeps city/ASN/screen_width/signals_collected; the other split row has them NULL
- [x] `TestMigration00034_DropsMisattributedRows` — reproduces the 29-row case: row under C, events under A; C's row goes, A's is rebuilt
- [x] `TestMigration00034_KeepsEventlessSessions` — a retention-purged session survives with its `event_count`, `entry_url` and `city` intact
- [x] `TestMigration00034_IsIdempotent` — resets the goose version, re-runs, and diffs the whole table
- [x] `TestStore_UpsertSession_SameIDInTwoProjects` — the behavioural proof: two projects, same ID, counts and entry URLs move independently

https://claude.ai/code/session_013ombByUEM1omcxHMpZhZzg