### PR TITLE
Backfill events.country_code from the session that resolved it (#234 Wave C)

### DIFF
--- a/internal/repository/migration_backfill_test.go
+++ b/internal/repository/migration_backfill_test.go
@@ -511,3 +511,89 @@ func dumpSessions(t *testing.T, db *sql.DB) string {
 	}
 	return out
 }
+
+// 00035 recovers events.country_code from the session row that did receive it.
+// The join is on (project_id, session_id) and was only safe to run once 00034
+// made that pair unambiguous.
+func TestMigration00035_BackfillsEventCountryFromSession(t *testing.T) {
+	db := openAtVersion(t, 34)
+
+	mustExec(t, db, `INSERT INTO projects (id, name, slug) VALUES ('pa', 'A', 'a')`)
+	mustExec(t, db, `INSERT INTO projects (id, name, slug) VALUES ('pb', 'B', 'b')`)
+	mustExec(t, db, `INSERT INTO sessions (id, project_id, first_seen_at, last_seen_at, country_code)
+		VALUES ('s-shared', 'pa', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'NL')`)
+	// The SAME session ID under another project, with a different country. This
+	// is the case that made the backfill unsafe before the composite key.
+	mustExec(t, db, `INSERT INTO sessions (id, project_id, first_seen_at, last_seen_at, country_code)
+		VALUES ('s-shared', 'pb', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'DE')`)
+	mustExec(t, db, `INSERT INTO sessions (id, project_id, first_seen_at, last_seen_at, country_code)
+		VALUES ('s-nogeo', 'pa', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '')`)
+
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at, country_code)
+		VALUES ('e-a', 'pa', 's-shared', 'pageview', 'i-a', CURRENT_TIMESTAMP, '')`)
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at, country_code)
+		VALUES ('e-b', 'pb', 's-shared', 'pageview', 'i-b', CURRENT_TIMESTAMP, '')`)
+	// Already has a country: must not be overwritten.
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at, country_code)
+		VALUES ('e-keep', 'pa', 's-shared', 'pageview', 'i-keep', CURRENT_TIMESTAMP, 'FR')`)
+	// Its session resolved no country: nothing to fill from.
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at, country_code)
+		VALUES ('e-none', 'pa', 's-nogeo', 'pageview', 'i-none', CURRENT_TIMESTAMP, '')`)
+	// No session row at all.
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at, country_code)
+		VALUES ('e-orphan-sess', 'pa', 's-missing', 'pageview', 'i-orphan', CURRENT_TIMESTAMP, '')`)
+
+	if err := goose.UpTo(db, "migrations", 35); err != nil {
+		t.Fatalf("goose up to 35: %v", err)
+	}
+
+	for _, c := range []struct {
+		id   string
+		want string
+	}{
+		// Each event takes the country of ITS OWN project's session row.
+		{"e-a", "NL"},
+		{"e-b", "DE"},
+		// Already had one — untouched.
+		{"e-keep", "FR"},
+		// Session resolved no country; nothing to fill from.
+		{"e-none", ""},
+		// No session row at all.
+		{"e-orphan-sess", ""},
+	} {
+		var got string
+		if err := db.QueryRow(`SELECT COALESCE(country_code,'') FROM events WHERE id = ?`, c.id).Scan(&got); err != nil {
+			t.Fatalf("read %s: %v", c.id, err)
+		}
+		if got != c.want {
+			t.Errorf("event %s country_code: want %q, got %q", c.id, c.want, got)
+		}
+	}
+}
+
+// Re-running must not move a country that is already set.
+func TestMigration00035_IsIdempotent(t *testing.T) {
+	db := openAtVersion(t, 35)
+
+	mustExec(t, db, `INSERT INTO projects (id, name, slug) VALUES ('pa', 'A', 'a')`)
+	mustExec(t, db, `INSERT INTO sessions (id, project_id, first_seen_at, last_seen_at, country_code)
+		VALUES ('s1', 'pa', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'NL')`)
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at, country_code)
+		VALUES ('e1', 'pa', 's1', 'pageview', 'i1', CURRENT_TIMESTAMP, 'FR')`)
+
+	mustExec(t, db, `UPDATE events SET country_code = (
+			SELECT s.country_code FROM sessions s
+			WHERE s.project_id = events.project_id AND s.id = events.session_id)
+		WHERE COALESCE(country_code, '') = ''
+		  AND EXISTS (SELECT 1 FROM sessions s
+			WHERE s.project_id = events.project_id AND s.id = events.session_id
+			  AND COALESCE(s.country_code, '') <> '')`)
+
+	var got string
+	if err := db.QueryRow(`SELECT country_code FROM events WHERE id = 'e1'`).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != "FR" {
+		t.Errorf("re-running the backfill overwrote an existing country: got %q", got)
+	}
+}

