### PR TITLE
Run the maintenance pass at startup, not only 24h after boot

### DIFF
--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -541,6 +541,11 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 	purgeTicker := time.NewTicker(24 * time.Hour)
 	defer purgeTicker.Stop()
 
+	// A restart must not postpone maintenance indefinitely; see
+	// startupMaintenanceDelay.
+	startupMaintenance := time.NewTimer(startupMaintenanceDelay)
+	defer startupMaintenance.Stop()
+
 	offset, err := spool.ReadCursor(cfg.SpoolDir)
 	if err != nil {
 		slog.Warn("worker: failed to read cursor, starting from 0", "err", err)
@@ -557,93 +562,10 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 		select {
 		case <-ctx.Done():
 			return
+		case <-startupMaintenance.C:
+			runMaintenance(ctx, cfg, store, recordings)
 		case <-purgeTicker.C:
-			purgeCtx, purgeSpan := tracing.StartSpan(ctx, "maintenance.purge")
-			// Sessions past their absolute cap are already unusable (the
-			// middleware enforces absolute_expires_at); this keeps the table
-			// from accumulating.
-			if n, err := store.DeleteExpiredWebSessions(purgeCtx, time.Now().UTC()); err != nil {
-				tracing.RecordError(purgeSpan, err)
-				slog.Error("purge expired web sessions", "err", err)
-			} else if n > 0 {
-				slog.Info("purged expired web sessions", "count", n)
-			}
-			if cfg.EventRetentionDays > 0 {
-				cutoff := time.Now().AddDate(0, 0, -cfg.EventRetentionDays)
-				n, err := store.PurgeOldEvents(purgeCtx, cutoff)
-				if err != nil {
-					tracing.RecordError(purgeSpan, err)
-					slog.Error("purge old events", "err", err)
-				} else if n > 0 {
-					slog.Info("purged old events", "count", n, "before", cutoff.Format(time.DateOnly))
-					metrics.EventsPurged.Add(float64(n))
-				}
-				ne, err := store.PurgeOldEvaluations(purgeCtx, cutoff)
-				if err != nil {
-					tracing.RecordError(purgeSpan, err)
-					slog.Error("purge old evaluations", "err", err)
-				} else if ne > 0 {
-					slog.Info("purged old evaluations", "count", ne, "before", cutoff.Format(time.DateOnly))
-				}
-			}
-			if cfg.AutoRegisterTTLDays > 0 {
-				cutoff := time.Now().AddDate(0, 0, -cfg.AutoRegisterTTLDays)
-				nf, err := store.PurgeStaleAutoFlags(purgeCtx, cutoff)
-				if err != nil {
-					tracing.RecordError(purgeSpan, err)
-					slog.Error("purge stale auto flags", "err", err)
-				} else if nf > 0 {
-					slog.Info("purged stale auto flags", "count", nf, "before", cutoff.Format(time.DateOnly))
-				}
-			}
-			// Unreachable rows are invisible to the product by construction —
-			// every read is project-scoped — so nothing surfaces them except a
-			// count. The 344 events that prompted this check went unnoticed for
-			// two months. Error level so it reaches BugBarn as an issue: with
-			// foreign keys enforced and the project_id triggers in place, a
-			// non-zero count means a guard was bypassed.
-			if orphans, err := store.CountOrphanedRows(purgeCtx); err != nil {
-				tracing.RecordError(purgeSpan, err)
-				slog.Error("count orphaned rows", "err", err)
-			} else if orphans.Total() > 0 {
-				slog.Error("rows exist under a project_id that matches no project; they are unreachable by every query",
-					"err", errors.New("orphaned rows present"), "handled", false,
-					"events", orphans.Events,
-					"sessions", orphans.Sessions,
-					"funnels", orphans.Funnels,
-				)
-			}
-
-			if recordings != nil {
-				retentionDays := 90 // default
-				if v, ok, _ := store.GetInstanceSetting(purgeCtx, "recording_retention_days"); ok {
-					if n, err := strconv.Atoi(v); err == nil && n > 0 {
-						retentionDays = n
-					}
-				}
-				if err := recordings.PurgeOldRecordings(purgeCtx, retentionDays); err != nil {
-					tracing.RecordError(purgeSpan, err)
-					slog.Error("purge old recordings", "err", err)
-				} else {
-					slog.Debug("recording retention purge complete", "retention_days", retentionDays)
-				}
-				if n, err := recordings.PurgeBrokenRecordings(purgeCtx); err != nil {
-					tracing.RecordError(purgeSpan, err)
-					slog.Error("purge broken recordings", "err", err)
-				} else if n > 0 {
-					slog.Info("purged unplayable recordings", "count", n)
-				}
-				// Bot recordings written before ingest started refusing them.
-				// The rows could be dropped by a migration, but their R2 chunk
-				// objects could not — deriving those keys needs the row.
-				if n, err := recordings.PurgeBotRecordings(purgeCtx); err != nil {
-					tracing.RecordError(purgeSpan, err)
-					slog.Error("purge bot recordings", "err", err)
-				} else if n > 0 {
-					slog.Info("purged bot recordings", "count", n)
-				}
-			}
-			purgeSpan.End()
+			runMaintenance(ctx, cfg, store, recordings)
 		case <-ticker.C:
 			tickCtx, tickSpan := tracing.StartSpan(ctx, "worker.tick",
 				attribute.Int64("spool.offset", offset),
@@ -804,4 +726,120 @@ func runBackgroundWorker(ctx context.Context, cfg config.Config, store *reposito
 			tickSpan.End()
 		}
 	}
+}
+
+// startupMaintenanceDelay is how long after boot the first maintenance pass
+// runs. The pass used to fire only on a 24h ticker with no initial run, so a
+// redeploy reset the timer — and during active development the pod restarts
+// more often than once a day, which meant the pass could go weeks without ever
+// executing. Production accumulated 7,373 bot recordings that
+// PurgeBotRecordings was never reached to sweep, and the orphan integrity
+// check never ran at all.
+//
+// The delay keeps a potentially R2-heavy sweep off the boot path so the
+// readiness probe settles first, and stops a crash-loop turning the pass into
+// a hot loop of object-store deletes.
+const startupMaintenanceDelay = 2 * time.Minute
+
+// maintenanceRecordings is the narrow slice of service.Recordings the
+// maintenance pass actually uses. Depending on the full fifteen-method
+// interface would mean any test of this pass had to stub twelve unrelated
+// methods, which is how a pass like this ends up untested.
+type maintenanceRecordings interface {
+	PurgeOldRecordings(ctx context.Context, retentionDays int) error
+	PurgeBrokenRecordings(ctx context.Context) (int, error)
+	PurgeBotRecordings(ctx context.Context) (int, error)
+}
+
+// runMaintenance executes one maintenance pass: retention purges, the recording
+// sweeps, and the orphaned-row integrity check. Every step is independent and
+// failure-tolerant — one failing purge logs and the rest still run — and every
+// step is idempotent, so running the pass more often than daily is harmless.
+func runMaintenance(ctx context.Context, cfg config.Config, store *repository.Store, recordings maintenanceRecordings) {
+	purgeCtx, purgeSpan := tracing.StartSpan(ctx, "maintenance.purge")
+	// Sessions past their absolute cap are already unusable (the
+	// middleware enforces absolute_expires_at); this keeps the table
+	// from accumulating.
+	if n, err := store.DeleteExpiredWebSessions(purgeCtx, time.Now().UTC()); err != nil {
+		tracing.RecordError(purgeSpan, err)
+		slog.Error("purge expired web sessions", "err", err)
+	} else if n > 0 {
+		slog.Info("purged expired web sessions", "count", n)
+	}
+	if cfg.EventRetentionDays > 0 {
+		cutoff := time.Now().AddDate(0, 0, -cfg.EventRetentionDays)
+		n, err := store.PurgeOldEvents(purgeCtx, cutoff)
+		if err != nil {
+			tracing.RecordError(purgeSpan, err)
+			slog.Error("purge old events", "err", err)
+		} else if n > 0 {
+			slog.Info("purged old events", "count", n, "before", cutoff.Format(time.DateOnly))
+			metrics.EventsPurged.Add(float64(n))
+		}
+		ne, err := store.PurgeOldEvaluations(purgeCtx, cutoff)
+		if err != nil {
+			tracing.RecordError(purgeSpan, err)
+			slog.Error("purge old evaluations", "err", err)
+		} else if ne > 0 {
+			slog.Info("purged old evaluations", "count", ne, "before", cutoff.Format(time.DateOnly))
+		}
+	}
+	if cfg.AutoRegisterTTLDays > 0 {
+		cutoff := time.Now().AddDate(0, 0, -cfg.AutoRegisterTTLDays)
+		nf, err := store.PurgeStaleAutoFlags(purgeCtx, cutoff)
+		if err != nil {
+			tracing.RecordError(purgeSpan, err)
+			slog.Error("purge stale auto flags", "err", err)
+		} else if nf > 0 {
+			slog.Info("purged stale auto flags", "count", nf, "before", cutoff.Format(time.DateOnly))
+		}
+	}
+	// Unreachable rows are invisible to the product by construction —
+	// every read is project-scoped — so nothing surfaces them except a
+	// count. The 344 events that prompted this check went unnoticed for
+	// two months. Error level so it reaches BugBarn as an issue: with
+	// foreign keys enforced and the project_id triggers in place, a
+	// non-zero count means a guard was bypassed.
+	if orphans, err := store.CountOrphanedRows(purgeCtx); err != nil {
+		tracing.RecordError(purgeSpan, err)
+		slog.Error("count orphaned rows", "err", err)
+	} else if orphans.Total() > 0 {
+		slog.Error("rows exist under a project_id that matches no project; they are unreachable by every query",
+			"err", errors.New("orphaned rows present"), "handled", false,
+			"events", orphans.Events,
+			"sessions", orphans.Sessions,
+			"funnels", orphans.Funnels,
+		)
+	}
+
+	if recordings != nil {
+		retentionDays := 90 // default
+		if v, ok, _ := store.GetInstanceSetting(purgeCtx, "recording_retention_days"); ok {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				retentionDays = n
+			}
+		}
+		if err := recordings.PurgeOldRecordings(purgeCtx, retentionDays); err != nil {
+			tracing.RecordError(purgeSpan, err)
+			slog.Error("purge old recordings", "err", err)
+		} else {
+			slog.Debug("recording retention purge complete", "retention_days", retentionDays)
+		}
+		if n, err := recordings.PurgeBrokenRecordings(purgeCtx); err != nil {
+			tracing.RecordError(purgeSpan, err)
+			slog.Error("purge broken recordings", "err", err)
+		} else if n > 0 {
+			slog.Info("purged unplayable recordings", "count", n)
+		}
+		// Bot recordings written before ingest started refusing them.
+		// The rows could be dropped by a migration, but their R2 chunk
+		// objects could not — deriving those keys needs the row.
+		if n, err := recordings.PurgeBotRecordings(purgeCtx); err != nil {
+			tracing.RecordError(purgeSpan, err)
+			slog.Error("purge bot recordings", "err", err)
+		} else if n > 0 {
+			slog.Info("purged bot recordings", "count", n)
+		}
+	}
+	purgeSpan.End()
 }

