### PR TITLE
Closes #259: fix Go SDK posting self-reported events to bare endpoint

### DIFF
--- a/cmd/funnelbarn/main.go
+++ b/cmd/funnelbarn/main.go
@@ -190,6 +190,9 @@ func run() error {
 	slog.SetDefault(buildLogger(cfg, spanbarnLogHandler))
 	if selfReporting {
 		slog.Info("self-reporting enabled", "endpoint", cfg.SelfEndpoint)
+	} else {
+		slog.Warn("self-reporting disabled; errors will not be reported to BugBarn — set FUNNELBARN_SELF_ENDPOINT and FUNNELBARN_SELF_API_KEY to enable it",
+			"handled", true)
 	}
 	if cfg.DogfoodAPIKey != "" {
 		slog.Info("dogfood analytics enabled", "project", cfg.DogfoodProject)
@@ -295,7 +298,9 @@ func run() error {
 		}
 	}
 
-	go runBackgroundWorker(ctx, cfg, store, eventSpool, geoLookup, recordingsSvc)
+	bblog.Go("background-worker", func() {
+		runBackgroundWorker(ctx, cfg, store, eventSpool, geoLookup, recordingsSvc)
+	})
 
 	apiAuthorizer, err := newAPIAuthorizer(cfg, store)
 	if err != nil {
@@ -430,9 +435,9 @@ func run() error {
 	slog.Info("funnelbarn starting", "addr", cfg.Addr, "version", version)
 
 	errCh := make(chan error, 1)
-	go func() {
+	bblog.Go("http-server", func() {
 		errCh <- server.ListenAndServe()
-	}()
+	})
 
 	select {
 	case <-ctx.Done():

--- a/internal/api/flags.go
+++ b/internal/api/flags.go
@@ -11,6 +11,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
+	"github.com/wiebe-xyz/funnelbarn/internal/bblog"
 	"github.com/wiebe-xyz/funnelbarn/internal/domain"
 	"github.com/wiebe-xyz/funnelbarn/internal/metrics"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
@@ -328,11 +329,11 @@ func (s *Server) handleEvaluateFlag(w http.ResponseWriter, r *http.Request) {
 	}
 	if s.projectHealth != nil {
 		pid := projectID
-		go func() {
+		bblog.Go("flags-health", func() {
 			if err := s.projectHealth.MarkFlagsEvaluated(context.Background(), pid); err != nil {
 				slog.Warn("evaluate flag: mark health", "project_id", pid, "err", err)
 			}
-		}()
+		})
 	}
 	// SDK callers auto-register unknown flags so they surface in the dashboard.
 	s.evaluateFlagInProject(w, r, projectID, true)

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/wiebe-xyz/funnelbarn/internal/bblog"
 	"github.com/wiebe-xyz/funnelbarn/internal/metrics"
 )
 
@@ -157,7 +158,7 @@ func (rl *rateLimiter) cleanup() {
 
 // startCleanup runs periodic cleanup in a background goroutine until ctx is cancelled.
 func (rl *rateLimiter) startCleanup(ctx context.Context) {
-	go func() {
+	bblog.Go("ratelimiter-cleanup", func() {
 		ticker := time.NewTicker(time.Minute)
 		defer ticker.Stop()
 		for {
@@ -168,7 +169,7 @@ func (rl *rateLimiter) startCleanup(ctx context.Context) {
 				rl.cleanup()
 			}
 		}
-	}()
+	})
 }
 
 // clientIP extracts the real client IP address from the request.

--- a/internal/api/recordings.go
+++ b/internal/api/recordings.go
@@ -11,6 +11,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
+	"github.com/wiebe-xyz/funnelbarn/internal/bblog"
 	"github.com/wiebe-xyz/funnelbarn/internal/domain"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
 	"github.com/wiebe-xyz/funnelbarn/internal/service"
@@ -64,11 +65,11 @@ func (s *Server) handleIngestRecordingChunk(w http.ResponseWriter, r *http.Reque
 
 	if s.projectHealth != nil {
 		pid := projectID
-		go func() {
+		bblog.Go("recordings-health", func() {
 			if err := s.projectHealth.MarkRecordingsReceived(context.Background(), pid); err != nil {
 				slog.Warn("recording chunk: mark health", "project_id", pid, "err", err)
 			}
-		}()
+		})
 	}
 
 	proj, err := s.projects.GetProject(ctx, projectID)

--- a/internal/api/setup.go
+++ b/internal/api/setup.go
@@ -13,6 +13,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
+	"github.com/wiebe-xyz/funnelbarn/internal/bblog"
 	"github.com/wiebe-xyz/funnelbarn/internal/tracing"
 )
 
@@ -82,11 +83,11 @@ func (s *Server) handleSetup(w http.ResponseWriter, r *http.Request) {
 
 	if s.projectHealth != nil {
 		pid := project.ID
-		go func() {
+		bblog.Go("setup-health", func() {
 			if err := s.projectHealth.MarkSetupCalled(context.Background(), pid); err != nil {
 				slog.Warn("setup: mark health", "project_id", pid, "err", err)
 			}
-		}()
+		})
 	}
 
 	publicURL := s.publicURL

--- a/internal/bblog/goroutine.go
+++ b/internal/bblog/goroutine.go
@@ -1,0 +1,36 @@
+package bblog
+
+import (
+	"fmt"
+	"log/slog"
+	"runtime/debug"
+)
+
+// Go runs fn in a new goroutine with panic recovery. A panic is logged at
+// error level with the panic value and a stack trace instead of taking down
+// the process — background workers and fire-and-forget goroutines (health
+// pings, periodic cleanup) have no caller to propagate a panic to, so an
+// unrecovered one either kills the pod (a long-lived worker loop) or just
+// silently ends the goroutine (a one-shot side effect), and either way the
+// failure was never reported. Logging with an "err" attribute at error level
+// routes it through Handler into BugBarn the same way any other error-level
+// log record does, so it shows up in the dashboard instead of only stderr.
+//
+// name identifies the goroutine in the log line and in BugBarn attributes; it
+// should be a short, stable label such as "background-worker" or
+// "recordings-health", not something that varies per call.
+func Go(name string, fn func()) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("panic recovered in background goroutine",
+					"goroutine", name,
+					"err", fmt.Errorf("panic: %v", r),
+					"stack", string(debug.Stack()),
+					"handled", true,
+				)
+			}
+		}()
+		fn()
+	}()
+}

--- a/internal/bblog/goroutine_test.go
+++ b/internal/bblog/goroutine_test.go
@@ -1,0 +1,111 @@
+package bblog_test
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/wiebe-xyz/funnelbarn/internal/bblog"
+)
+
+// syncHandler is a slog.Handler that signals a channel on every record so
+// tests can wait deterministically instead of sleeping.
+type syncHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+	notify  chan struct{}
+}
+
+func newSyncHandler() *syncHandler {
+	return &syncHandler{notify: make(chan struct{}, 8)}
+}
+
+func (h *syncHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *syncHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	h.records = append(h.records, r)
+	h.mu.Unlock()
+	h.notify <- struct{}{}
+	return nil
+}
+
+func (h *syncHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *syncHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *syncHandler) waitForRecord(t *testing.T) slog.Record {
+	t.Helper()
+	select {
+	case <-h.notify:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for a log record")
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.records[len(h.records)-1]
+}
+
+func TestGo_RunsFunction(t *testing.T) {
+	done := make(chan struct{})
+	bblog.Go("test-goroutine", func() {
+		close(done)
+	})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("fn was not run")
+	}
+}
+
+func TestGo_RecoversPanicAndLogs(t *testing.T) {
+	h := newSyncHandler()
+	prev := slog.Default()
+	slog.SetDefault(slog.New(h))
+	defer slog.SetDefault(prev)
+
+	bblog.Go("panicky-goroutine", func() {
+		panic("boom")
+	})
+
+	rec := h.waitForRecord(t)
+	if rec.Level != slog.LevelError {
+		t.Fatalf("level = %v, want Error", rec.Level)
+	}
+
+	var sawGoroutineName, sawErr bool
+	rec.Attrs(func(a slog.Attr) bool {
+		if a.Key == "goroutine" && a.Value.String() == "panicky-goroutine" {
+			sawGoroutineName = true
+		}
+		if a.Key == "err" {
+			sawErr = true
+		}
+		return true
+	})
+	if !sawGoroutineName {
+		t.Error("expected goroutine name attribute")
+	}
+	if !sawErr {
+		t.Error("expected err attribute carrying the panic")
+	}
+}
+
+func TestGo_PanicDoesNotCrashProcess(t *testing.T) {
+	// A test process still running after this is the assertion: an
+	// unrecovered panic in any goroutine is always fatal to the whole
+	// process, so simply reaching the end of the test proves recovery
+	// worked.
+	done := make(chan struct{})
+	bblog.Go("panic-then-signal", func() {
+		defer close(done)
+		panic("should be recovered")
+	})
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine never completed")
+	}
+}

