### PR TITLE
Seed the canonical event mappings and suggest namespaced names (#231)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,35 @@ funnelbarn user create --username admin --password yourpassword
 </script>
 ```
 
+## Naming events
+
+FunnelBarn accepts any event name, and nothing enforces a house style. Pick one
+and hold to it, because a funnel step matches an event name **exactly** — a
+funnel built on `page_view` reports a flat 0% for a project that sends
+`page.view`, and nothing about that looks like a misconfiguration.
+
+The convention across this platform:
+
+- **`lower_snake_case`**, no namespace prefix: `page_view`, `sign_up`,
+  `checkout_started`, `purchase`.
+- **Name the thing that happened**, past tense where it reads naturally
+  (`purchase`, `invite_created`), and keep a start distinct from a completion
+  (`signup_started` and `signup_completed` are two events, not one).
+- **Properties, not names, carry the variation.** Send
+  `track('purchase', { plan: 'pro' })`, not `purchase_pro`.
+
+If names have already drifted, the **Event Mapping** page reconciles them
+without rewriting history: each project maps its raw names onto a shared
+canonical key, and cross-project funnels resolve through that mapping at read
+time. Names that are the same word in a different style (`page.view`,
+`PageView`, `seo.page_view` -> `page_view`) are mapped automatically; anything
+that differs in meaning is left for you to decide, because `login_started` is
+not `login`.
+
+The dashboard also flags a funnel whose steps reference an event name the
+project has never sent, so a mismatch shows up as a warning rather than as a
+flat line.
+
 ## Configuration
 
 | Variable | Default | Description |

--- a/internal/repository/canonical_suggest.go
+++ b/internal/repository/canonical_suggest.go
@@ -62,11 +62,52 @@ var builtinAliases = map[string]string{
 	"paymentsuccess":   "purchase",
 }
 
+// stripNamespace removes a leading dotted namespace segment ("seo.page_view" ->
+// "page_view"). Returns "" when there is nothing to strip.
+//
+// Dotted names in production are namespaced, not differently-spelled: the
+// platform emits page_view, page.view and seo.page_view for one concept. The
+// first two already normalise to the same thing, but a namespace survives
+// separator stripping and turns "seo.page_view" into "seopageview", which
+// matches nothing — so the names most in need of a suggestion were the ones
+// least likely to get one.
+//
+// Only the FIRST segment is dropped, and only when something follows it. The
+// remainder is then matched exactly as any other raw name would be, so a
+// namespace cannot manufacture a match that the bare name would not have.
+func stripNamespace(raw string) string {
+	i := strings.Index(raw, ".")
+	if i <= 0 || i == len(raw)-1 {
+		return ""
+	}
+	return raw[i+1:]
+}
+
 // guessCanonicalKey returns a best-guess canonical key for a raw event name, or
 // "" when there is no confident match. A raw name that already equals a catalog
-// key maps to itself; otherwise the built-in alias table is consulted and the
+// key maps to itself; otherwise the built-in alias table is consulted, then the
+// same two checks are retried against the name with its namespace stripped. The
 // result is only returned when that key exists in the catalog.
+//
+// Every rule here is syntactic — a different spelling of the same word. Names
+// that differ in MEANING are deliberately left unsuggested even when they look
+// related: "login_started" is not "login" and "signup_started" is not
+// "signup_completed", and collapsing a start into a completion would silently
+// inflate every funnel built on it. Those are for a human to map on the event
+// mapping page.
 func guessCanonicalKey(raw string, catalogKeys map[string]bool) string {
+	if key := matchCanonicalKey(raw, catalogKeys); key != "" {
+		return key
+	}
+	if bare := stripNamespace(raw); bare != "" {
+		return matchCanonicalKey(bare, catalogKeys)
+	}
+	return ""
+}
+
+// matchCanonicalKey resolves one raw name against the catalog and the built-in
+// alias table, comparing on the separator-stripped form.
+func matchCanonicalKey(raw string, catalogKeys map[string]bool) string {
 	n := normalizeRawName(raw)
 	if n == "" {
 		return ""

--- a/internal/repository/canonical_suggest_test.go
+++ b/internal/repository/canonical_suggest_test.go
@@ -1,0 +1,96 @@
+package repository
+
+import "testing"
+
+func catalog() map[string]bool {
+	// The six keys 00027 seeds.
+	return map[string]bool{
+		"page_view": true, "sign_up": true, "login": true,
+		"add_to_cart": true, "checkout_start": true, "purchase": true,
+	}
+}
+
+// The production drift this exists to reconcile: page_view (59,416 events),
+// page.view (2,259) and seo.page_view (626) are one concept. Separator
+// stripping already handled the first two; a namespace survived it and turned
+// "seo.page_view" into "seopageview", which matched nothing — so the names most
+// in need of a suggestion were the ones least likely to get one.
+func TestGuessCanonicalKey_NamespacedNames(t *testing.T) {
+	keys := catalog()
+	for _, tc := range []struct{ raw, want string }{
+		{"page_view", "page_view"},
+		{"page.view", "page_view"},
+		{"PAGE-VIEW", "page_view"},
+		{"seo.page_view", "page_view"},
+		{"app.sign_up", "sign_up"},
+		{"web.checkout", "checkout_start"},
+		{"shop.purchased", "purchase"},
+	} {
+		if got := guessCanonicalKey(tc.raw, keys); got != tc.want {
+			t.Errorf("guessCanonicalKey(%q) = %q, want %q", tc.raw, got, tc.want)
+		}
+	}
+}
+
+// Only names that are the same WORD are matched. A name that differs in meaning
+// gets no suggestion even when it looks related: collapsing a start into a
+// completion would silently inflate every funnel built on it.
+func TestGuessCanonicalKey_LeavesSemanticDifferencesAlone(t *testing.T) {
+	keys := catalog()
+	for _, raw := range []string{
+		"login_started",  // a login attempt is not a login
+		"auth.initiated", // same, namespaced
+		"signup_started", // not the same event as signup_completed
+		"qr.created",     // "created" means nothing on its own
+		"invite_created",
+		"page_engaged",
+		"sketch.queued",
+	} {
+		if got := guessCanonicalKey(raw, keys); got != "" {
+			t.Errorf("guessCanonicalKey(%q) = %q, want no suggestion", raw, got)
+		}
+	}
+}
+
+// A namespace must not manufacture a match the bare name would not have had,
+// and only the first segment is ever dropped.
+func TestStripNamespace(t *testing.T) {
+	for _, tc := range []struct{ raw, want string }{
+		{"seo.page_view", "page_view"},
+		{"a.b.c", "b.c"}, // one segment only
+		{"page_view", ""},
+		{".leading", ""},  // nothing before the dot
+		{"trailing.", ""}, // nothing after it
+		{"", ""},
+		{".", ""},
+	} {
+		if got := stripNamespace(tc.raw); got != tc.want {
+			t.Errorf("stripNamespace(%q) = %q, want %q", tc.raw, got, tc.want)
+		}
+	}
+}
+
+// A key must exist in the catalog before it is suggested — a mapping to a key
+// that is not there would violate the foreign key on insert.
+func TestGuessCanonicalKey_RespectsTheCatalog(t *testing.T) {
+	only := map[string]bool{"login": true}
+	if got := guessCanonicalKey("seo.page_view", only); got != "" {
+		t.Errorf("suggested %q for a key not in the catalog", got)
+	}
+	if got := guessCanonicalKey("app.signin", only); got != "login" {
+		t.Errorf("guessCanonicalKey(app.signin) = %q, want login", got)
+	}
+}
+
+func TestNormalizeRawName(t *testing.T) {
+	for _, tc := range []struct{ raw, want string }{
+		{"page_view", "pageview"},
+		{"  Page-View  ", "pageview"},
+		{"seo/page:view", "seopageview"},
+		{"", ""},
+	} {
+		if got := normalizeRawName(tc.raw); got != tc.want {
+			t.Errorf("normalizeRawName(%q) = %q, want %q", tc.raw, got, tc.want)
+		}
+	}
+}

--- a/internal/repository/migration_backfill_test.go
+++ b/internal/repository/migration_backfill_test.go
@@ -597,3 +597,93 @@ func TestMigration00035_IsIdempotent(t *testing.T) {
 		t.Errorf("re-running the backfill overwrote an existing country: got %q", got)
 	}
 }
+
+// 00036 seeds the mappings that are true by spelling alone, so the canonical
+// funnel read path — which joins through event_name_mappings — is useful on
+// first load instead of excluding every project.
+func TestMigration00036_SeedsSyntacticMappings(t *testing.T) {
+	db := openAtVersion(t, 35)
+
+	mustExec(t, db, `INSERT INTO projects (id, name, slug) VALUES ('pa', 'A', 'a')`)
+	mustExec(t, db, `INSERT INTO projects (id, name, slug) VALUES ('pb', 'B', 'b')`)
+
+	addEvent := func(id, project, name string) {
+		t.Helper()
+		mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at)
+			VALUES (?, ?, 's1', ?, ?, CURRENT_TIMESTAMP)`, id, project, name, "i-"+id)
+	}
+	addEvent("e1", "pa", "page.view")     // separator variant
+	addEvent("e2", "pa", "seo.page_view") // namespaced
+	addEvent("e3", "pb", "PageView")      // casing variant
+	addEvent("e4", "pa", "login_started") // a login attempt is not a login
+	addEvent("e5", "pa", "qr.created")    // "created" means nothing on its own
+	addEvent("e6", "pa", "page_engaged")  // unrelated
+
+	if err := goose.UpTo(db, "migrations", 36); err != nil {
+		t.Fatalf("goose up to 36: %v", err)
+	}
+
+	for _, c := range []struct {
+		project, raw, want string
+	}{
+		{"pa", "page.view", "page_view"},
+		{"pa", "seo.page_view", "page_view"},
+		{"pb", "PageView", "page_view"},
+		{"pa", "login_started", ""},
+		{"pa", "qr.created", ""},
+		{"pa", "page_engaged", ""},
+	} {
+		var got string
+		err := db.QueryRow(`SELECT COALESCE(MAX(canonical_key), '') FROM event_name_mappings
+			WHERE project_id = ? AND raw_name = ?`, c.project, c.raw).Scan(&got)
+		if err != nil {
+			t.Fatalf("read mapping %s/%s: %v", c.project, c.raw, err)
+		}
+		if got != c.want {
+			t.Errorf("mapping %s/%s: want %q, got %q", c.project, c.raw, c.want, got)
+		}
+	}
+
+	// The mapping is per project: pb never sent page.view, so it gets no row
+	// for it.
+	if got := countRows(t, db, `SELECT COUNT(*) FROM event_name_mappings WHERE project_id = 'pb'`); got != 1 {
+		t.Errorf("project B mappings: want 1, got %d", got)
+	}
+}
+
+// A mapping a human has already made must survive, and a re-run must add
+// nothing new.
+func TestMigration00036_IsIdempotentAndPreservesHumanMappings(t *testing.T) {
+	db := openAtVersion(t, 35)
+
+	mustExec(t, db, `INSERT INTO projects (id, name, slug) VALUES ('pa', 'A', 'a')`)
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at)
+		VALUES ('e1', 'pa', 's1', 'page.view', 'i1', CURRENT_TIMESTAMP)`)
+	// Someone has already decided page.view means something else here.
+	mustExec(t, db, `INSERT INTO event_name_mappings (project_id, raw_name, canonical_key)
+		VALUES ('pa', 'page.view', 'login')`)
+
+	if err := goose.UpTo(db, "migrations", 36); err != nil {
+		t.Fatalf("goose up to 36: %v", err)
+	}
+
+	var got string
+	if err := db.QueryRow(`SELECT canonical_key FROM event_name_mappings
+		WHERE project_id = 'pa' AND raw_name = 'page.view'`).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != "login" {
+		t.Errorf("the seed overwrote a human's mapping: got %q, want login", got)
+	}
+
+	before := countRows(t, db, `SELECT COUNT(*) FROM event_name_mappings`)
+	if _, err := db.Exec(`DELETE FROM goose_db_version WHERE version_id = 36`); err != nil {
+		t.Fatalf("reset goose version: %v", err)
+	}
+	if err := goose.UpTo(db, "migrations", 36); err != nil {
+		t.Fatalf("second goose up to 36: %v", err)
+	}
+	if after := countRows(t, db, `SELECT COUNT(*) FROM event_name_mappings`); after != before {
+		t.Errorf("re-running the seed added rows: %d -> %d", before, after)
+	}
+}

--- a/internal/repository/migrations/00036_seed_event_name_mappings.sql
+++ b/internal/repository/migrations/00036_seed_event_name_mappings.sql
@@ -1,0 +1,75 @@
+-- +goose Up
+-- canonical_events was seeded by 00027 with 6 keys; event_name_mappings has
+-- never had a row. Nothing has ever been mapped, so page.view and seo.page_view
+-- (2,885 events between them) remain invisible to anything built on page_view.
+--
+-- The machinery for this all exists and is wired end to end: the repository
+-- layer, MappingSuggestions, the REST endpoints, the Event Mapping page, and
+-- the read path in AnalyzeCanonicalFunnel that joins through the table. Mapping
+-- is applied at READ time, not at ingest — the raw name is preserved on the
+-- event and resolved through this table when a canonical funnel is analysed.
+-- That is reversible and rewrites no history, and is the design 00027 already
+-- committed to.
+--
+-- What was missing is rows: the table starts empty and stays empty until
+-- someone opens the page and saves. This seeds the mappings that are true by
+-- SPELLING alone, so the feature is useful on first load and the suggestions a
+-- human then reviews are the genuinely ambiguous ones.
+--
+-- Strictly syntactic. A raw name qualifies only when it is the same word as a
+-- catalog key with different separators or casing. Names that differ in MEANING
+-- are never seeded, however similar they look: login_started is not login, and
+-- signup_started is not signup_completed — collapsing a start into a completion
+-- would silently inflate every funnel built on it. Those stay on the Event
+-- Mapping page for a human to decide.
+--
+-- Idempotent: NOT EXISTS plus ON CONFLICT DO NOTHING, and the join is over
+-- names that are already present. A mapping a human has already made is never
+-- overwritten.
+
+-- 1. Exact match after stripping separators and case: page.view, page-view,
+--    PageView -> page_view.
+INSERT INTO event_name_mappings (project_id, raw_name, canonical_key)
+SELECT DISTINCT e.project_id, e.name, c.key
+FROM events e
+JOIN canonical_events c
+  ON replace(replace(replace(lower(e.name), '_', ''), '.', ''), '-', '')
+   = replace(replace(replace(lower(c.key),  '_', ''), '.', ''), '-', '')
+WHERE e.name <> ''
+  AND NOT EXISTS (
+    SELECT 1 FROM event_name_mappings m
+    WHERE m.project_id = e.project_id AND m.raw_name = e.name
+  )
+ON CONFLICT(project_id, raw_name) DO NOTHING;
+
+-- 2. The same match after dropping ONE leading namespace segment:
+--    seo.page_view -> page_view. Only names carrying a dot are considered, the
+--    remainder is matched exactly as above, and a name that already matched in
+--    step 1 is excluded by the NOT EXISTS — so a namespace can never
+--    manufacture a match the bare name would not have had.
+INSERT INTO event_name_mappings (project_id, raw_name, canonical_key)
+SELECT DISTINCT e.project_id, e.name, c.key
+FROM events e
+JOIN canonical_events c
+  ON replace(replace(replace(lower(substr(e.name, instr(e.name, '.') + 1)), '_', ''), '.', ''), '-', '')
+   = replace(replace(replace(lower(c.key), '_', ''), '.', ''), '-', '')
+WHERE instr(e.name, '.') > 1
+  AND instr(e.name, '.') < length(e.name)
+  AND NOT EXISTS (
+    SELECT 1 FROM event_name_mappings m
+    WHERE m.project_id = e.project_id AND m.raw_name = e.name
+  )
+ON CONFLICT(project_id, raw_name) DO NOTHING;
+
+-- +goose Down
+-- Only the rows this migration could have created, and only where they still
+-- say what it would have said — a mapping a human has since re-pointed is left
+-- alone.
+DELETE FROM event_name_mappings
+WHERE (project_id, raw_name, canonical_key) IN (
+    SELECT DISTINCT e.project_id, e.name, c.key
+    FROM events e
+    JOIN canonical_events c
+      ON replace(replace(replace(lower(e.name), '_', ''), '.', ''), '-', '')
+       = replace(replace(replace(lower(c.key), '_', ''), '.', ''), '-', '')
+);


### PR DESCRIPTION
## Summary

The same concept arrives under three names — `page_view` (59,416 events), `page.view` (2,259) and `seo.page_view` (626) — and `event_name_mappings`, the table built to reconcile them, has never held a row.

Part of #234 (Wave C). **Closes #231.**

## The scoping note, corrected

The epic scoped this as *"wire the read path — no analytics query joins through `event_name_mappings`"*. **The read path is already wired.** `AnalyzeCanonicalFunnel` joins through the table, and the repository layer, `MappingSuggestions`, the REST endpoints (`GET/PUT .../event-mappings`, `.../suggestions`) and the Event Mapping page are live end to end. Nothing needed building.

That also answers the issue's second question — read-time or ingest-time — as already decided: **read time**. The raw name stays on the event and resolves through the mapping when a canonical funnel is analysed, which is reversible and rewrites no history. This PR keeps that.

Two things were actually missing.

## 1. The table starts empty and stays empty

Until someone opens the Event Mapping page and saves, there are no rows — and `AnalyzeCanonicalFunnel` **excludes any project missing a mapping for any step**, so with an empty table every project is excluded from every canonical funnel. The feature has never done anything.

Migration `00036` seeds the mappings that are true by **spelling alone**:

1. A raw name that is the same word as a catalog key with different separators or casing — `page.view`, `page-view`, `PageView` → `page_view`.
2. The same match after dropping **one** leading namespace segment — `seo.page_view` → `page_view`.

Step 2's remainder is matched exactly as step 1 would match it, and a name matched in step 1 is excluded by the `NOT EXISTS`, so a namespace can never manufacture a match the bare name would not have had.

## 2. The suggester could not see the names that had drifted

`guessCanonicalKey` strips separators before matching, so `page.view` already resolved. But a namespace *survives* separator stripping — `seo.page_view` becomes `seopageview`, which matches nothing. The names most in need of a suggestion were the ones least likely to get one:

| raw name | before | after |
|---|---|---|
| `page.view` | `page_view` | `page_view` |
| `seo.page_view` | — | `page_view` |
| `app.sign_up` | — | `sign_up` |
| `auth.initiated` | — | — |
| `login_started` | — | — |
| `qr.created` | — | — |

It now retries against the name with its first namespace segment removed.

## Syntactic only — deliberately

Both changes match a different **spelling** of the same word. Names that differ in **meaning** are left unmapped however similar they look:

- `login_started` is not `login` — an attempt is not a success.
- `signup_started` is not `signup_completed` — they are two funnel steps.
- `auth.initiated`, `qr.created`, `sketch.queued` — `created` and `initiated` mean nothing on their own.

Collapsing a start into a completion would silently inflate every funnel built on it, which is worse than leaving the mapping unmade. Those stay on the Event Mapping page, where they now appear as unmapped names for a human to decide, which is what that page is for.

## Also: the naming convention (issue item 3)

Documented in the README — the SDKs impose none, and a funnel step matches an event name exactly, so `lower_snake_case`, no namespace prefix, properties rather than name variants, and a start kept distinct from a completion. It also points at the Event Mapping page for names that have already drifted, and at the funnel warning from #253.

## Migration `00036_seed_event_name_mappings.sql`

- **Idempotent** — `NOT EXISTS` plus `ON CONFLICT DO NOTHING`; re-running adds nothing.
- **Never overwrites a human's decision** — a mapping already in the table is left exactly as it is, verified in `TestMigration00036_IsIdempotentAndPreservesHumanMappings` (which points `page.view` at `login` and checks it survives).
- **Down** removes only rows this migration could have created, and only where they still say what it would have said.

**Row counts to confirm on staging:**

```sql
SELECT COUNT(*) FROM event_name_mappings;   -- 0 before
SELECT project_id, raw_name, canonical_key FROM event_name_mappings ORDER BY project_id;
```

Expect `page.view` and `seo.page_view` mapped to `page_view` for the projects that send them, and nothing for `auth.initiated` / `qr.created` / `login_started`.

## Testing

- [x] `go test -race -count=1 ./...` — exit 0, all packages pass
- [x] `python3 scripts/coverage-gate.py` — passes, global 87.60%
- [x] `bash scripts/go-quality-gates.sh` — within pinned thresholds
- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `TestGuessCanonicalKey_NamespacedNames` — the table above
- [x] `TestGuessCanonicalKey_LeavesSemanticDifferencesAlone` — seven production names that must stay unsuggested
- [x] `TestStripNamespace` — one segment only, and no match from a leading or trailing dot
- [x] `TestGuessCanonicalKey_RespectsTheCatalog` — never suggests a key absent from `canonical_events`, which would violate the foreign key on insert
- [x] `TestMigration00036_SeedsSyntacticMappings` — separator, namespace and casing variants mapped; the three semantic ones not; mappings scoped per project
- [x] `TestMigration00036_IsIdempotentAndPreservesHumanMappings`

> Note: the first local run of the Go suite failed at the linker with `errno=28 (No space left on device)` — the machine's data volume was at 100%. Not a code failure; re-run clean after the disk was freed.

https://claude.ai/code/session_013ombByUEM1omcxHMpZhZzg