--- a/cmd/funnelbarn/main_test.go
+++ b/cmd/funnelbarn/main_test.go
@@ -201,3 +201,81 @@ func TestRunReplayDeadLetter(t *testing.T) {
 		t.Error("replayed event should be attributed to the --project project")
 	}
 }
+
+// fakeRecordings records which sweeps ran, so the test can prove the
+// maintenance pass reaches all three rather than just not crashing.
+type fakeRecordings struct {
+	oldCalled    bool
+	brokenCalled bool
+	botCalled    bool
+	retentionGot int
+}
+
+func (f *fakeRecordings) PurgeOldRecordings(_ context.Context, retentionDays int) error {
+	f.oldCalled = true
+	f.retentionGot = retentionDays
+	return nil
+}
+
+func (f *fakeRecordings) PurgeBrokenRecordings(_ context.Context) (int, error) {
+	f.brokenCalled = true
+	return 0, nil
+}
+
+func (f *fakeRecordings) PurgeBotRecordings(_ context.Context) (int, error) {
+	f.botCalled = true
+	return 0, nil
+}
+
+// The maintenance pass must reach every sweep. PurgeBotRecordings in particular
+// is the only thing that can delete a bot recording's R2 chunks, so a pass that
+// silently skips it leaves them stored forever.
+func TestRunMaintenance_ReachesEverySweep(t *testing.T) {
+	store, err := repository.Open(filepath.Join(t.TempDir(), "maint.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+
+	rec := &fakeRecordings{}
+	cfg := config.Config{EventRetentionDays: 30, AutoRegisterTTLDays: 30}
+
+	runMaintenance(context.Background(), cfg, store, rec)
+
+	if !rec.oldCalled {
+		t.Error("PurgeOldRecordings was not called")
+	}
+	if !rec.brokenCalled {
+		t.Error("PurgeBrokenRecordings was not called")
+	}
+	if !rec.botCalled {
+		t.Error("PurgeBotRecordings was not called")
+	}
+	if rec.retentionGot != 90 {
+		t.Errorf("retention days: want the 90-day default, got %d", rec.retentionGot)
+	}
+}
+
+// Recordings are optional (no object storage configured), and the pass must
+// still run the database-side work rather than skipping or panicking.
+func TestRunMaintenance_NilRecordingsIsSafe(t *testing.T) {
+	store, err := repository.Open(filepath.Join(t.TempDir(), "maint-nil.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+
+	runMaintenance(context.Background(), config.Config{}, store, nil)
+}
+
+// The first pass must happen soon after boot, not a full day later. A redeploy
+// resets the 24h ticker, and this instance redeploys more often than daily —
+// with a startup delay of a day the pass would never run at all.
+func TestStartupMaintenanceDelay_IsShortEnoughToSurviveRedeploys(t *testing.T) {
+	if startupMaintenanceDelay <= 0 {
+		t.Fatalf("startupMaintenanceDelay must be positive, got %v", startupMaintenanceDelay)
+	}
+	if startupMaintenanceDelay >= time.Hour {
+		t.Errorf("startupMaintenanceDelay is %v; a delay this long is reset by an ordinary redeploy, which is the bug this exists to fix", startupMaintenanceDelay)
+	}
+}


### PR DESCRIPTION
## Summary

The maintenance pass fired only on `time.NewTicker(24 * time.Hour)` with **no initial run**, so every redeploy reset the timer. This instance redeploys more often than once a day, which means the pass could go weeks without ever executing.

It evidently had. `PurgeBotRecordings` shipped in #247 and has never run: production still held **7,373 bot recordings** three hours after the deploy that added the sweep, unchanged from before it.

Found while verifying the #234 production deploy. Refs #228, #232.

## Everything that was not running

| | |
|---|---|
| `PurgeBotRecordings` | #247's sweep — the only thing that can delete a bot recording's R2 chunks |
| `PurgeOldRecordings` | recording retention |
| `PurgeBrokenRecordings` | unplayable recordings |
| `PurgeOldEvents`, `PurgeOldEvaluations` | event retention |
| `PurgeStaleAutoFlags` | auto-flag TTL |
| `DeleteExpiredWebSessions` | session table growth |
| `CountOrphanedRows` | #232's integrity check — added in #250 and never once executed |

The integrity check is the sharpest one: it exists specifically to catch silent data problems early, and it was itself silently never running.

## Change

A `time.Timer` fires the first pass **two minutes after boot**, then the 24h ticker takes over.

Two minutes rather than immediately: it keeps a potentially R2-heavy sweep off the boot path so the readiness probe settles first, and it stops a crash-loop turning the pass into a hot loop of object-store deletes. Every step is idempotent and independently failure-tolerant, so running the pass more often than daily costs nothing.

The pass also moves out of the `select` into `runMaintenance`. It takes a three-method `maintenanceRecordings` rather than the full fifteen-method `service.Recordings` — depending on the whole interface is precisely why this code was never tested, since a fake would have had to stub twelve unrelated methods to reach three.

## Testing

- [x] `go test -race -count=1 ./...` — exit 0
- [x] `python3 scripts/coverage-gate.py` — passes; `cmd/funnelbarn` **15.27% → 19.16%**, global 87.69%
- [x] `bash scripts/go-quality-gates.sh` — within pinned thresholds (the extraction lowers `runBackgroundWorker`'s complexity)
- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `TestRunMaintenance_ReachesEverySweep` — asserts all three recording sweeps are called and that the 90-day retention default is applied, rather than just that the pass does not panic
- [x] `TestRunMaintenance_NilRecordingsIsSafe` — recordings are optional when no object storage is configured; the database-side work must still run
- [x] `TestStartupMaintenanceDelay_IsShortEnoughToSurviveRedeploys` — **verified to fail against the old 24h value**, with the message naming the reason

## After deploy

The first pass lands two minutes after the pod is ready, and `SELECT COUNT(*) FROM recordings WHERE is_bot = 1` should go 7,373 → 0 along with the matching R2 chunks. I will confirm it on production rather than assume it.

https://claude.ai/code/session_013ombByUEM1omcxHMpZhZzg