### PR TITLE
Stop the sessions rebuild wiping country, and re-run the events backfill

### DIFF
--- a/internal/repository/migration_backfill_test.go
+++ b/internal/repository/migration_backfill_test.go
@@ -687,3 +687,135 @@ func TestMigration00036_IsIdempotentAndPreservesHumanMappings(t *testing.T) {
 		t.Errorf("re-running the seed added rows: %d -> %d", before, after)
 	}
 }
+
+// Regression for the bug that reached production: 00034 took country_code from
+// the event CTE instead of the session, so the rebuild overwrote every
+// session's country with the event's empty string and destroyed the only copy.
+// country_code is a geo field — resolved from the visitor's IP and written to
+// the session, never to the event (that is #227) — so it must be carried across
+// with the other geo fields.
+func TestMigration00034_PreservesSessionCountry(t *testing.T) {
+	db := openAtVersion(t, 33)
+
+	mustExec(t, db, `INSERT INTO projects (id, name, slug) VALUES ('pa', 'A', 'a')`)
+	mustExec(t, db, `INSERT INTO projects (id, name, slug) VALUES ('pb', 'B', 'b')`)
+
+	// The production shape exactly: the session carries the geo, the event
+	// carries none.
+	mustExec(t, db, `INSERT INTO sessions
+		(id, project_id, first_seen_at, last_seen_at, country_code, city, asn_org)
+		VALUES ('s1', 'pa', '2026-08-01 10:00:00', '2026-08-01 10:00:00', 'NL', 'Nijmegen', 'Example ISP')`)
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at, country_code)
+		VALUES ('e1', 'pa', 's1', 'pageview', 'i1', '2026-08-01 10:00:00', '')`)
+
+	if err := goose.UpTo(db, "migrations", 34); err != nil {
+		t.Fatalf("goose up to 34: %v", err)
+	}
+
+	var country, city, asn string
+	err := db.QueryRow(`SELECT COALESCE(country_code,''), COALESCE(city,''), COALESCE(asn_org,'')
+		FROM sessions WHERE id = 's1' AND project_id = 'pa'`).Scan(&country, &city, &asn)
+	if err != nil {
+		t.Fatalf("read rebuilt session: %v", err)
+	}
+	if country != "NL" {
+		t.Errorf("session country_code: want NL, got %q — the rebuild overwrote it from the event", country)
+	}
+	// The fields that were already correct must stay correct.
+	if city != "Nijmegen" || asn != "Example ISP" {
+		t.Errorf("other geo fields lost: city=%q asn=%q", city, asn)
+	}
+}
+
+// An event that does carry a country still supplies one for a session that has
+// none, so the fallback is not dropped along with the bug.
+func TestMigration00034_FallsBackToEventCountry(t *testing.T) {
+	db := openAtVersion(t, 33)
+
+	mustExec(t, db, `INSERT INTO projects (id, name, slug) VALUES ('pa', 'A', 'a')`)
+	mustExec(t, db, `INSERT INTO sessions (id, project_id, first_seen_at, last_seen_at, country_code)
+		VALUES ('s1', 'pa', '2026-08-01 10:00:00', '2026-08-01 10:00:00', '')`)
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at, country_code)
+		VALUES ('e1', 'pa', 's1', 'pageview', 'i1', '2026-08-01 10:00:00', 'DE')`)
+
+	if err := goose.UpTo(db, "migrations", 34); err != nil {
+		t.Fatalf("goose up to 34: %v", err)
+	}
+
+	var country string
+	if err := db.QueryRow(`SELECT COALESCE(country_code,'') FROM sessions
+		WHERE id = 's1' AND project_id = 'pa'`).Scan(&country); err != nil {
+		t.Fatal(err)
+	}
+	if country != "DE" {
+		t.Errorf("session country_code: want DE from the event, got %q", country)
+	}
+}
+
+// A split row must not inherit another project's country, the same rule the
+// other geo fields follow.
+func TestMigration00034_CountryDoesNotLeakAcrossSplitRows(t *testing.T) {
+	db := openAtVersion(t, 33)
+
+	mustExec(t, db, `INSERT INTO projects (id, name, slug) VALUES ('pa', 'A', 'a')`)
+	mustExec(t, db, `INSERT INTO projects (id, name, slug) VALUES ('pb', 'B', 'b')`)
+	// One row, owned by B, carrying B's country.
+	mustExec(t, db, `INSERT INTO sessions (id, project_id, first_seen_at, last_seen_at, country_code)
+		VALUES ('shared', 'pb', '2026-08-01 10:00:00', '2026-08-01 10:00:00', 'DE')`)
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at)
+		VALUES ('e-a', 'pa', 'shared', 'pageview', 'i-a', '2026-08-01 10:00:00')`)
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at)
+		VALUES ('e-b', 'pb', 'shared', 'pageview', 'i-b', '2026-08-01 10:00:00')`)
+
+	if err := goose.UpTo(db, "migrations", 34); err != nil {
+		t.Fatalf("goose up to 34: %v", err)
+	}
+
+	var b, a string
+	if err := db.QueryRow(`SELECT COALESCE(country_code,'') FROM sessions WHERE id='shared' AND project_id='pb'`).Scan(&b); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COALESCE(country_code,'') FROM sessions WHERE id='shared' AND project_id='pa'`).Scan(&a); err != nil {
+		t.Fatal(err)
+	}
+	if b != "DE" {
+		t.Errorf("the owning project lost its country: got %q", b)
+	}
+	if a != "" {
+		t.Errorf("project A inherited another project's country: got %q", a)
+	}
+}
+
+// 00037 re-runs the events backfill, which 00035 could not do again once goose
+// had recorded it. On a database where 00035 worked it is a no-op.
+func TestMigration00037_FillsEventsFromRecoveredSessions(t *testing.T) {
+	db := openAtVersion(t, 36)
+
+	mustExec(t, db, `INSERT INTO projects (id, name, slug) VALUES ('pa', 'A', 'a')`)
+	mustExec(t, db, `INSERT INTO sessions (id, project_id, first_seen_at, last_seen_at, country_code)
+		VALUES ('s1', 'pa', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'NL')`)
+	// The post-recovery production state: sessions have their country back,
+	// events are still empty because 00035 ran while sessions were blank.
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at, country_code)
+		VALUES ('e1', 'pa', 's1', 'pageview', 'i1', CURRENT_TIMESTAMP, '')`)
+	mustExec(t, db, `INSERT INTO events (id, project_id, session_id, name, ingest_id, occurred_at, country_code)
+		VALUES ('e2', 'pa', 's1', 'pageview', 'i2', CURRENT_TIMESTAMP, 'FR')`)
+
+	if err := goose.UpTo(db, "migrations", 37); err != nil {
+		t.Fatalf("goose up to 37: %v", err)
+	}
+
+	var filled, kept string
+	if err := db.QueryRow(`SELECT COALESCE(country_code,'') FROM events WHERE id='e1'`).Scan(&filled); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COALESCE(country_code,'') FROM events WHERE id='e2'`).Scan(&kept); err != nil {
+		t.Fatal(err)
+	}
+	if filled != "NL" {
+		t.Errorf("event country_code: want NL, got %q", filled)
+	}
+	if kept != "FR" {
+		t.Errorf("an event that already had a country was overwritten: got %q", kept)
+	}
+}

--- a/internal/repository/migrations/00034_sessions_composite_key.sql
+++ b/internal/repository/migrations/00034_sessions_composite_key.sql
@@ -108,7 +108,17 @@ WITH ranked AS (
 SELECT
     f.session_id, f.project_id, f.first_seen_at, f.last_seen_at, f.event_count,
     f.url, l.url, f.referrer, f.utm_source, f.utm_medium, f.utm_campaign,
-    f.device_type, f.country_code, COALESCE(f.environment, ''),
+    f.device_type,
+    -- country_code is a GEO field: it is resolved from the visitor's IP and
+    -- written to the session, never to the event (that is issue #227, which
+    -- 00035 fixes in the other direction). Taking it from the event here would
+    -- overwrite every session's country with the event's empty string and
+    -- destroy the only copy — which is exactly what happened on production
+    -- before this line was corrected. It belongs with the other geo fields
+    -- below, sourced from s, with the event as a fallback for any event that
+    -- does already carry one.
+    COALESCE(NULLIF(s.country_code, ''), f.country_code),
+    COALESCE(f.environment, ''),
     -- The join below matches only the project that already owned the old row,
     -- so every other split row gets NULL geo and NULL signals. That IS the
     -- rule; no CASE is needed to express it.

--- a/internal/repository/migrations/00037_backfill_event_country_retry.sql
+++ b/internal/repository/migrations/00037_backfill_event_country_retry.sql
@@ -1,0 +1,35 @@
+-- +goose Up
+-- 00035 was a no-op on production and it should not have been.
+--
+-- 00034 rebuilt the sessions table and took country_code from the EVENT rather
+-- than from the session, so the rebuild overwrote all 5,249 session countries
+-- with the event's empty string. 00035 ran seconds later, found no session with
+-- a country to copy from, and filled nothing. Both sides ended up empty. The
+-- session values were restored from the litestream replica; this re-runs the
+-- events half, which 00035 cannot do again now that goose has recorded it.
+--
+-- 00034 is corrected in the same change, so a database migrating from scratch
+-- never loses the value and reaches this migration with nothing left to do.
+--
+-- Identical predicate and effect to 00035: fills only events with no country of
+-- their own, only from sessions that have one, joined on (project_id,
+-- session_id). Idempotent, and a no-op on any database where 00035 already did
+-- its job.
+UPDATE events
+SET country_code = (
+    SELECT s.country_code FROM sessions s
+    WHERE s.project_id = events.project_id
+      AND s.id         = events.session_id
+)
+WHERE COALESCE(country_code, '') = ''
+  AND EXISTS (
+    SELECT 1 FROM sessions s
+    WHERE s.project_id = events.project_id
+      AND s.id         = events.session_id
+      AND COALESCE(s.country_code, '') <> ''
+  );
+
+-- +goose Down
+-- Not reversible: a backfilled country is indistinguishable from one resolved
+-- at ingest, so undoing this would clear both.
+SELECT 1;


### PR DESCRIPTION
## Summary

Migration `00034` took `country_code` from the events CTE (`f.country_code`) instead of the session row. `country_code` is a **geo** field — resolved from the visitor's IP and written to the session, never to the event, which is the whole of #227 — so on production the rebuild overwrote **all 5,249 session countries** with the event's empty string and destroyed the only copy.

`00035` ran seconds later, found no session with a country to copy from, and filled nothing. Both sides ended up empty.

Found while verifying the production deploy of #234. Refs #225, #227.

## What was and was not affected

| | |
|---|---|
| `sessions.country_code` | **lost** — 5,249 rows → 0 |
| `city`, `region`, `latitude`, `longitude`, `timezone`, `asn_org`, `connection_class` | intact — sourced from `s`, 4,980–5,240 rows survived |
| `events.country_code` | still 0, i.e. unchanged; `00035` was a no-op |
| New traffic | never at risk — `PersistEvent` writes the country to both event and session |
| Dashboard | no visible regression; the country widgets were already empty (that is #227) |

One column, one line.

## Production has already been recovered

The pre-deploy database was restored from the litestream replica (generation `7a7fd5e95267f5c8`, index 37738, schema 30) and the countries copied back, matched on `(project_id, id)`:

- **5,240 rows restored**, matching the dry-run prediction exactly
- **0 mismatches** against the original values
- 9 old rows deliberately **not** copied — those are the rows `00034` correctly re-owned, so their old country belonged to a project that did not own the session. Skipping them follows the same rule the migration applies to every other geo field.
- `PRAGMA integrity_check` → `ok`; the restored scratch copy was then deleted

## Changes

**`00034` sources country from the session**, falling back to the event for any event that does carry one:

```sql
COALESCE(NULLIF(s.country_code, ''), f.country_code),
```

Editing an already-applied migration only affects databases that have not run it. Production and staging keep the values they have; a fresh install never loses them in the first place. The alternative — leaving the bug in place and repairing after — would mean every new deployment reproduces the data loss and depends on a follow-up to undo it.

**`00037` re-runs the events backfill.** `00035` cannot run again now that goose has recorded it, and production's events are still empty. Identical predicate and effect; a no-op on any database where `00035` already did its job. It will fill **20,452 events** on production.

## Testing

- [x] `go test -race -count=1 ./...` — exit 0
- [x] `python3 scripts/coverage-gate.py` — passes, global 87.61%
- [x] `bash scripts/go-quality-gates.sh` — within pinned thresholds
- [x] `gofmt -l .` clean, `go vet ./...` clean

Three regression tests, **each verified to fail against the original line** rather than only to pass against the fix:

- `TestMigration00034_PreservesSessionCountry` — the production shape exactly (session has geo, event has none). Against the old line it fails with `want NL, got ""`.
- `TestMigration00034_FallsBackToEventCountry` — an event that does carry a country still supplies one for a session that has none, so the fallback is not lost with the bug.
- `TestMigration00034_CountryDoesNotLeakAcrossSplitRows` — a split row does not inherit another project's country, the same rule the other geo fields follow.
- `TestMigration00037_FillsEventsFromRecoveredSessions` — fills an empty event, leaves an event that already had a country alone.

## What this says about the original PR

`00034`'s tests asserted that `city`, `asn_org`, `screen_width` and `signals_collected` carried across, and that they did **not** leak to split rows. `country_code` was in the same sentence in the PR description but was never asserted, and it was the one geo column read from the wrong side of the join. The three tests above close that gap for every geo field the migration touches.

https://claude.ai/code/session_013ombByUEM1omcxHMpZhZzg