--- a/internal/service/flags.go
+++ b/internal/service/flags.go
@@ -17,6 +17,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
+	"github.com/wiebe-xyz/funnelbarn/internal/bblog"
 	"github.com/wiebe-xyz/funnelbarn/internal/domain"
 	"github.com/wiebe-xyz/funnelbarn/internal/ports"
 	"github.com/wiebe-xyz/funnelbarn/internal/repository"
@@ -440,7 +441,7 @@ func (svc *FlagService) touchEvaluated(projectID, flagKey string) {
 	if !svc.shouldTouch(projectID, flagKey, time.Now()) {
 		return
 	}
-	go func() {
+	bblog.Go("flags-touch-evaluated", func() {
 		ctx := context.Background()
 		f, err := svc.store.FlagByKey(ctx, projectID, flagKey)
 		if err != nil {
@@ -450,7 +451,7 @@ func (svc *FlagService) touchEvaluated(projectID, flagKey string) {
 			slog.WarnContext(ctx, "flag: touch last_evaluated_at", "err", err, "handled", true,
 				"flag_id", f.ID, "project_id", projectID)
 		}
-	}()
+	})
 }
 
 func (svc *FlagService) AnalyzeFlag(ctx context.Context, flag repository.FeatureFlag, from, to time.Time) ([]repository.FlagAnalysisResult, error) {

--- a/sdks/go-bugbarn/bugbarn.go
+++ b/sdks/go-bugbarn/bugbarn.go
@@ -55,6 +55,7 @@ func Init(o Options) {
 	}
 	opts = o
 	tp = newTransport(o.APIKey, o.Endpoint, o.ProjectSlug, o.QueueSize)
+	go tp.selfTest()
 }
 
 // CaptureError captures an error and enqueues it for delivery.

--- a/sdks/go-bugbarn/envelope.go
+++ b/sdks/go-bugbarn/envelope.go
@@ -90,6 +90,19 @@ func buildEnvelope(err error, opts captureOpts) envelope {
 	return env
 }
 
+// buildSelfTestEnvelope builds the one info-level event Init sends at startup
+// to verify self-reporting actually reaches BugBarn. See transport.selfTest.
+func buildSelfTestEnvelope() envelope {
+	msg := "bugbarn self-reporting initialised"
+	return envelope{
+		Timestamp:    time.Now().UTC().Format(time.RFC3339Nano),
+		SeverityText: "INFO",
+		Body:         msg,
+		Exception:    exceptionBlock{Type: "Info", Message: msg},
+		Sender:       senderBlock{SDK: sdkBlock{Name: sdkName, Version: sdkVersion}},
+	}
+}
+
 func buildMessageEnvelope(msg string, opts captureOpts) envelope {
 	fakeErr := fmt.Errorf("%s", msg)
 	env := buildEnvelope(fakeErr, opts)

--- a/sdks/go-bugbarn/transport.go
+++ b/sdks/go-bugbarn/transport.go
@@ -5,9 +5,27 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"log/slog"
 	"net/http"
+	"strings"
+	"sync"
 	"time"
 )
+
+// eventsPath is the ingest endpoint every envelope is posted to. Endpoint is
+// meant to be the server root ("https://bugbarn.example.com") with this path
+// appended by the transport — but nothing enforced that, so a caller handing
+// in the full ingest URL (copied from a project's setup page, or from a
+// sibling SDK's config) silently posted every event to the bare root and got
+// a 405 back that was never logged. See issue #259.
+const eventsPath = "/api/v1/events"
+
+// logRateLimit is the minimum gap between consecutive "delivery failing"
+// warnings. A misconfigured endpoint fails every single send, and logging
+// each one would spam stderr as hard as the silence it replaces; one line per
+// window is enough to notice the problem and stay findable in the logs.
+const logRateLimit = time.Minute
 
 type transport struct {
 	apiKey      string
@@ -16,12 +34,15 @@ type transport struct {
 	queue       chan envelope
 	done        chan struct{}
 	client      *http.Client
+
+	logMu      sync.Mutex
+	lastLogged time.Time
 }
 
 func newTransport(apiKey, endpoint, projectSlug string, queueSize int) *transport {
 	t := &transport{
 		apiKey:      apiKey,
-		endpoint:    endpoint,
+		endpoint:    normaliseEndpoint(endpoint),
 		projectSlug: projectSlug,
 		queue:       make(chan envelope, queueSize),
 		done:        make(chan struct{}),
@@ -29,6 +50,15 @@ func newTransport(apiKey, endpoint, projectSlug string, queueSize int) *transpor
 	}
 	go t.run()
 	return t
+}
+
+// normaliseEndpoint reduces whatever was configured to a base URL. Endpoint
+// is meant to be the server root — the transport appends eventsPath itself —
+// but a full ingest URL is accepted too, so that the same "BugBarn endpoint"
+// value handed to a browser SDK and to this one both work.
+func normaliseEndpoint(endpoint string) string {
+	e := strings.TrimRight(strings.TrimSpace(endpoint), "/")
+	return strings.TrimSuffix(e, eventsPath)
 }
 
 func (t *transport) enqueue(env envelope) bool {
@@ -43,8 +73,36 @@ func (t *transport) enqueue(env envelope) bool {
 func (t *transport) run() {
 	defer close(t.done)
 	for env := range t.queue {
-		_ = t.send(env) // log failure silently
+		if err := t.send(env); err != nil {
+			t.logSendErr(err)
+		}
 	}
+}
+
+// logSendErr reports a failed delivery via slog, rate-limited so a
+// permanently broken endpoint logs steadily instead of either flooding the
+// log or (as before) never logging at all.
+func (t *transport) logSendErr(err error) {
+	t.logMu.Lock()
+	defer t.logMu.Unlock()
+	if time.Since(t.lastLogged) < logRateLimit {
+		return
+	}
+	t.lastLogged = time.Now()
+	slog.Warn("bugbarn: event delivery failed", "err", err)
+}
+
+// selfTest sends one info-level event synchronously (bypassing the queue) so
+// a misconfigured endpoint or API key is reported once, loudly, at startup —
+// instead of surfacing only as a rate-limited trickle of warnings once real
+// error traffic starts arriving, or (as before this fix) not surfacing at
+// all. Meant to be run in its own goroutine so it never blocks Init.
+func (t *transport) selfTest() {
+	if err := t.send(buildSelfTestEnvelope()); err != nil {
+		slog.Error("bugbarn: self-test failed; self-reporting is misconfigured and events will not reach BugBarn", "err", err)
+		return
+	}
+	slog.Info("bugbarn: self-test succeeded")
 }
 
 func (t *transport) flush(timeout time.Duration) bool {
@@ -80,7 +138,12 @@ func (t *transport) send(env envelope) error {
 		return fmt.Errorf("marshal: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, t.endpoint, bytes.NewReader(body))
+	if t.endpoint == "" {
+		return fmt.Errorf("bugbarn: endpoint not configured")
+	}
+	url := t.endpoint + eventsPath
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -94,6 +157,18 @@ func (t *transport) send(env envelope) error {
 	if err != nil {
 		return err
 	}
-	resp.Body.Close()
+	defer resp.Body.Close()
+
+	// A 404 (wrong endpoint) or 405 (bare root, no path) used to return nil
+	// here — the whole reason this bug went unnoticed for two months. Include
+	// a slice of the body so the log line says which of those it is.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		if detail := strings.TrimSpace(string(snippet)); detail != "" {
+			return fmt.Errorf("bugbarn: ingest rejected the event: %s: %s", resp.Status, detail)
+		}
+		return fmt.Errorf("bugbarn: ingest rejected the event: %s", resp.Status)
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
 	return nil
 }

--- a/sdks/go-bugbarn/transport_test.go
+++ b/sdks/go-bugbarn/transport_test.go
@@ -1,13 +1,185 @@
 package bugbarn
 
 import (
+	"context"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
+
+// notifyHandler is a minimal slog.Handler that signals a channel on every
+// record so tests can wait deterministically instead of sleeping.
+type notifyHandler struct {
+	notify  chan slog.Record
+	minimum slog.Level
+}
+
+func (h *notifyHandler) Enabled(_ context.Context, l slog.Level) bool { return l >= h.minimum }
+func (h *notifyHandler) Handle(_ context.Context, r slog.Record) error {
+	h.notify <- r
+	return nil
+}
+func (h *notifyHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *notifyHandler) WithGroup(string) slog.Handler      { return h }
+
+func TestNormaliseEndpoint(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"bare root", "https://bugbarn.example.com", "https://bugbarn.example.com"},
+		{"trailing slash", "https://bugbarn.example.com/", "https://bugbarn.example.com"},
+		{"full ingest URL", "https://bugbarn.example.com/api/v1/events", "https://bugbarn.example.com"},
+		{"full ingest URL with trailing slash", "https://bugbarn.example.com/api/v1/events/", "https://bugbarn.example.com"},
+		{"whitespace", "  https://bugbarn.example.com  ", "https://bugbarn.example.com"},
+		{"subpath root", "https://bugbarn.example.com/bugbarn", "https://bugbarn.example.com/bugbarn"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := normaliseEndpoint(c.in); got != c.want {
+				t.Errorf("normaliseEndpoint(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestTransportSend_AcceptsFullIngestURLAsEndpoint(t *testing.T) {
+	paths := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths <- r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Endpoint configured with the full ingest path already appended, as the
+	// setup page used to hand out — must not double up to
+	// /api/v1/events/api/v1/events.
+	tr := newTransport("key", srv.URL+"/api/v1/events", "", 8)
+	defer tr.shutdown(2 * time.Second)
+
+	if err := tr.send(envelope{Timestamp: "now", SeverityText: "ERROR"}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if gotPath := <-paths; gotPath != "/api/v1/events" {
+		t.Fatalf("posted to %q, want /api/v1/events (not doubled up)", gotPath)
+	}
+}
+
+func TestTransportSend_NonSuccessStatusIsAnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		w.Write([]byte("405 method not allowed"))
+	}))
+	defer srv.Close()
+
+	tr := newTransport("key", srv.URL, "", 8)
+	defer tr.shutdown(2 * time.Second)
+
+	err := tr.send(envelope{Timestamp: "now", SeverityText: "ERROR"})
+	if err == nil {
+		t.Fatal("expected an error for a 405 response, got nil")
+	}
+	if !strings.Contains(err.Error(), "405") {
+		t.Errorf("err = %v, want it to name the status", err)
+	}
+}
+
+func TestTransport_LogsDeliveryFailureViaSlog(t *testing.T) {
+	prev := slog.Default()
+	h := &notifyHandler{notify: make(chan slog.Record, 8), minimum: slog.LevelWarn}
+	slog.SetDefault(slog.New(h))
+	defer slog.SetDefault(prev)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer srv.Close()
+
+	tr := newTransport("key", srv.URL, "", 8)
+	defer tr.shutdown(2 * time.Second)
+	tr.enqueue(envelope{Timestamp: "now", SeverityText: "ERROR"})
+
+	select {
+	case rec := <-h.notify:
+		if rec.Level != slog.LevelWarn {
+			t.Fatalf("level = %v, want Warn", rec.Level)
+		}
+		if !strings.Contains(rec.Message, "delivery failed") {
+			t.Fatalf("message = %q, want it to mention delivery failure", rec.Message)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for the delivery-failure log")
+	}
+}
+
+func TestTransport_SelfTest(t *testing.T) {
+	bodies := make(chan []byte, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		bodies <- body
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	prev := slog.Default()
+	h := &notifyHandler{notify: make(chan slog.Record, 8), minimum: slog.LevelInfo}
+	slog.SetDefault(slog.New(h))
+	defer slog.SetDefault(prev)
+
+	tr := newTransport("key", srv.URL, "", 8)
+	defer tr.shutdown(2 * time.Second)
+
+	tr.selfTest() // run synchronously for a deterministic assertion
+
+	var received envelope
+	if err := json.Unmarshal(<-bodies, &received); err != nil {
+		t.Fatalf("invalid JSON body: %v", err)
+	}
+	if received.SeverityText != "INFO" {
+		t.Fatalf("self-test event severity = %q, want INFO", received.SeverityText)
+	}
+
+	select {
+	case rec := <-h.notify:
+		if rec.Level != slog.LevelInfo {
+			t.Fatalf("level = %v, want Info", rec.Level)
+		}
+		if !strings.Contains(rec.Message, "self-test succeeded") {
+			t.Fatalf("message = %q, want it to report self-test success", rec.Message)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for the self-test success log")
+	}
+}
+
+func TestTransport_SelfTestFailureLogsError(t *testing.T) {
+	prev := slog.Default()
+	h := &notifyHandler{notify: make(chan slog.Record, 8), minimum: slog.LevelInfo}
+	slog.SetDefault(slog.New(h))
+	defer slog.SetDefault(prev)
+
+	// Non-listening address: the self-test send fails outright.
+	tr := newTransport("key", "http://127.0.0.1:1", "", 8)
+	defer tr.shutdown(200 * time.Millisecond)
+
+	tr.selfTest()
+
+	select {
+	case rec := <-h.notify:
+		if rec.Level != slog.LevelError {
+			t.Fatalf("level = %v, want Error", rec.Level)
+		}
+		if !strings.Contains(rec.Message, "self-test failed") {
+			t.Fatalf("message = %q, want it to report self-test failure", rec.Message)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for the self-test failure log")
+	}
+}
 
 func TestTransportQueueFull(t *testing.T) {
 	// Use a non-listening address so sends fail fast without blocking.
@@ -56,6 +228,9 @@ func TestTransportSend(t *testing.T) {
 	case req := <-received:
 		if req.Method != http.MethodPost {
 			t.Fatalf("expected POST, got %s", req.Method)
+		}
+		if req.URL.Path != "/api/v1/events" {
+			t.Fatalf("posted to %q, want /api/v1/events", req.URL.Path)
 		}
 		if ct := req.Header.Get("Content-Type"); ct != "application/json" {
 			t.Fatalf("unexpected Content-Type: %s", ct)


### PR DESCRIPTION
## Summary

Self-reporting was configured correctly end to end (endpoint, key, project, `bb.Init`), yet BugBarn's `funnelbarn` project had received nothing for two months while the production pod logged thousands of errors a day. The vendored Go SDK (`sdks/go-bugbarn`) posted every event to the bare configured endpoint instead of appending the ingest path, so BugBarn returned a 405 that the SDK discarded without logging.

## Changes

- `sdks/go-bugbarn/transport.go`: append `/api/v1/events` to the endpoint, normalise a full ingest URL if one is handed in as `Endpoint` (mirrors the JS/Python/funnelbarn SDKs), and log a non-2xx response via `slog` at warn, rate-limited to one line a minute so a permanently broken endpoint doesn't flood the log.
- `sdks/go-bugbarn/bugbarn.go` / `envelope.go`: `Init` now fires a synchronous self-test event at startup, so a misconfigured endpoint or key is reported once, loudly, instead of surfacing only once real error traffic starts arriving.
- `internal/bblog/goroutine.go`: new `bblog.Go` helper — runs a goroutine with panic recovery that logs via `slog` at error level (routing through the existing selflog handler into BugBarn) instead of crashing the process or silently dying. Wired into the two long-lived background goroutines (`main.go`'s background worker and HTTP server) and the five fire-and-forget ones (`recordings.go`, `setup.go`, `flags.go` in both `api` and `service`, `middleware.go`'s rate-limiter cleanup) that previously had no recovery.
- `cmd/funnelbarn/main.go`: log a warning when self-reporting is left unconfigured, so a dropped secret is visible instead of silently disabling crash reporting.

## Testing

- `go test -race -count=1 ./...` — full suite passes
- `cd sdks/go-bugbarn && go test ./... -race` — passes, including new tests for endpoint normalisation, the appended ingest path, non-2xx logging, and the startup self-test (success and failure)
- `go vet ./...`, `staticcheck ./...`, `gofmt -l .` — clean
- `make build` — Go binaries, web SPA, and marketing site all build
- `cd web && npm run lint && npm run lint:eslint` — clean (pre-existing warnings only, unrelated)

Closes #259