--- a/internal/repository/migrations/00035_backfill_event_country.sql
+++ b/internal/repository/migrations/00035_backfill_event_country.sql
@@ -1,0 +1,35 @@
+-- +goose Up
+-- events.country_code was never written: the geo lookup only ever landed on the
+-- session row. #246 fixed the ingest path, but every event already stored still
+-- has an empty country, and TopCountries / OverviewTopCountries group events,
+-- not sessions.
+--
+-- The value can be recovered from sessions, which did receive it — but only now.
+-- This backfill joins events to sessions on (project_id, session_id), and that
+-- join was ambiguous until 00034: session IDs were shared across projects
+-- (28 of them, covering 54% of the events table), so before the composite key
+-- an event could have picked up the country of a different visitor in a
+-- different project. Held back from #246 for exactly that reason.
+--
+-- Only fills rows that have no country of their own, and only from sessions
+-- that have one. Idempotent: the predicate is the condition that selects the
+-- rows, so a re-run matches nothing new, and no event that already carries a
+-- country is touched.
+UPDATE events
+SET country_code = (
+    SELECT s.country_code FROM sessions s
+    WHERE s.project_id = events.project_id
+      AND s.id         = events.session_id
+)
+WHERE COALESCE(country_code, '') = ''
+  AND EXISTS (
+    SELECT 1 FROM sessions s
+    WHERE s.project_id = events.project_id
+      AND s.id         = events.session_id
+      AND COALESCE(s.country_code, '') <> ''
+  );
+
+-- +goose Down
+-- Not reversible: a backfilled country is indistinguishable from one resolved
+-- at ingest, so undoing this would clear both.
+SELECT 1;


### PR DESCRIPTION
## Summary

`events.country_code` was never written — the geo lookup only ever landed on the session row. #246 fixed the ingest path, but every event already stored still has an empty country, and `TopCountries` / `OverviewTopCountries` group **events**, not sessions.

This is Wave C item 1 of #234. Refs #227.

## Why this waited for #251

It was deliberately held back from #246, and #246 said so at the time. The backfill joins events to sessions on `(project_id, session_id)`, and that pair was ambiguous until migration `00034` gave `sessions` a composite key: **28 session IDs were shared across projects, covering 54% of the events table**, so running this earlier could have stamped an event with the country of a different visitor in a different project — and a backfilled country is indistinguishable from a real one afterwards.

`TestMigration00035_BackfillsEventCountryFromSession` builds exactly that shape — one session ID under two projects, `NL` and `DE` — and asserts each project's events take their own project's country.

## Migration `00035_backfill_event_country.sql`

```sql
UPDATE events
SET country_code = (SELECT s.country_code FROM sessions s
                    WHERE s.project_id = events.project_id AND s.id = events.session_id)
WHERE COALESCE(country_code, '') = ''
  AND EXISTS (SELECT 1 FROM sessions s
              WHERE s.project_id = events.project_id AND s.id = events.session_id
                AND COALESCE(s.country_code, '') <> '');
```

- **Idempotent** — the predicate is the condition that selects the rows, so a re-run matches nothing new.
- **Non-destructive outside its predicate** — an event that already carries a country is never overwritten, and an event whose session resolved none is left empty rather than given a wrong one.
- **Down is a no-op** — a backfilled country is indistinguishable from one resolved at ingest, so reversing would clear both.

**Row counts to confirm on staging:**

```sql
-- candidates before
SELECT COUNT(*) FROM events e WHERE COALESCE(e.country_code,'') = ''
  AND EXISTS (SELECT 1 FROM sessions s WHERE s.project_id = e.project_id AND s.id = e.session_id
                AND COALESCE(s.country_code,'') <> '');
-- after: 0, and events with a country should rise by that amount
SELECT COUNT(*) FROM events WHERE COALESCE(country_code,'') <> '';
```

The audit put resolved-country sessions at 58%, so expect the country widgets to go from empty to covering roughly that share of events.

## Testing

- [x] `go test -race -count=1 ./...` — all packages pass
- [x] `python3 scripts/coverage-gate.py` — passes, global 87.59%
- [x] `bash scripts/go-quality-gates.sh` — within pinned thresholds
- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `TestMigration00035_BackfillsEventCountryFromSession` — five cases in one table: the two shared-ID projects each get their own country, an event that already had `FR` keeps it, an event whose session resolved nothing stays empty, and an event with no session row at all stays empty
- [x] `TestMigration00035_IsIdempotent` — re-running does not move a country that is already set
- [x] No code changes, no API changes — data only

https://claude.ai/code/session_013ombByUEM1omcxHMpZhZzg